### PR TITLE
Modify ride drawing code to use ImageId

### DIFF
--- a/src/openrct2/drawing/ImageId.hpp
+++ b/src/openrct2/drawing/ImageId.hpp
@@ -254,6 +254,14 @@ public:
         return result;
     }
 
+    [[nodiscard]] constexpr ImageId WithoutSecondary() const
+    {
+        ImageId result = *this;
+        result._secondary = 0;
+        result._flags &= ~NEW_FLAG_SECONDARY;
+        return result;
+    }
+
     [[nodiscard]] constexpr ImageId WithTertiary(colour_t tertiary) const
     {
         ImageId result = *this;

--- a/src/openrct2/entity/Fountain.cpp
+++ b/src/openrct2/entity/Fountain.cpp
@@ -426,7 +426,7 @@ void JumpingFountain::Paint(paint_session& session, int32_t imageDirection) cons
 
     uint32_t baseImageId = (FountainType == JumpingFountainType::Snow) ? JumpingFountainSnowBaseImage
                                                                        : JumpingFountainWaterBaseImage;
-    uint32_t imageId = baseImageId + imageDirection * 16 + frame;
+    auto imageId = ImageId(baseImageId + imageDirection * 16 + frame);
     constexpr std::array antiClockWiseBoundingBoxes = {
         CoordsXY{ -COORDS_XY_STEP, -3 },
         CoordsXY{ 0, -3 },

--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -778,6 +778,13 @@ paint_struct* PaintAddImageAsChild(
     return PaintAddImageAsChild(session, ImageId::FromUInt32(image_id), offset, { boundBoxOffset, boundBoxLength });
 }
 
+paint_struct* PaintAddImageAsChild(
+    paint_session& session, ImageId imageId, const CoordsXYZ& offset, const CoordsXYZ& boundBoxLength,
+    const CoordsXYZ& boundBoxOffset)
+{
+    return PaintAddImageAsChild(session, imageId, offset, { boundBoxOffset, boundBoxLength });
+}
+
 /**
  *
  *  rct2: 0x006874B0, 0x00687618, 0x0068778C, 0x00687902, 0x0098199C

--- a/src/openrct2/paint/Paint.h
+++ b/src/openrct2/paint/Paint.h
@@ -198,7 +198,7 @@ struct PaintSessionCore
     uint32_t ViewFlags;
     uint32_t QuadrantBackIndex;
     uint32_t QuadrantFrontIndex;
-    uint32_t TrackColours[4];
+    ImageId TrackColours[4];
     support_height SupportSegments[9];
     support_height Support;
     uint16_t WaterHeight;
@@ -287,6 +287,9 @@ extern CoordsXY gClipSelectionB;
 
 /** rct2: 0x00993CC4. The white ghost that indicates not-yet-built elements. */
 #define CONSTRUCTION_MARKER (COLOUR_DARK_GREEN << 19 | COLOUR_GREY << 24 | IMAGE_TYPE_REMAP)
+constexpr const ImageId ConstructionMarker = ImageId(0).WithRemap(FilterPaletteID::Palette44);
+constexpr const ImageId HighlightMarker = ImageId(0).WithRemap(FilterPaletteID::Palette44);
+
 extern bool gShowDirtyVisuals;
 extern bool gPaintBoundingBoxes;
 extern bool gPaintBlockedTiles;
@@ -310,14 +313,23 @@ paint_struct* PaintAddImageAsChild(
     paint_session& session, uint32_t image_id, const CoordsXYZ& offset, const CoordsXYZ& boundBoxLength,
     const CoordsXYZ& boundBoxOffset);
 paint_struct* PaintAddImageAsChild(
+    paint_session& session, ImageId imageId, const CoordsXYZ& offset, const CoordsXYZ& boundBoxLength,
+    const CoordsXYZ& boundBoxOffset);
+paint_struct* PaintAddImageAsChild(
     paint_session& session, ImageId image_id, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox);
 
 paint_struct* PaintAddImageAsChildRotated(
-    paint_session& session, const uint8_t direction, const uint32_t image_id, const CoordsXYZ& offset,
+    paint_session& session, const uint8_t direction, const ImageId& image_id, const CoordsXYZ& offset,
     const CoordsXYZ& boundBoxSize, const CoordsXYZ& boundBoxOffset);
+paint_struct* PaintAddImageAsParentRotated(
+    paint_session& session, const uint8_t direction, const ImageId& image_id, const CoordsXYZ& offset,
+    const CoordsXYZ& boundBoxSize);
 paint_struct* PaintAddImageAsParentRotated(
     paint_session& session, const uint8_t direction, const uint32_t image_id, const CoordsXYZ& offset,
     const CoordsXYZ& boundBoxSize);
+paint_struct* PaintAddImageAsParentRotated(
+    paint_session& session, const uint8_t direction, const ImageId& imageId, const CoordsXYZ& offset,
+    const CoordsXYZ& boundBoxSize, const CoordsXYZ& boundBoxOffset);
 paint_struct* PaintAddImageAsParentRotated(
     paint_session& session, const uint8_t direction, const uint32_t image_id, const CoordsXYZ& offset,
     const CoordsXYZ& boundBoxSize, const CoordsXYZ& boundBoxOffset);

--- a/src/openrct2/paint/PaintHelpers.cpp
+++ b/src/openrct2/paint/PaintHelpers.cpp
@@ -12,21 +12,21 @@
 #include "Paint.h"
 
 paint_struct* PaintAddImageAsParentRotated(
-    paint_session& session, const uint8_t direction, const uint32_t image_id, const CoordsXYZ& offset,
+    paint_session& session, const uint8_t direction, const ImageId& imageId, const CoordsXYZ& offset,
     const CoordsXYZ& boundBoxSize, const CoordsXYZ& boundBoxOffset)
 {
     if (direction & 1)
     {
         return PaintAddImageAsParent(
-            session, image_id, { offset.y, offset.x, offset.z }, { boundBoxSize.y, boundBoxSize.x, boundBoxSize.z },
+            session, imageId, { offset.y, offset.x, offset.z }, { boundBoxSize.y, boundBoxSize.x, boundBoxSize.z },
             { boundBoxOffset.y, boundBoxOffset.x, boundBoxOffset.z });
     }
 
-    return PaintAddImageAsParent(session, image_id, offset, boundBoxSize, boundBoxOffset);
+    return PaintAddImageAsParent(session, imageId, offset, boundBoxSize, boundBoxOffset);
 }
 
 paint_struct* PaintAddImageAsParentRotated(
-    paint_session& session, const uint8_t direction, const uint32_t image_id, const CoordsXYZ& offset,
+    paint_session& session, const uint8_t direction, const ImageId& image_id, const CoordsXYZ& offset,
     const CoordsXYZ& boundBoxSize)
 {
     if (direction & 1)
@@ -39,7 +39,7 @@ paint_struct* PaintAddImageAsParentRotated(
 }
 
 paint_struct* PaintAddImageAsChildRotated(
-    paint_session& session, const uint8_t direction, const uint32_t image_id, const CoordsXYZ& offset,
+    paint_session& session, const uint8_t direction, const ImageId& image_id, const CoordsXYZ& offset,
     const CoordsXYZ& boundBoxSize, const CoordsXYZ& boundBoxOffset)
 {
     if (direction & 1)

--- a/src/openrct2/paint/Supports.cpp
+++ b/src/openrct2/paint/Supports.cpp
@@ -798,7 +798,7 @@ bool wooden_b_supports_paint_setup(
  *  rct2: 0x00663105
  */
 bool metal_a_supports_paint_setup(
-    paint_session& session, uint8_t supportType, uint8_t segment, int32_t special, int32_t height, uint32_t imageColourFlags)
+    paint_session& session, uint8_t supportType, uint8_t segment, int32_t special, int32_t height, ImageId imageColourFlags)
 {
     support_height* supportSegments = session.SupportSegments;
 
@@ -813,7 +813,7 @@ bool metal_a_supports_paint_setup(
         {
             return false;
         }
-        imageColourFlags = ImageId(0).WithTransparancy(FilterPaletteID::PaletteDarken1).ToUInt32();
+        imageColourFlags = ImageId(0).WithTransparancy(FilterPaletteID::PaletteDarken1);
     }
 
     int16_t originalHeight = height;
@@ -862,8 +862,7 @@ bool metal_a_supports_paint_setup(
         int16_t boundBoxLengthX = _97B062[ebp].x;
         int16_t boundBoxLengthY = _97B062[ebp].y;
 
-        uint32_t image_id = _metalSupportTypeToCrossbeamImages[supportType][ebp];
-        image_id |= imageColourFlags;
+        auto image_id = imageColourFlags.WithIndex(_metalSupportTypeToCrossbeamImages[supportType][ebp]);
         PaintAddImageAsParent(session, image_id, { xOffset, yOffset, height }, { boundBoxLengthX, boundBoxLengthY, 1 });
 
         segment = newSegment;
@@ -879,9 +878,9 @@ bool metal_a_supports_paint_setup(
         int8_t xOffset = SupportBoundBoxes[segment].x;
         int8_t yOffset = SupportBoundBoxes[segment].y;
 
-        uint32_t image_id = _97B15C[supportType].base_id;
-        image_id += metal_supports_slope_image_map[supportSegments[segment].slope & TILE_ELEMENT_SURFACE_SLOPE_MASK];
-        image_id |= imageColourFlags;
+        uint32_t imageIndex = _97B15C[supportType].base_id;
+        imageIndex += metal_supports_slope_image_map[supportSegments[segment].slope & TILE_ELEMENT_SURFACE_SLOPE_MASK];
+        auto image_id = imageColourFlags.WithIndex(imageIndex);
 
         PaintAddImageAsParent(session, image_id, { xOffset, yOffset, supportSegments[segment].height }, { 0, 0, 5 });
 
@@ -903,9 +902,9 @@ bool metal_a_supports_paint_setup(
         int8_t xOffset = SupportBoundBoxes[segment].x;
         int8_t yOffset = SupportBoundBoxes[segment].y;
 
-        uint32_t image_id = _97B15C[supportType].beam_id;
-        image_id += heightDiff - 1;
-        image_id |= imageColourFlags;
+        uint32_t imageIndex = _97B15C[supportType].beam_id;
+        imageIndex += heightDiff - 1;
+        auto image_id = imageColourFlags.WithIndex(imageIndex);
 
         PaintAddImageAsParent(session, image_id, { xOffset, yOffset, height }, { 0, 0, heightDiff - 1 });
     }
@@ -931,13 +930,13 @@ bool metal_a_supports_paint_setup(
         int8_t xOffset = SupportBoundBoxes[segment].x;
         int8_t yOffset = SupportBoundBoxes[segment].y;
 
-        uint32_t image_id = _97B15C[supportType].beam_id;
-        image_id += z - 1;
-        image_id |= imageColourFlags;
+        uint32_t imageIndex = _97B15C[supportType].beam_id;
+        imageIndex += z - 1;
 
         if (count == 3 && z == 0x10)
-            image_id++;
+            imageIndex++;
 
+        auto image_id = imageColourFlags.WithIndex(imageIndex);
         PaintAddImageAsParent(session, image_id, { xOffset, yOffset, height }, { 0, 0, z - 1 });
 
         height += z;
@@ -975,9 +974,9 @@ bool metal_a_supports_paint_setup(
         int8_t xOffset = SupportBoundBoxes[segment].x;
         int8_t yOffset = SupportBoundBoxes[segment].y;
 
-        uint32_t image_id = _97B190[supportType].beam_id;
-        image_id += z - 1;
-        image_id |= imageColourFlags;
+        uint32_t imageIndex = _97B190[supportType].beam_id;
+        imageIndex += z - 1;
+        auto image_id = imageColourFlags.WithIndex(imageIndex);
 
         PaintAddImageAsParent(session, image_id, { xOffset, yOffset, height }, { 0, 0, 0 }, boundBoxOffset);
 
@@ -1000,7 +999,7 @@ bool metal_a_supports_paint_setup(
  * @return (Carry Flag)
  */
 bool metal_b_supports_paint_setup(
-    paint_session& session, uint8_t supportType, uint8_t segment, int32_t special, int32_t height, uint32_t imageColourFlags)
+    paint_session& session, uint8_t supportType, uint8_t segment, int32_t special, int32_t height, ImageId imageColourFlags)
 {
     support_height* supportSegments = session.SupportSegments;
     uint8_t originalSegment = segment;
@@ -1016,7 +1015,7 @@ bool metal_b_supports_paint_setup(
         {
             return false;
         }
-        imageColourFlags = ImageId(0).WithTransparancy(FilterPaletteID::PaletteDarken1).ToUInt32();
+        imageColourFlags = ImageId(0).WithTransparancy(FilterPaletteID::PaletteDarken1);
     }
 
     uint16_t _9E3294 = 0xFFFF;
@@ -1062,7 +1061,7 @@ bool metal_b_supports_paint_setup(
         }
 
         PaintAddImageAsParent(
-            session, _metalSupportTypeToCrossbeamImages[supportType][ebp] | imageColourFlags,
+            session, imageColourFlags.WithIndex(_metalSupportTypeToCrossbeamImages[supportType][ebp]),
             { SupportBoundBoxes[originalSegment] + loc_97B052[ebp], baseHeight }, { _97B062[ebp], 1 });
     }
 
@@ -1079,7 +1078,8 @@ bool metal_b_supports_paint_setup(
         uint32_t imageId = _97B15C[supportType].base_id + imageOffset;
 
         PaintAddImageAsParent(
-            session, imageId | imageColourFlags, { SupportBoundBoxes[segment], supportSegments[segment].height }, { 0, 0, 5 });
+            session, imageColourFlags.WithIndex(imageId), { SupportBoundBoxes[segment], supportSegments[segment].height },
+            { 0, 0, 5 });
 
         baseHeight = supportSegments[segment].height + 6;
     }
@@ -1094,7 +1094,7 @@ bool metal_b_supports_paint_setup(
     if (heightDiff > 0)
     {
         PaintAddImageAsParent(
-            session, (_97B15C[supportType].beam_id + (heightDiff - 1)) | imageColourFlags,
+            session, imageColourFlags.WithIndex(_97B15C[supportType].beam_id + (heightDiff - 1)),
             { SupportBoundBoxes[segment], baseHeight }, { 0, 0, heightDiff - 1 });
     }
 
@@ -1130,7 +1130,7 @@ bool metal_b_supports_paint_setup(
         }
 
         PaintAddImageAsParent(
-            session, imageId | imageColourFlags, { SupportBoundBoxes[segment], baseHeight }, { 0, 0, beamLength - 1 });
+            session, imageColourFlags.WithIndex(imageId), { SupportBoundBoxes[segment], baseHeight }, { 0, 0, beamLength - 1 });
 
         baseHeight += beamLength;
         i++;
@@ -1159,7 +1159,7 @@ bool metal_b_supports_paint_setup(
 
             uint32_t imageId = _97B15C[supportType].beam_id + (beamLength - 1);
             PaintAddImageAsParent(
-                session, imageId | imageColourFlags, { SupportBoundBoxes[originalSegment], baseHeight }, { 0, 0, 0 },
+                session, imageColourFlags.WithIndex(imageId), { SupportBoundBoxes[originalSegment], baseHeight }, { 0, 0, 0 },
                 { SupportBoundBoxes[originalSegment], height });
             baseHeight += beamLength;
         }

--- a/src/openrct2/paint/Supports.h
+++ b/src/openrct2/paint/Supports.h
@@ -26,9 +26,9 @@ bool wooden_a_supports_paint_setup(
 bool wooden_b_supports_paint_setup(
     paint_session& session, int32_t supportType, int32_t special, int32_t height, uint32_t imageColourFlags);
 bool metal_a_supports_paint_setup(
-    paint_session& session, uint8_t supportType, uint8_t segment, int32_t special, int32_t height, uint32_t imageColourFlags);
+    paint_session& session, uint8_t supportType, uint8_t segment, int32_t special, int32_t height, ImageId imageColourFlags);
 bool metal_b_supports_paint_setup(
-    paint_session& session, uint8_t supportType, uint8_t segment, int32_t special, int32_t height, uint32_t imageColourFlags);
+    paint_session& session, uint8_t supportType, uint8_t segment, int32_t special, int32_t height, ImageId imageColourFlags);
 bool path_a_supports_paint_setup(
     paint_session& session, int32_t supportType, int32_t special, int32_t height, ImageId imageTemplate,
     const FootpathPaintInfo& pathPaintInfo, bool* underground);

--- a/src/openrct2/paint/tile_element/Paint.TileElement.cpp
+++ b/src/openrct2/paint/tile_element/Paint.TileElement.cpp
@@ -172,7 +172,8 @@ static void PaintTileElementBase(paint_session& session, const CoordsXY& origCoo
     {
         uint8_t arrowRotation = (rotation + (gMapSelectArrowDirection & 3)) & 3;
 
-        uint32_t imageId = arrowRotation + (gMapSelectArrowDirection & 0xFC) + 0x20900C27;
+        uint32_t imageIndex = arrowRotation + (gMapSelectArrowDirection & 0xFC) + PEEP_SPAWN_ARROW_0;
+        ImageId imageId = ImageId(imageIndex, COLOUR_YELLOW);
         int32_t arrowZ = gMapSelectArrowPosition.z;
 
         session.SpritePosition.x = coords.x;

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -262,7 +262,7 @@ bool track_paint_util_has_fence(
 }
 
 void track_paint_util_paint_floor(
-    paint_session& session, uint8_t edges, uint32_t colourFlags, uint16_t height, const uint32_t floorSprites[4],
+    paint_session& session, uint8_t edges, ImageId colourFlags, uint16_t height, const uint32_t floorSprites[4],
     const StationObject* stationStyle)
 {
     if (stationStyle != nullptr && stationStyle->Flags & STATION_OBJECT_FLAGS::NO_PLATFORMS)
@@ -287,34 +287,32 @@ void track_paint_util_paint_floor(
         imageId = floorSprites[3];
     }
 
-    PaintAddImageAsParent(session, imageId | colourFlags, { 0, 0, height }, { 32, 32, 1 }, { 0, 0, height });
+    PaintAddImageAsParent(session, colourFlags.WithIndex(imageId), { 0, 0, height }, { 32, 32, 1 }, { 0, 0, height });
 }
 
 void track_paint_util_paint_fences(
     paint_session& session, uint8_t edges, const CoordsXY& position, const TrackElement& trackElement, const Ride& ride,
-    uint32_t colourFlags, uint16_t height, const uint32_t fenceSprites[4], uint8_t rotation)
+    const ImageId& colourFlags, uint16_t height, const uint32_t fenceSprites[4], uint8_t rotation)
 {
-    uint32_t imageId;
-
     if (edges & EDGE_NW && track_paint_util_has_fence(EDGE_NW, position, trackElement, ride, rotation))
     {
-        imageId = fenceSprites[3] | colourFlags;
-        PaintAddImageAsChild(session, imageId, { 0, 0, height }, { 32, 1, 7 }, { 0, 2, height + 2 });
+        PaintAddImageAsChild(
+            session, colourFlags.WithIndex(fenceSprites[3]), { 0, 0, height }, { 32, 1, 7 }, { 0, 2, height + 2 });
     }
     if (edges & EDGE_NE && track_paint_util_has_fence(EDGE_NE, position, trackElement, ride, rotation))
     {
-        imageId = fenceSprites[0] | colourFlags;
-        PaintAddImageAsChild(session, imageId, { 0, 0, height }, { 1, 32, 7 }, { 2, 0, height + 2 });
+        PaintAddImageAsChild(
+            session, colourFlags.WithIndex(fenceSprites[0]), { 0, 0, height }, { 1, 32, 7 }, { 2, 0, height + 2 });
     }
     if (edges & EDGE_SE && track_paint_util_has_fence(EDGE_SE, position, trackElement, ride, rotation))
     {
-        imageId = fenceSprites[1] | colourFlags;
-        PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 1, 7 }, { 0, 30, height + 2 });
+        PaintAddImageAsParent(
+            session, colourFlags.WithIndex(fenceSprites[1]), { 0, 0, height }, { 32, 1, 7 }, { 0, 30, height + 2 });
     }
     if (edges & EDGE_SW && track_paint_util_has_fence(EDGE_SW, position, trackElement, ride, rotation))
     {
-        imageId = fenceSprites[2] | colourFlags;
-        PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 32, 7 }, { 30, 0, height + 2 });
+        PaintAddImageAsParent(
+            session, colourFlags.WithIndex(fenceSprites[2]), { 0, 0, height }, { 1, 32, 7 }, { 30, 0, height + 2 });
     }
 }
 
@@ -366,7 +364,7 @@ static void track_paint_util_draw_station_impl(
         return;
 
     bool hasFence;
-    uint32_t imageId;
+    ImageId imageId;
 
     if (direction == 0 || direction == 2)
     {
@@ -377,26 +375,24 @@ static void track_paint_util_draw_station_impl(
         {
             if (hasGreenLight)
             {
-                imageId = (hasFence ? SPR_STATION_PLATFORM_FENCED_END_GREEN_LIGHT_SW_NE
-                                    : SPR_STATION_PLATFORM_END_GREEN_LIGHT_SW_NE)
-                    | session.TrackColours[SCHEME_SUPPORTS];
+                imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(
+                    hasFence ? SPR_STATION_PLATFORM_FENCED_END_GREEN_LIGHT_SW_NE : SPR_STATION_PLATFORM_END_GREEN_LIGHT_SW_NE);
             }
             else
             {
-                imageId = (hasFence ? SPR_STATION_PLATFORM_FENCED_END_RED_LIGHT_SW_NE
-                                    : SPR_STATION_PLATFORM_END_RED_LIGHT_SW_NE)
-                    | session.TrackColours[SCHEME_SUPPORTS];
+                imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(
+                    hasFence ? SPR_STATION_PLATFORM_FENCED_END_RED_LIGHT_SW_NE : SPR_STATION_PLATFORM_END_RED_LIGHT_SW_NE);
             }
         }
         else if (trackElement.GetTrackType() == TrackElemType::BeginStation && direction == 2)
         {
-            imageId = (hasFence ? SPR_STATION_PLATFORM_BEGIN_FENCED_SW_NE : SPR_STATION_PLATFORM_BEGIN_SW_NE)
-                | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(
+                (hasFence ? SPR_STATION_PLATFORM_BEGIN_FENCED_SW_NE : SPR_STATION_PLATFORM_BEGIN_SW_NE));
         }
         else
         {
-            imageId = (hasFence ? SPR_STATION_PLATFORM_FENCED_SW_NE : SPR_STATION_PLATFORM_SW_NE)
-                | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(
+                (hasFence ? SPR_STATION_PLATFORM_FENCED_SW_NE : SPR_STATION_PLATFORM_SW_NE));
         }
         PaintAddImageAsParent(session, imageId, { 0, 0, height + fenceOffsetA }, { 32, 8, 1 });
         // height -= 5 (height)
@@ -405,16 +401,16 @@ static void track_paint_util_draw_station_impl(
 
         if (trackElement.GetTrackType() == TrackElemType::EndStation && direction == 0)
         {
-            imageId = (hasGreenLight ? SPR_STATION_PLATFORM_END_GREEN_LIGHT_SW_NE : SPR_STATION_PLATFORM_END_RED_LIGHT_SW_NE)
-                | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(
+                (hasGreenLight ? SPR_STATION_PLATFORM_END_GREEN_LIGHT_SW_NE : SPR_STATION_PLATFORM_END_RED_LIGHT_SW_NE));
         }
         else if (trackElement.GetTrackType() == TrackElemType::BeginStation && direction == 2)
         {
-            imageId = SPR_STATION_PLATFORM_BEGIN_SW_NE | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_PLATFORM_BEGIN_SW_NE);
         }
         else
         {
-            imageId = SPR_STATION_PLATFORM_SW_NE | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_PLATFORM_SW_NE);
         }
         PaintAddImageAsParent(session, imageId, { 0, 24, height + fenceOffsetA }, { 32, 8, 1 });
         // height += 2 (height + 7)
@@ -424,28 +420,28 @@ static void track_paint_util_draw_station_impl(
         {
             if (trackElement.GetTrackType() == TrackElemType::BeginStation && direction == 0)
             {
-                imageId = SPR_STATION_BEGIN_ANGLE_FENCE_SW_NE | session.TrackColours[SCHEME_SUPPORTS];
+                imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_BEGIN_ANGLE_FENCE_SW_NE);
             }
             else if (trackElement.GetTrackType() == TrackElemType::EndStation && direction == 2)
             {
-                imageId = SPR_STATION_LIGHT_BACK_ANGLE_FENCED_NE_SW | session.TrackColours[SCHEME_SUPPORTS];
+                imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_LIGHT_BACK_ANGLE_FENCED_NE_SW);
             }
             else
             {
-                imageId = SPR_STATION_FENCE_SW_NE | session.TrackColours[SCHEME_SUPPORTS];
+                imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_FENCE_SW_NE);
             }
             PaintAddImageAsParent(session, imageId, { 0, 31, height + fenceOffsetB }, { 32, 1, 7 });
         }
         else if (trackElement.GetTrackType() == TrackElemType::BeginStation && direction == 0)
         {
             // Addition: draw only small fence if there is an entrance/exit at the beginning
-            imageId = SPR_STATION_FENCE_SMALL_NW_SE | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_FENCE_SMALL_NW_SE);
             PaintAddImageAsParent(session, imageId, { 31, 23, height + fenceOffsetB }, { 1, 8, 7 });
         }
         else if (trackElement.GetTrackType() == TrackElemType::EndStation && direction == 2)
         {
             // Addition: draw only small fence if there is an entrance/exit at the end
-            imageId = SPR_STATION_LIGHT_BACK_NE_SW | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_LIGHT_BACK_NE_SW);
             PaintAddImageAsParent(session, imageId, { 31, 23, height + fenceOffsetB }, { 1, 8, 7 });
         }
         // height -= 7 (height)
@@ -454,12 +450,12 @@ static void track_paint_util_draw_station_impl(
 
         if (trackElement.GetTrackType() == TrackElemType::BeginStation && direction == 0)
         {
-            imageId = SPR_STATION_FENCE_SMALL_NW_SE | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_FENCE_SMALL_NW_SE);
             PaintAddImageAsParent(session, imageId, { 31, 0, height + fenceOffsetB }, { 1, 8, 7 });
         }
         else if (trackElement.GetTrackType() == TrackElemType::EndStation && direction == 2)
         {
-            imageId = SPR_STATION_LIGHT_BACK_NE_SW | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_LIGHT_BACK_NE_SW);
             PaintAddImageAsParent(session, imageId, { 31, 0, height + fenceOffsetB }, { 1, 8, 7 });
         }
     }
@@ -472,26 +468,24 @@ static void track_paint_util_draw_station_impl(
         {
             if (hasGreenLight)
             {
-                imageId = (hasFence ? SPR_STATION_PLATFORM_FENCED_END_GREEN_LIGHT_NW_SE
-                                    : SPR_STATION_PLATFORM_END_GREEN_LIGHT_NW_SE)
-                    | session.TrackColours[SCHEME_SUPPORTS];
+                imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(
+                    hasFence ? SPR_STATION_PLATFORM_FENCED_END_GREEN_LIGHT_NW_SE : SPR_STATION_PLATFORM_END_GREEN_LIGHT_NW_SE);
             }
             else
             {
-                imageId = (hasFence ? SPR_STATION_PLATFORM_FENCED_END_RED_LIGHT_NW_SE
-                                    : SPR_STATION_PLATFORM_END_RED_LIGHT_NW_SE)
-                    | session.TrackColours[SCHEME_SUPPORTS];
+                imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(
+                    hasFence ? SPR_STATION_PLATFORM_FENCED_END_RED_LIGHT_NW_SE : SPR_STATION_PLATFORM_END_RED_LIGHT_NW_SE);
             }
         }
         else if (trackElement.GetTrackType() == TrackElemType::BeginStation && direction == 1)
         {
-            imageId = (hasFence ? SPR_STATION_PLATFORM_BEGIN_FENCED_NW_SE : SPR_STATION_PLATFORM_BEGIN_NW_SE)
-                | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(
+                (hasFence ? SPR_STATION_PLATFORM_BEGIN_FENCED_NW_SE : SPR_STATION_PLATFORM_BEGIN_NW_SE));
         }
         else
         {
-            imageId = (hasFence ? SPR_STATION_PLATFORM_FENCED_NW_SE : SPR_STATION_PLATFORM_NW_SE)
-                | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(
+                (hasFence ? SPR_STATION_PLATFORM_FENCED_NW_SE : SPR_STATION_PLATFORM_NW_SE));
         }
         PaintAddImageAsParent(session, imageId, { 0, 0, height + fenceOffsetA }, { 8, 32, 1 });
         // height -= 5 (height)
@@ -500,16 +494,16 @@ static void track_paint_util_draw_station_impl(
 
         if (trackElement.GetTrackType() == TrackElemType::EndStation && direction == 3)
         {
-            imageId = (hasGreenLight ? SPR_STATION_PLATFORM_END_GREEN_LIGHT_NW_SE : SPR_STATION_PLATFORM_END_RED_LIGHT_NW_SE)
-                | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(
+                (hasGreenLight ? SPR_STATION_PLATFORM_END_GREEN_LIGHT_NW_SE : SPR_STATION_PLATFORM_END_RED_LIGHT_NW_SE));
         }
         else if (trackElement.GetTrackType() == TrackElemType::BeginStation && direction == 1)
         {
-            imageId = SPR_STATION_PLATFORM_BEGIN_NW_SE | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_PLATFORM_BEGIN_NW_SE);
         }
         else
         {
-            imageId = SPR_STATION_PLATFORM_NW_SE | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_PLATFORM_NW_SE);
         }
         PaintAddImageAsParent(session, imageId, { 24, 0, height + fenceOffsetA }, { 8, 32, 1 });
         // height += 2 (height + 7)
@@ -519,28 +513,28 @@ static void track_paint_util_draw_station_impl(
         {
             if (trackElement.GetTrackType() == TrackElemType::BeginStation && direction == 3)
             {
-                imageId = SPR_STATION_BEGIN_ANGLE_FENCE_NW_SE | session.TrackColours[SCHEME_SUPPORTS];
+                imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_BEGIN_ANGLE_FENCE_NW_SE);
             }
             else if (trackElement.GetTrackType() == TrackElemType::EndStation && direction == 1)
             {
-                imageId = SPR_STATION_LIGHT_BACK_ANGLE_FENCED_NW_SE | session.TrackColours[SCHEME_SUPPORTS];
+                imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_LIGHT_BACK_ANGLE_FENCED_NW_SE);
             }
             else
             {
-                imageId = SPR_STATION_FENCE_NW_SE | session.TrackColours[SCHEME_SUPPORTS];
+                imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_FENCE_NW_SE);
             }
             PaintAddImageAsParent(session, imageId, { 31, 0, height + fenceOffsetB }, { 1, 32, 7 });
         }
         else if (trackElement.GetTrackType() == TrackElemType::BeginStation && direction == 3)
         {
             // Addition: draw only small fence if there is an entrance/exit at the beginning
-            imageId = SPR_STATION_FENCE_SMALL_SW_NE | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_FENCE_SMALL_SW_NE);
             PaintAddImageAsParent(session, imageId, { 23, 31, height + fenceOffsetB }, { 8, 1, 7 });
         }
         else if (trackElement.GetTrackType() == TrackElemType::EndStation && direction == 1)
         {
             // Addition: draw only small fence if there is an entrance/exit at the end
-            imageId = SPR_STATION_LIGHT_BACK_NW_SE | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_LIGHT_BACK_NW_SE);
             PaintAddImageAsParent(session, imageId, { 23, 31, height + fenceOffsetB }, { 8, 1, 7 });
         }
 
@@ -550,12 +544,12 @@ static void track_paint_util_draw_station_impl(
 
         if (trackElement.GetTrackType() == TrackElemType::BeginStation && direction == 3)
         {
-            imageId = SPR_STATION_FENCE_SMALL_SW_NE | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_FENCE_SMALL_SW_NE);
             PaintAddImageAsParent(session, imageId, { 0, 31, height + fenceOffsetB }, { 8, 1, 7 });
         }
         else if (trackElement.GetTrackType() == TrackElemType::EndStation && direction == 1)
         {
-            imageId = SPR_STATION_LIGHT_BACK_NW_SE | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_LIGHT_BACK_NW_SE);
             PaintAddImageAsParent(session, imageId, { 0, 31, height + fenceOffsetB }, { 8, 1, 7 });
         }
     }
@@ -573,7 +567,7 @@ void track_paint_util_draw_station_inverted(
         return;
 
     bool hasFence;
-    uint32_t imageId;
+    ImageId imageId;
 
     if (direction == 0 || direction == 2)
     {
@@ -584,26 +578,24 @@ void track_paint_util_draw_station_inverted(
         {
             if (hasGreenLight)
             {
-                imageId = (hasFence ? SPR_STATION_PLATFORM_FENCED_END_GREEN_LIGHT_SW_NE
-                                    : SPR_STATION_PLATFORM_END_GREEN_LIGHT_SW_NE)
-                    | session.TrackColours[SCHEME_SUPPORTS];
+                imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(
+                    hasFence ? SPR_STATION_PLATFORM_FENCED_END_GREEN_LIGHT_SW_NE : SPR_STATION_PLATFORM_END_GREEN_LIGHT_SW_NE);
             }
             else
             {
-                imageId = (hasFence ? SPR_STATION_PLATFORM_FENCED_END_RED_LIGHT_SW_NE
-                                    : SPR_STATION_PLATFORM_END_RED_LIGHT_SW_NE)
-                    | session.TrackColours[SCHEME_SUPPORTS];
+                imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(
+                    hasFence ? SPR_STATION_PLATFORM_FENCED_END_RED_LIGHT_SW_NE : SPR_STATION_PLATFORM_END_RED_LIGHT_SW_NE);
             }
         }
         else if (trackElement.GetTrackType() == TrackElemType::BeginStation && direction == 2)
         {
-            imageId = (hasFence ? SPR_STATION_PLATFORM_BEGIN_FENCED_SW_NE : SPR_STATION_PLATFORM_BEGIN_SW_NE)
-                | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(
+                (hasFence ? SPR_STATION_PLATFORM_BEGIN_FENCED_SW_NE : SPR_STATION_PLATFORM_BEGIN_SW_NE));
         }
         else
         {
-            imageId = (hasFence ? SPR_STATION_PLATFORM_FENCED_SW_NE : SPR_STATION_PLATFORM_SW_NE)
-                | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(
+                (hasFence ? SPR_STATION_PLATFORM_FENCED_SW_NE : SPR_STATION_PLATFORM_SW_NE));
         }
         PaintAddImageAsParent(session, imageId, { 0, 0, height + 6 }, { 32, 8, 1 });
         // height -= 5 (height)
@@ -612,16 +604,16 @@ void track_paint_util_draw_station_inverted(
 
         if (trackElement.GetTrackType() == TrackElemType::EndStation && direction == 0)
         {
-            imageId = (hasGreenLight ? SPR_STATION_PLATFORM_END_GREEN_LIGHT_SW_NE : SPR_STATION_PLATFORM_END_RED_LIGHT_SW_NE)
-                | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(
+                (hasGreenLight ? SPR_STATION_PLATFORM_END_GREEN_LIGHT_SW_NE : SPR_STATION_PLATFORM_END_RED_LIGHT_SW_NE));
         }
         else if (trackElement.GetTrackType() == TrackElemType::BeginStation && direction == 2)
         {
-            imageId = SPR_STATION_PLATFORM_BEGIN_SW_NE | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_PLATFORM_BEGIN_SW_NE);
         }
         else
         {
-            imageId = SPR_STATION_PLATFORM_SW_NE | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_PLATFORM_SW_NE);
         }
         PaintAddImageAsParent(session, imageId, { 0, 24, height + 6 }, { 32, 8, 1 });
         // height += 2 (height + 7)
@@ -631,28 +623,28 @@ void track_paint_util_draw_station_inverted(
         {
             if (trackElement.GetTrackType() == TrackElemType::BeginStation && direction == 0)
             {
-                imageId = SPR_STATION_INVERTED_BEGIN_ANGLE_FENCE_SW_NE | session.TrackColours[SCHEME_SUPPORTS];
+                imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_INVERTED_BEGIN_ANGLE_FENCE_SW_NE);
             }
             else if (trackElement.GetTrackType() == TrackElemType::EndStation && direction == 2)
             {
-                imageId = SPR_STATION_INVERTED_LIGHT_BACK_ANGLE_FENCED_NE_SW | session.TrackColours[SCHEME_SUPPORTS];
+                imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_INVERTED_LIGHT_BACK_ANGLE_FENCED_NE_SW);
             }
             else
             {
-                imageId = SPR_STATION_INVERTED_FENCE_SW_NE | session.TrackColours[SCHEME_SUPPORTS];
+                imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_INVERTED_FENCE_SW_NE);
             }
             PaintAddImageAsParent(session, imageId, { 0, 31, height + 8 }, { 32, 1, 7 });
         }
         else if (trackElement.GetTrackType() == TrackElemType::BeginStation && direction == 0)
         {
             // Addition: draw only small fence if there is an entrance/exit at the beginning
-            imageId = SPR_STATION_FENCE_SMALL_NW_SE | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_FENCE_SMALL_NW_SE);
             PaintAddImageAsParent(session, imageId, { 31, 23, height + 8 }, { 1, 8, 7 });
         }
         else if (trackElement.GetTrackType() == TrackElemType::EndStation && direction == 2)
         {
             // Addition: draw only small fence if there is an entrance/exit at the end
-            imageId = SPR_STATION_LIGHT_BACK_NE_SW | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_LIGHT_BACK_NE_SW);
             PaintAddImageAsParent(session, imageId, { 31, 23, height + 8 }, { 1, 8, 7 });
         }
         // height -= 7 (height)
@@ -661,12 +653,12 @@ void track_paint_util_draw_station_inverted(
 
         if (trackElement.GetTrackType() == TrackElemType::BeginStation && direction == 0)
         {
-            imageId = SPR_STATION_FENCE_SMALL_NW_SE | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_FENCE_SMALL_NW_SE);
             PaintAddImageAsParent(session, imageId, { 31, 0, height + 8 }, { 1, 8, 7 });
         }
         else if (trackElement.GetTrackType() == TrackElemType::EndStation && direction == 2)
         {
-            imageId = SPR_STATION_LIGHT_BACK_NE_SW | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_LIGHT_BACK_NE_SW);
             PaintAddImageAsParent(session, imageId, { 31, 0, height + 8 }, { 1, 8, 7 });
         }
     }
@@ -679,26 +671,24 @@ void track_paint_util_draw_station_inverted(
         {
             if (hasGreenLight)
             {
-                imageId = (hasFence ? SPR_STATION_PLATFORM_FENCED_END_GREEN_LIGHT_NW_SE
-                                    : SPR_STATION_PLATFORM_END_GREEN_LIGHT_NW_SE)
-                    | session.TrackColours[SCHEME_SUPPORTS];
+                imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(
+                    hasFence ? SPR_STATION_PLATFORM_FENCED_END_GREEN_LIGHT_NW_SE : SPR_STATION_PLATFORM_END_GREEN_LIGHT_NW_SE);
             }
             else
             {
-                imageId = (hasFence ? SPR_STATION_PLATFORM_FENCED_END_RED_LIGHT_NW_SE
-                                    : SPR_STATION_PLATFORM_END_RED_LIGHT_NW_SE)
-                    | session.TrackColours[SCHEME_SUPPORTS];
+                imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(
+                    hasFence ? SPR_STATION_PLATFORM_FENCED_END_RED_LIGHT_NW_SE : SPR_STATION_PLATFORM_END_RED_LIGHT_NW_SE);
             }
         }
         else if (trackElement.GetTrackType() == TrackElemType::BeginStation && direction == 1)
         {
-            imageId = (hasFence ? SPR_STATION_PLATFORM_BEGIN_FENCED_NW_SE : SPR_STATION_PLATFORM_BEGIN_NW_SE)
-                | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(
+                (hasFence ? SPR_STATION_PLATFORM_BEGIN_FENCED_NW_SE : SPR_STATION_PLATFORM_BEGIN_NW_SE));
         }
         else
         {
-            imageId = (hasFence ? SPR_STATION_PLATFORM_FENCED_NW_SE : SPR_STATION_PLATFORM_NW_SE)
-                | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(
+                (hasFence ? SPR_STATION_PLATFORM_FENCED_NW_SE : SPR_STATION_PLATFORM_NW_SE));
         }
         PaintAddImageAsParent(session, imageId, { 0, 0, height + 6 }, { 8, 32, 1 });
         // height -= 5 (height)
@@ -707,16 +697,16 @@ void track_paint_util_draw_station_inverted(
 
         if (trackElement.GetTrackType() == TrackElemType::EndStation && direction == 3)
         {
-            imageId = (hasGreenLight ? SPR_STATION_PLATFORM_END_GREEN_LIGHT_NW_SE : SPR_STATION_PLATFORM_END_RED_LIGHT_NW_SE)
-                | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(
+                (hasGreenLight ? SPR_STATION_PLATFORM_END_GREEN_LIGHT_NW_SE : SPR_STATION_PLATFORM_END_RED_LIGHT_NW_SE));
         }
         else if (trackElement.GetTrackType() == TrackElemType::BeginStation && direction == 1)
         {
-            imageId = SPR_STATION_PLATFORM_BEGIN_NW_SE | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_PLATFORM_BEGIN_NW_SE);
         }
         else
         {
-            imageId = SPR_STATION_PLATFORM_NW_SE | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_PLATFORM_NW_SE);
         }
         PaintAddImageAsParent(session, imageId, { 24, 0, height + 6 }, { 8, 32, 1 });
         // height += 2 (height + 7)
@@ -726,28 +716,28 @@ void track_paint_util_draw_station_inverted(
         {
             if (trackElement.GetTrackType() == TrackElemType::BeginStation && direction == 3)
             {
-                imageId = SPR_STATION_INVERTED_BEGIN_ANGLE_FENCE_NW_SE | session.TrackColours[SCHEME_SUPPORTS];
+                imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_INVERTED_BEGIN_ANGLE_FENCE_NW_SE);
             }
             else if (trackElement.GetTrackType() == TrackElemType::EndStation && direction == 1)
             {
-                imageId = SPR_STATION_INVERTED_LIGHT_BACK_ANGLE_FENCED_NW_SE | session.TrackColours[SCHEME_SUPPORTS];
+                imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_INVERTED_LIGHT_BACK_ANGLE_FENCED_NW_SE);
             }
             else
             {
-                imageId = SPR_STATION_INVERTED_FENCE_NW_SE | session.TrackColours[SCHEME_SUPPORTS];
+                imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_INVERTED_FENCE_NW_SE);
             }
             PaintAddImageAsParent(session, imageId, { 31, 0, height + 8 }, { 1, 32, 7 });
         }
         else if (trackElement.GetTrackType() == TrackElemType::BeginStation && direction == 3)
         {
             // Addition: draw only small fence if there is an entrance/exit at the beginning
-            imageId = SPR_STATION_FENCE_SMALL_SW_NE | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_FENCE_SMALL_SW_NE);
             PaintAddImageAsParent(session, imageId, { 23, 31, height + 8 }, { 8, 1, 7 });
         }
         else if (trackElement.GetTrackType() == TrackElemType::EndStation && direction == 1)
         {
             // Addition: draw only small fence if there is an entrance/exit at the end
-            imageId = SPR_STATION_LIGHT_BACK_NW_SE | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_LIGHT_BACK_NW_SE);
             PaintAddImageAsParent(session, imageId, { 23, 31, height + 8 }, { 8, 1, 7 });
         }
 
@@ -757,12 +747,12 @@ void track_paint_util_draw_station_inverted(
 
         if (trackElement.GetTrackType() == TrackElemType::BeginStation && direction == 3)
         {
-            imageId = SPR_STATION_FENCE_SMALL_SW_NE | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_FENCE_SMALL_SW_NE);
             PaintAddImageAsParent(session, imageId, { 0, 31, height + 8 }, { 8, 1, 7 });
         }
         else if (trackElement.GetTrackType() == TrackElemType::EndStation && direction == 1)
         {
-            imageId = SPR_STATION_LIGHT_BACK_NW_SE | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_LIGHT_BACK_NW_SE);
             PaintAddImageAsParent(session, imageId, { 0, 31, height + 8 }, { 8, 1, 7 });
         }
     }
@@ -826,12 +816,13 @@ bool track_paint_util_draw_station_covers_2(
         imageOffset += SPR_STATION_COVER_OFFSET_TALL;
     }
 
-    auto imageTemplate = ImageId::FromUInt32(session.TrackColours[SCHEME_TRACK]);
+    auto imageTemplate = session.TrackColours[SCHEME_TRACK];
     auto imageId = imageTemplate.WithIndex(baseImageIndex + imageOffset);
     PaintAddImageAsParent(session, imageId, offset, boundBox);
 
     // Glass
-    if (session.TrackColours[SCHEME_MISC] == IMAGE_TYPE_REMAP && (stationObject->Flags & STATION_OBJECT_FLAGS::IS_TRANSPARENT))
+    if (session.TrackColours[SCHEME_MISC].ToUInt32() == IMAGE_TYPE_REMAP
+        && (stationObject->Flags & STATION_OBJECT_FLAGS::IS_TRANSPARENT))
     {
         imageId = ImageId(baseImageIndex + imageOffset + 12).WithTransparancy(imageTemplate.GetPrimary());
         PaintAddImageAsChild(session, imageId, offset, boundBox);
@@ -851,18 +842,18 @@ void track_paint_util_draw_narrow_station_platform(
     if (direction & 1)
     {
         bool hasFence = track_paint_util_has_fence(EDGE_NE, position, trackElement, ride, session.CurrentRotation);
-        uint32_t imageId = (hasFence ? SPR_STATION_NARROW_EDGE_FENCED_NE : SPR_STATION_NARROW_EDGE_NE)
-            | session.TrackColours[SCHEME_SUPPORTS];
+        ImageId imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(
+            (hasFence ? SPR_STATION_NARROW_EDGE_FENCED_NE : SPR_STATION_NARROW_EDGE_NE));
         PaintAddImageAsParent(session, imageId, { 0, 0, height + zOffset }, { 8, 32, 1 });
         track_paint_util_draw_station_covers(session, EDGE_NE, hasFence, stationObj, height);
 
-        imageId = SPR_STATION_NARROW_EDGE_SW | session.TrackColours[SCHEME_SUPPORTS];
+        imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_NARROW_EDGE_SW);
         PaintAddImageAsParent(session, imageId, { 24, 0, height + zOffset }, { 8, 32, 1 });
 
         hasFence = track_paint_util_has_fence(EDGE_SW, position, trackElement, ride, session.CurrentRotation);
         if (hasFence)
         {
-            imageId = SPR_STATION_FENCE_NW_SE | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_FENCE_NW_SE);
             PaintAddImageAsParent(session, imageId, { 31, 0, height + zOffset + 2 }, { 1, 32, 7 });
         }
         track_paint_util_draw_station_covers(session, EDGE_SW, hasFence, stationObj, height);
@@ -870,18 +861,18 @@ void track_paint_util_draw_narrow_station_platform(
     else
     {
         bool hasFence = track_paint_util_has_fence(EDGE_NW, position, trackElement, ride, session.CurrentRotation);
-        uint32_t imageId = (hasFence ? SPR_STATION_NARROW_EDGE_FENCED_NW : SPR_STATION_NARROW_EDGE_NW)
-            | session.TrackColours[SCHEME_SUPPORTS];
+        ImageId imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(
+            (hasFence ? SPR_STATION_NARROW_EDGE_FENCED_NW : SPR_STATION_NARROW_EDGE_NW));
         PaintAddImageAsParent(session, imageId, { 0, 0, height + zOffset }, { 32, 8, 1 });
         track_paint_util_draw_station_covers(session, EDGE_NW, hasFence, stationObj, height);
 
-        imageId = SPR_STATION_NARROW_EDGE_SE | session.TrackColours[SCHEME_SUPPORTS];
+        imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_NARROW_EDGE_SE);
         PaintAddImageAsParent(session, imageId, { 0, 24, height + zOffset }, { 32, 8, 1 });
 
         hasFence = track_paint_util_has_fence(EDGE_SE, position, trackElement, ride, session.CurrentRotation);
         if (hasFence)
         {
-            imageId = SPR_STATION_FENCE_SW_NE | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_FENCE_SW_NE);
             PaintAddImageAsParent(session, imageId, { 0, 31, height + zOffset + 2 }, { 32, 1, 7 });
         }
         track_paint_util_draw_station_covers(session, EDGE_SE, hasFence, stationObj, height);
@@ -896,23 +887,23 @@ void track_paint_util_draw_pier(
         return;
 
     bool hasFence;
-    uint32_t imageId;
+    ImageId imageId;
 
     if (direction & 1)
     {
         hasFence = track_paint_util_has_fence(EDGE_NE, position, trackElement, ride, session.CurrentRotation);
-        imageId = (hasFence ? SPR_STATION_PIER_EDGE_NE_FENCED : SPR_STATION_PIER_EDGE_NE)
-            | session.TrackColours[SCHEME_SUPPORTS];
+        imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(
+            (hasFence ? SPR_STATION_PIER_EDGE_NE_FENCED : SPR_STATION_PIER_EDGE_NE));
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 6, 32, 1 }, { 2, 0, height });
         track_paint_util_draw_station_covers(session, EDGE_NE, hasFence, stationObj, height);
 
-        imageId = SPR_STATION_PIER_EDGE_SW | session.TrackColours[SCHEME_SUPPORTS];
+        imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_PIER_EDGE_SW);
         PaintAddImageAsParent(session, imageId, { 24, 0, height }, { 8, 32, 1 });
 
         hasFence = track_paint_util_has_fence(EDGE_SW, position, trackElement, ride, session.CurrentRotation);
         if (hasFence)
         {
-            imageId = SPR_STATION_PIER_FENCE_SW | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_PIER_FENCE_SW);
             PaintAddImageAsParent(session, imageId, { 31, 0, height + 2 }, { 1, 32, 7 });
         }
         track_paint_util_draw_station_covers(session, EDGE_SW, hasFence, stationObj, height);
@@ -920,31 +911,31 @@ void track_paint_util_draw_pier(
     else
     {
         hasFence = track_paint_util_has_fence(EDGE_NW, position, trackElement, ride, rotation);
-        imageId = (hasFence ? SPR_STATION_PIER_EDGE_NW_FENCED : SPR_STATION_PIER_EDGE_NW)
-            | session.TrackColours[SCHEME_SUPPORTS];
+        imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(
+            (hasFence ? SPR_STATION_PIER_EDGE_NW_FENCED : SPR_STATION_PIER_EDGE_NW));
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 6, 1 }, { 0, 2, height });
         track_paint_util_draw_station_covers(session, EDGE_NW, hasFence, stationObj, height);
 
-        imageId = SPR_STATION_PIER_EDGE_SE | session.TrackColours[SCHEME_SUPPORTS];
+        imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_PIER_EDGE_SE);
         PaintAddImageAsParent(session, imageId, { 0, 24, height }, { 32, 8, 1 });
 
         hasFence = track_paint_util_has_fence(EDGE_SE, position, trackElement, ride, rotation);
         if (hasFence)
         {
-            imageId = SPR_STATION_PIER_FENCE_SE | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_PIER_FENCE_SE);
             PaintAddImageAsParent(session, imageId, { 0, 31, height + 2 }, { 32, 1, 7 });
         }
         track_paint_util_draw_station_covers(session, EDGE_SE, hasFence, stationObj, height);
     }
 }
 
-void track_paint_util_draw_station_metal_supports(paint_session& session, Direction direction, uint16_t height, uint32_t colour)
+void track_paint_util_draw_station_metal_supports(paint_session& session, Direction direction, uint16_t height, ImageId colour)
 {
     track_paint_util_draw_station_metal_supports_2(session, direction, height, colour, 3);
 }
 
 void track_paint_util_draw_station_metal_supports_2(
-    paint_session& session, Direction direction, uint16_t height, uint32_t colour, uint8_t type)
+    paint_session& session, Direction direction, uint16_t height, ImageId colour, uint8_t type)
 {
     if (direction & 1)
     {
@@ -1013,7 +1004,7 @@ static constexpr const int8_t right_helix_up_small_quarter_tiles_sprite_map[] = 
 
 void track_paint_util_right_helix_up_small_quarter_tiles_paint(
     paint_session& session, const int8_t thickness[2], int16_t height, Direction direction, uint8_t trackSequence,
-    uint32_t colourFlags, const uint32_t sprites[4][3][2], const CoordsXY offsets[4][3][2],
+    const ImageId& colourFlags, const uint32_t sprites[4][3][2], const CoordsXY offsets[4][3][2],
     const CoordsXY boundsLengths[4][3][2], const CoordsXYZ boundsOffsets[4][3][2])
 {
     int32_t index = right_helix_up_small_quarter_tiles_sprite_map[trackSequence];
@@ -1024,7 +1015,7 @@ void track_paint_util_right_helix_up_small_quarter_tiles_paint(
 
     if (sprites[direction][index][0] != 0)
     {
-        uint32_t imageId = sprites[direction][index][0] | colourFlags;
+        auto imageId = colourFlags.WithIndex(sprites[direction][index][0]);
         CoordsXY offset = (offsets == nullptr ? CoordsXY() : offsets[direction][index][0]);
         CoordsXY boundsLength = boundsLengths[direction][index][0];
         CoordsXYZ boundsOffset = (boundsOffsets == nullptr ? CoordsXYZ(offset, 0) : boundsOffsets[direction][index][0]);
@@ -1035,7 +1026,7 @@ void track_paint_util_right_helix_up_small_quarter_tiles_paint(
     }
     if (sprites[direction][index][1] != 0)
     {
-        uint32_t imageId = sprites[direction][index][1] | colourFlags;
+        auto imageId = colourFlags.WithIndex(sprites[direction][index][1]);
         CoordsXY offset = (offsets == nullptr ? CoordsXY() : offsets[direction][index][1]);
         CoordsXY boundsLength = boundsLengths[direction][index][1];
         CoordsXYZ boundsOffset = (boundsOffsets == nullptr ? CoordsXYZ(offset, 0) : boundsOffsets[direction][index][1]);
@@ -1113,7 +1104,7 @@ static constexpr const int8_t right_helix_up_large_quarter_sprite_map[] = {
 };
 void track_paint_util_right_helix_up_large_quarter_tiles_paint(
     paint_session& session, const int8_t thickness[2], int16_t height, Direction direction, uint8_t trackSequence,
-    uint32_t colourFlags, const uint32_t sprites[4][5][2], const CoordsXY offsets[4][5][2],
+    const ImageId& colourFlags, const uint32_t sprites[4][5][2], const CoordsXY offsets[4][5][2],
     const CoordsXY boundsLengths[4][5][2], const CoordsXYZ boundsOffsets[4][5][2])
 {
     int32_t index = right_helix_up_large_quarter_sprite_map[trackSequence];
@@ -1124,7 +1115,7 @@ void track_paint_util_right_helix_up_large_quarter_tiles_paint(
 
     if (sprites[direction][index][0] != 0)
     {
-        uint32_t imageId = sprites[direction][index][0] | colourFlags;
+        auto imageId = colourFlags.WithIndex(sprites[direction][index][0]);
         CoordsXY offset = (offsets == nullptr ? CoordsXY() : offsets[direction][index][0]);
         CoordsXY boundsLength = boundsLengths[direction][index][0];
         CoordsXYZ boundsOffset = (boundsOffsets == nullptr ? CoordsXYZ(offset, 0) : boundsOffsets[direction][index][0]);
@@ -1135,7 +1126,7 @@ void track_paint_util_right_helix_up_large_quarter_tiles_paint(
     }
     if (sprites[direction][index][1] != 0)
     {
-        uint32_t imageId = sprites[direction][index][1] | colourFlags;
+        auto imageId = colourFlags.WithIndex(sprites[direction][index][1]);
         CoordsXY offset = (offsets == nullptr ? CoordsXY() : offsets[direction][index][1]);
         CoordsXY boundsLength = boundsLengths[direction][index][1];
         CoordsXYZ boundsOffset = (boundsOffsets == nullptr ? CoordsXYZ(offset, 0) : boundsOffsets[direction][index][1]);
@@ -1290,7 +1281,7 @@ static constexpr const int8_t eighth_to_diag_sprite_map[] = {
 };
 void track_paint_util_eighth_to_diag_tiles_paint(
     paint_session& session, const int8_t thickness[4][4], int16_t height, Direction direction, uint8_t trackSequence,
-    uint32_t colourFlags, const uint32_t sprites[4][4], const CoordsXY offsets[4][4], const CoordsXY boundsLengths[4][4],
+    const ImageId& colourFlags, const uint32_t sprites[4][4], const CoordsXY offsets[4][4], const CoordsXY boundsLengths[4][4],
     const CoordsXYZ boundsOffsets[4][4])
 {
     int32_t index = eighth_to_diag_sprite_map[trackSequence];
@@ -1299,7 +1290,7 @@ void track_paint_util_eighth_to_diag_tiles_paint(
         return;
     }
 
-    uint32_t imageId = sprites[direction][index] | colourFlags;
+    auto imageId = colourFlags.WithIndex(sprites[direction][index]);
     CoordsXY offset = (offsets == nullptr ? CoordsXY() : offsets[direction][index]);
     CoordsXY boundsLength = boundsLengths[direction][index];
     CoordsXYZ boundsOffset = (boundsOffsets == nullptr ? CoordsXYZ(offset, 0) : boundsOffsets[direction][index]);
@@ -1331,8 +1322,9 @@ static constexpr const int8_t diag_sprite_map[4][4] = {
 };
 
 void track_paint_util_diag_tiles_paint(
-    paint_session& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence, uint32_t colourFlags,
-    const uint32_t sprites[4], const CoordsXY offsets[4], const CoordsXY boundsLengths[4], const CoordsXYZ boundsOffsets[4])
+    paint_session& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
+    const ImageId& colourFlags, const uint32_t sprites[4], const CoordsXY offsets[4], const CoordsXY boundsLengths[4],
+    const CoordsXYZ boundsOffsets[4])
 {
     int32_t index = diag_sprite_map[direction][trackSequence];
     if (index < 0)
@@ -1340,7 +1332,7 @@ void track_paint_util_diag_tiles_paint(
         return;
     }
 
-    uint32_t imageId = sprites[direction] | colourFlags;
+    auto imageId = colourFlags.WithIndex(sprites[direction]);
     CoordsXY offset = (offsets == nullptr ? CoordsXY() : offsets[direction]);
     CoordsXY boundsLength = boundsLengths[direction];
     CoordsXYZ boundsOffset = (boundsOffsets == nullptr ? CoordsXYZ(offset, 0) : boundsOffsets[direction]);
@@ -1452,8 +1444,8 @@ static constexpr const int8_t right_quarter_turn_5_tiles_sprite_map[] = {
 };
 
 void track_paint_util_right_quarter_turn_5_tiles_paint(
-    paint_session& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence, uint32_t colourFlags,
-    const uint32_t sprites[4][5], const CoordsXY offsets[4][5], const CoordsXY boundsLengths[4][5],
+    paint_session& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
+    const ImageId& colourFlags, const uint32_t sprites[4][5], const CoordsXY offsets[4][5], const CoordsXY boundsLengths[4][5],
     const CoordsXYZ boundsOffsets[4][5])
 {
     int32_t index = right_quarter_turn_5_tiles_sprite_map[trackSequence];
@@ -1462,7 +1454,7 @@ void track_paint_util_right_quarter_turn_5_tiles_paint(
         return;
     }
 
-    uint32_t imageId = sprites[direction][index] | colourFlags;
+    auto imageId = colourFlags.WithIndex(sprites[direction][index]);
     CoordsXY offset = (offsets == nullptr ? CoordsXY() : offsets[direction][index]);
     CoordsXY boundsLength = boundsLengths[direction][index];
     CoordsXYZ boundsOffset = (boundsOffsets == nullptr ? CoordsXYZ(offset, 0) : boundsOffsets[direction][index]);
@@ -1473,7 +1465,7 @@ void track_paint_util_right_quarter_turn_5_tiles_paint(
 }
 
 void track_paint_util_right_quarter_turn_5_tiles_paint_2(
-    paint_session& session, int16_t height, Direction direction, uint8_t trackSequence, uint32_t colourFlags,
+    paint_session& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId& colourFlags,
     const sprite_bb sprites[][5])
 {
     int8_t sprite = right_quarter_turn_5_tiles_sprite_map[trackSequence];
@@ -1483,7 +1475,7 @@ void track_paint_util_right_quarter_turn_5_tiles_paint_2(
     }
 
     const sprite_bb* spriteBB = &sprites[direction][sprite];
-    const uint32_t imageId = spriteBB->sprite_id | colourFlags;
+    const auto imageId = colourFlags.WithIndex(spriteBB->sprite_id);
     const auto& offset = spriteBB->offset;
     const auto& bbOffset = spriteBB->bb_offset;
     PaintAddImageAsParent(
@@ -1492,7 +1484,7 @@ void track_paint_util_right_quarter_turn_5_tiles_paint_2(
 }
 
 void track_paint_util_right_quarter_turn_5_tiles_paint_3(
-    paint_session& session, int16_t height, Direction direction, uint8_t trackSequence, uint32_t colourFlags,
+    paint_session& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId& colourFlags,
     const sprite_bb sprites[][5])
 {
     int8_t sprite = right_quarter_turn_5_tiles_sprite_map[trackSequence];
@@ -1502,7 +1494,7 @@ void track_paint_util_right_quarter_turn_5_tiles_paint_3(
     }
 
     const sprite_bb* spriteBB = &sprites[direction][sprite];
-    const uint32_t imageId = spriteBB->sprite_id | colourFlags;
+    const auto imageId = colourFlags.WithIndex(spriteBB->sprite_id);
     const auto& offset = spriteBB->offset;
     PaintAddImageAsParent(session, imageId, { offset.x, offset.y, height + offset.z }, spriteBB->bb_size);
 }
@@ -1628,8 +1620,8 @@ static constexpr const int8_t right_quarter_turn_3_tiles_sprite_map[] = {
 };
 
 void track_paint_util_right_quarter_turn_3_tiles_paint(
-    paint_session& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence, uint32_t colourFlags,
-    const uint32_t sprites[4][3], const CoordsXY offsets[4][3], const CoordsXY boundsLengths[4][3],
+    paint_session& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
+    const ImageId& colourFlags, const uint32_t sprites[4][3], const CoordsXY offsets[4][3], const CoordsXY boundsLengths[4][3],
     const CoordsXYZ boundsOffsets[4][3])
 {
     int32_t index = right_quarter_turn_3_tiles_sprite_map[trackSequence];
@@ -1638,7 +1630,7 @@ void track_paint_util_right_quarter_turn_3_tiles_paint(
         return;
     }
 
-    uint32_t imageId = sprites[direction][index] | colourFlags;
+    auto imageId = colourFlags.WithIndex(sprites[direction][index]);
     CoordsXY offset = (offsets == nullptr ? CoordsXY() : offsets[direction][index]);
     CoordsXY boundsLength = boundsLengths[direction][index];
     CoordsXYZ boundsOffset = (boundsOffsets == nullptr ? CoordsXYZ(offset, 0) : boundsOffsets[direction][index]);
@@ -1649,16 +1641,16 @@ void track_paint_util_right_quarter_turn_3_tiles_paint(
 }
 
 void track_paint_util_right_quarter_turn_3_tiles_paint_2(
-    paint_session& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence, uint32_t colourFlags,
-    const uint32_t sprites[4][3])
+    paint_session& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
+    const ImageId& colourFlags, const uint32_t sprites[4][3])
 {
     track_paint_util_right_quarter_turn_3_tiles_paint_2_with_height_offset(
         session, thickness, height, direction, trackSequence, colourFlags, sprites, 0);
 }
 
 void track_paint_util_right_quarter_turn_3_tiles_paint_2_with_height_offset(
-    paint_session& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence, uint32_t colourFlags,
-    const uint32_t sprites[4][3], int32_t heightOffset)
+    paint_session& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
+    const ImageId& colourFlags, const uint32_t sprites[4][3], int32_t heightOffset)
 {
     int8_t sprite = right_quarter_turn_3_tiles_sprite_map[trackSequence];
     if (sprite < 0)
@@ -1666,7 +1658,7 @@ void track_paint_util_right_quarter_turn_3_tiles_paint_2_with_height_offset(
         return;
     }
 
-    uint32_t imageId = sprites[(direction + 1) % 4][sprite] | colourFlags;
+    auto imageId = colourFlags.WithIndex(sprites[(direction + 1) % 4][sprite]);
 
     switch (direction)
     {
@@ -1745,7 +1737,7 @@ void track_paint_util_right_quarter_turn_3_tiles_paint_2_with_height_offset(
 }
 
 void track_paint_util_right_quarter_turn_3_tiles_paint_3(
-    paint_session& session, int16_t height, Direction direction, uint8_t trackSequence, uint32_t colourFlags,
+    paint_session& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId& colourFlags,
     const sprite_bb sprites[4][3])
 {
     int8_t sprite = right_quarter_turn_3_tiles_sprite_map[trackSequence];
@@ -1757,12 +1749,12 @@ void track_paint_util_right_quarter_turn_3_tiles_paint_3(
     const auto& offset = spriteBB->offset;
     const auto& bbOffset = spriteBB->bb_offset;
     PaintAddImageAsParent(
-        session, spriteBB->sprite_id | colourFlags, { offset.x, offset.y, offset.z + height }, spriteBB->bb_size,
+        session, colourFlags.WithIndex(spriteBB->sprite_id), { offset.x, offset.y, offset.z + height }, spriteBB->bb_size,
         { bbOffset.x, bbOffset.y, height + bbOffset.z });
 }
 
 void track_paint_util_right_quarter_turn_3_tiles_paint_4(
-    paint_session& session, int16_t height, Direction direction, uint8_t trackSequence, uint32_t colourFlags,
+    paint_session& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId& colourFlags,
     const sprite_bb sprites[4][3])
 {
     int8_t sprite = right_quarter_turn_3_tiles_sprite_map[trackSequence];
@@ -1772,7 +1764,7 @@ void track_paint_util_right_quarter_turn_3_tiles_paint_4(
     }
 
     const sprite_bb* spriteBB = &sprites[direction][sprite];
-    const uint32_t imageId = spriteBB->sprite_id | colourFlags;
+    const auto imageId = colourFlags.WithIndex(spriteBB->sprite_id);
     const auto& offset = spriteBB->offset;
     PaintAddImageAsParent(session, imageId, { offset.x, offset.y, height + offset.z }, spriteBB->bb_size);
 }
@@ -1853,16 +1845,16 @@ static constexpr const int8_t left_quarter_turn_3_tiles_sprite_map[] = {
 };
 
 void track_paint_util_left_quarter_turn_3_tiles_paint(
-    paint_session& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence, uint32_t colourFlags,
-    const uint32_t sprites[4][3])
+    paint_session& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
+    const ImageId& colourFlags, const uint32_t sprites[4][3])
 {
     track_paint_util_left_quarter_turn_3_tiles_paint_with_height_offset(
         session, thickness, height, direction, trackSequence, colourFlags, sprites, 0);
 }
 
 void track_paint_util_left_quarter_turn_3_tiles_paint_with_height_offset(
-    paint_session& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence, uint32_t colourFlags,
-    const uint32_t sprites[4][3], int32_t heightOffset)
+    paint_session& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
+    const ImageId& colourFlags, const uint32_t sprites[4][3], int32_t heightOffset)
 {
     int8_t sprite = left_quarter_turn_3_tiles_sprite_map[trackSequence];
     if (sprite < 0)
@@ -1870,7 +1862,7 @@ void track_paint_util_left_quarter_turn_3_tiles_paint_with_height_offset(
         return;
     }
 
-    uint32_t imageId = sprites[(direction + 1) % 4][sprite] | colourFlags;
+    auto imageId = colourFlags.WithIndex(sprites[(direction + 1) % 4][sprite]);
 
     switch (direction)
     {
@@ -1974,9 +1966,9 @@ void track_paint_util_left_quarter_turn_3_tiles_tunnel(
 
 void track_paint_util_left_quarter_turn_1_tile_paint(
     paint_session& session, int8_t thickness, int16_t height, int16_t boundBoxZOffset, Direction direction,
-    uint32_t colourFlags, const uint32_t* sprites)
+    const ImageId& colourFlags, const uint32_t* sprites)
 {
-    uint32_t imageId = sprites[direction] | colourFlags;
+    auto imageId = colourFlags.WithIndex(sprites[direction]);
 
     switch (direction)
     {
@@ -2029,15 +2021,15 @@ void track_paint_util_left_quarter_turn_1_tile_tunnel(
 void track_paint_util_spinning_tunnel_paint(paint_session& session, int8_t thickness, int16_t height, Direction direction)
 {
     int32_t frame = gCurrentTicks >> 2 & 3;
-    uint32_t colourFlags = session.TrackColours[SCHEME_SUPPORTS];
+    auto colourFlags = session.TrackColours[SCHEME_SUPPORTS];
 
-    uint32_t colourFlags2 = session.TrackColours[SCHEME_TRACK];
-    if (colourFlags2 & IMAGE_TYPE_REMAP_2_PLUS)
+    auto colourFlags2 = session.TrackColours[SCHEME_TRACK];
+    if (colourFlags2.HasSecondary())
     {
-        colourFlags |= colourFlags2 & (IMAGE_TYPE_REMAP_2_PLUS | (0x1F << 24));
+        colourFlags = colourFlags.WithSecondary(colourFlags2.GetSecondary());
     }
 
-    uint32_t imageId = trackSpritesGhostTrainSpinningTunnel[direction & 1][0][frame] | colourFlags;
+    auto imageId = colourFlags.WithIndex(trackSpritesGhostTrainSpinningTunnel[direction & 1][0][frame]);
     if (direction == 0 || direction == 2)
     {
         PaintAddImageAsChild(session, imageId, { 0, 0, height }, { 28, 20, thickness }, { 2, 6, height });
@@ -2047,7 +2039,7 @@ void track_paint_util_spinning_tunnel_paint(paint_session& session, int8_t thick
         PaintAddImageAsChild(session, imageId, { 0, 0, height }, { 20, 28, thickness }, { 6, 2, height });
     }
 
-    imageId = trackSpritesGhostTrainSpinningTunnel[direction & 1][1][frame] | colourFlags;
+    imageId = colourFlags.WithIndex(trackSpritesGhostTrainSpinningTunnel[direction & 1][1][frame]);
     if (direction == 0 || direction == 2)
     {
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 26, 1, 23 }, { 4, 28, height });
@@ -2069,8 +2061,8 @@ void track_paint_util_onride_photo_small_paint(
     };
 
     bool takingPhoto = trackElement.IsTakingPhoto();
-    uint32_t imageId = imageIds[direction][0] | session.TrackColours[SCHEME_MISC];
-    uint32_t flashImageId = imageIds[direction][takingPhoto ? 2 : 1] | session.TrackColours[SCHEME_MISC];
+    ImageId imageId = session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][0]);
+    ImageId flashImageId = session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][takingPhoto ? 2 : 1]);
     switch (direction)
     {
         case 0:
@@ -2107,8 +2099,8 @@ void track_paint_util_onride_photo_paint(
     };
 
     bool takingPhoto = trackElement.IsTakingPhoto();
-    uint32_t imageId = imageIds[direction][0] | session.TrackColours[SCHEME_MISC];
-    uint32_t flashImageId = imageIds[direction][takingPhoto ? 2 : 1] | session.TrackColours[SCHEME_MISC];
+    ImageId imageId = session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][0]);
+    ImageId flashImageId = session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][takingPhoto ? 2 : 1]);
     switch (direction)
     {
         case 0:
@@ -2207,11 +2199,10 @@ void PaintTrack(paint_session& session, Direction direction, int32_t height, con
                 uint16_t ax = ride->GetRideTypeDescriptor().Heights.VehicleZOffset;
                 // 0x1689 represents 0 height there are -127 to 128 heights above and below it
                 // There are 3 arrays of 256 heights (units, m, ft) chosen with the get_height_marker_offset()
-                uint32_t imageId = SPRITE_ID_PALETTE_COLOUR_1(COLOUR_LIGHT_BLUE) | (0x1689 + get_height_marker_offset());
                 auto heightNum = (height + 8) / 16 - gMapBaseZ;
+                auto imageId = ImageId(SPR_HEIGHT_MARKER_BASE + get_height_marker_offset() + heightNum, COLOUR_LIGHT_BLUE);
 
-                PaintAddImageAsParent(
-                    session, imageId + heightNum, { 16, 16, height + ax + 3 }, { 1, 1, 0 }, { 1000, 1000, 2047 });
+                PaintAddImageAsParent(session, imageId, { 16, 16, height + ax + 3 }, { 1, 1, 0 }, { 1000, 1000, 2047 });
             }
         }
 
@@ -2230,26 +2221,25 @@ void PaintTrack(paint_session& session, Direction direction, int32_t height, con
         }
 
         session.InteractionType = ViewportInteractionItem::Ride;
-        session.TrackColours[SCHEME_TRACK] = SPRITE_ID_PALETTE_COLOUR_2(
-            ride->track_colour[trackColourScheme].main, ride->track_colour[trackColourScheme].additional);
-        session.TrackColours[SCHEME_SUPPORTS] = SPRITE_ID_PALETTE_COLOUR_1(ride->track_colour[trackColourScheme].supports);
-        session.TrackColours[SCHEME_MISC] = IMAGE_TYPE_REMAP;
-        session.TrackColours[SCHEME_3] = 0x20C00000;
+        session.TrackColours[SCHEME_TRACK] = ImageId(
+            0, ride->track_colour[trackColourScheme].main, ride->track_colour[trackColourScheme].additional);
+        session.TrackColours[SCHEME_SUPPORTS] = ImageId(0, ride->track_colour[trackColourScheme].supports);
+        session.TrackColours[SCHEME_MISC] = ImageId(0, COLOUR_BLACK);
+        session.TrackColours[SCHEME_3] = ImageId(0, COLOUR_YELLOW);
         if (trackElement.IsHighlighted())
         {
-            session.TrackColours[SCHEME_TRACK] = 0x21600000;
-            session.TrackColours[SCHEME_SUPPORTS] = 0x21600000;
-            session.TrackColours[SCHEME_MISC] = 0x21600000;
-            session.TrackColours[SCHEME_3] = 0x21600000;
+            session.TrackColours[SCHEME_TRACK] = HighlightMarker;
+            session.TrackColours[SCHEME_SUPPORTS] = HighlightMarker;
+            session.TrackColours[SCHEME_MISC] = HighlightMarker;
+            session.TrackColours[SCHEME_3] = HighlightMarker;
         }
         if (trackElement.IsGhost())
         {
-            uint32_t ghost_id = CONSTRUCTION_MARKER;
             session.InteractionType = ViewportInteractionItem::None;
-            session.TrackColours[SCHEME_TRACK] = ghost_id;
-            session.TrackColours[SCHEME_SUPPORTS] = ghost_id;
-            session.TrackColours[SCHEME_MISC] = ghost_id;
-            session.TrackColours[SCHEME_3] = ghost_id;
+            session.TrackColours[SCHEME_TRACK] = ConstructionMarker;
+            session.TrackColours[SCHEME_SUPPORTS] = ConstructionMarker;
+            session.TrackColours[SCHEME_MISC] = ConstructionMarker;
+            session.TrackColours[SCHEME_3] = ConstructionMarker;
         }
 
         if (ride->type >= RIDE_TYPE_COUNT)

--- a/src/openrct2/ride/TrackPaint.h
+++ b/src/openrct2/ride/TrackPaint.h
@@ -282,11 +282,11 @@ extern const size_t mini_golf_peep_animation_lengths[];
 bool track_paint_util_has_fence(
     enum edge_t edge, const CoordsXY& position, const TrackElement& trackElement, const Ride& ride, uint8_t rotation);
 void track_paint_util_paint_floor(
-    paint_session& session, uint8_t edges, uint32_t colourFlags, uint16_t height, const uint32_t floorSprites[4],
+    paint_session& session, uint8_t edges, ImageId colourFlags, uint16_t height, const uint32_t floorSprites[4],
     const StationObject* stationStyle);
 void track_paint_util_paint_fences(
     paint_session& session, uint8_t edges, const CoordsXY& position, const TrackElement& trackElement, const Ride& ride,
-    uint32_t colourFlags, uint16_t height, const uint32_t fenceSprites[4], uint8_t rotation);
+    const ImageId& colourFlags, uint16_t height, const uint32_t fenceSprites[4], uint8_t rotation);
 bool track_paint_util_draw_station_covers(
     paint_session& session, enum edge_t edge, bool hasFence, const StationObject* stationObject, uint16_t height);
 bool track_paint_util_draw_station_covers_2(
@@ -310,20 +310,19 @@ bool track_paint_util_should_paint_supports(const CoordsXY& position);
 void track_paint_util_draw_pier(
     paint_session& session, const Ride& ride, const StationObject* stationObject, const CoordsXY& position, Direction direction,
     int32_t height, const TrackElement& trackElement, uint8_t rotation);
-void track_paint_util_draw_station_metal_supports(
-    paint_session& session, Direction direction, uint16_t height, uint32_t colour);
+void track_paint_util_draw_station_metal_supports(paint_session& session, Direction direction, uint16_t height, ImageId colour);
 void track_paint_util_draw_station_metal_supports_2(
-    paint_session& session, Direction direction, uint16_t height, uint32_t colour, uint8_t type);
+    paint_session& session, Direction direction, uint16_t height, ImageId colour, uint8_t type);
 
 void track_paint_util_right_quarter_turn_5_tiles_paint(
-    paint_session& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence, uint32_t colourFlags,
-    const uint32_t sprites[4][5], const CoordsXY offsets[4][5], const CoordsXY boundsLengths[4][5],
+    paint_session& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
+    const ImageId& colourFlags, const uint32_t sprites[4][5], const CoordsXY offsets[4][5], const CoordsXY boundsLengths[4][5],
     const CoordsXYZ boundsOffsets[4][5]);
 void track_paint_util_right_quarter_turn_5_tiles_paint_2(
-    paint_session& session, int16_t height, Direction direction, uint8_t trackSequence, uint32_t colourFlags,
+    paint_session& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId& colourFlags,
     const sprite_bb sprites[][5]);
 void track_paint_util_right_quarter_turn_5_tiles_paint_3(
-    paint_session& session, int16_t height, Direction direction, uint8_t trackSequence, uint32_t colourFlags,
+    paint_session& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId& colourFlags,
     const sprite_bb sprites[][5]);
 void track_paint_util_right_quarter_turn_5_tiles_tunnel(
     paint_session& session, int16_t height, Direction direction, uint8_t trackSequence, uint8_t tunnelType);
@@ -336,34 +335,34 @@ void track_paint_util_right_quarter_turn_3_tiles_25_deg_down_tunnel(
     paint_session& session, int16_t height, Direction direction, uint8_t trackSequence, uint8_t tunnelType0,
     uint8_t tunnelType3);
 void track_paint_util_right_quarter_turn_3_tiles_paint(
-    paint_session& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence, uint32_t colourFlags,
-    const uint32_t sprites[4][3], const CoordsXY offsets[4][3], const CoordsXY boundsLengths[4][3],
+    paint_session& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
+    const ImageId& colourFlags, const uint32_t sprites[4][3], const CoordsXY offsets[4][3], const CoordsXY boundsLengths[4][3],
     const CoordsXYZ boundsOffsets[4][3]);
 void track_paint_util_right_quarter_turn_3_tiles_paint_2(
-    paint_session& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence, uint32_t colourFlags,
-    const uint32_t sprites[4][3]);
+    paint_session& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
+    const ImageId& colourFlags, const uint32_t sprites[4][3]);
 void track_paint_util_right_quarter_turn_3_tiles_paint_2_with_height_offset(
-    paint_session& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence, uint32_t colourFlags,
-    const uint32_t sprites[4][3], int32_t heightOffset);
+    paint_session& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
+    const ImageId& colourFlags, const uint32_t sprites[4][3], int32_t heightOffset);
 void track_paint_util_right_quarter_turn_3_tiles_paint_3(
-    paint_session& session, int16_t height, Direction direction, uint8_t trackSequence, uint32_t colourFlags,
+    paint_session& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId& colourFlags,
     const sprite_bb sprites[4][3]);
 void track_paint_util_right_quarter_turn_3_tiles_paint_4(
-    paint_session& session, int16_t height, Direction direction, uint8_t trackSequence, uint32_t colourFlags,
+    paint_session& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId& colourFlags,
     const sprite_bb sprites[4][3]);
 void track_paint_util_right_quarter_turn_3_tiles_tunnel(
     paint_session& session, int16_t height, Direction direction, uint8_t trackSequence, uint8_t tunnelType);
 void track_paint_util_left_quarter_turn_3_tiles_paint(
-    paint_session& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence, uint32_t colourFlags,
-    const uint32_t sprites[4][3]);
+    paint_session& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
+    const ImageId& colourFlags, const uint32_t sprites[4][3]);
 void track_paint_util_left_quarter_turn_3_tiles_paint_with_height_offset(
-    paint_session& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence, uint32_t colourFlags,
-    const uint32_t sprites[4][3], int32_t heightOffset);
+    paint_session& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
+    const ImageId& colourFlags, const uint32_t sprites[4][3], int32_t heightOffset);
 void track_paint_util_left_quarter_turn_3_tiles_tunnel(
     paint_session& session, int16_t height, uint8_t tunnelType, Direction direction, uint8_t trackSequence);
 void track_paint_util_left_quarter_turn_1_tile_paint(
     paint_session& session, int8_t thickness, int16_t height, int16_t boundBoxZOffset, Direction direction,
-    uint32_t colourFlags, const uint32_t* sprites);
+    const ImageId& colourFlags, const uint32_t* sprites);
 void track_paint_util_spinning_tunnel_paint(paint_session& session, int8_t thickness, int16_t height, Direction direction);
 void track_paint_util_onride_photo_small_paint(
     paint_session& session, Direction direction, int32_t height, const TrackElement& trackElement);
@@ -371,19 +370,20 @@ void track_paint_util_onride_photo_paint(
     paint_session& session, Direction direction, int32_t height, const TrackElement& trackElement);
 void track_paint_util_right_helix_up_small_quarter_tiles_paint(
     paint_session& session, const int8_t thickness[2], int16_t height, Direction direction, uint8_t trackSequence,
-    uint32_t colourFlags, const uint32_t sprites[4][3][2], const CoordsXY offsets[4][3][2],
+    const ImageId& colourFlags, const uint32_t sprites[4][3][2], const CoordsXY offsets[4][3][2],
     const CoordsXY boundsLengths[4][3][2], const CoordsXYZ boundsOffsets[4][3][2]);
 void track_paint_util_right_helix_up_large_quarter_tiles_paint(
     paint_session& session, const int8_t thickness[2], int16_t height, Direction direction, uint8_t trackSequence,
-    uint32_t colourFlags, const uint32_t sprites[4][5][2], const CoordsXY offsets[4][5][2],
+    const ImageId& colourFlags, const uint32_t sprites[4][5][2], const CoordsXY offsets[4][5][2],
     const CoordsXY boundsLengths[4][5][2], const CoordsXYZ boundsOffsets[4][5][2]);
 void track_paint_util_eighth_to_diag_tiles_paint(
     paint_session& session, const int8_t thickness[4][4], int16_t height, Direction direction, uint8_t trackSequence,
-    uint32_t colourFlags, const uint32_t sprites[4][4], const CoordsXY offsets[4][4], const CoordsXY boundsLengths[4][4],
+    const ImageId& colourFlags, const uint32_t sprites[4][4], const CoordsXY offsets[4][4], const CoordsXY boundsLengths[4][4],
     const CoordsXYZ boundsOffsets[4][4]);
 void track_paint_util_diag_tiles_paint(
-    paint_session& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence, uint32_t colourFlags,
-    const uint32_t sprites[4], const CoordsXY offsets[4], const CoordsXY boundsLengths[4], const CoordsXYZ boundsOffsets[4]);
+    paint_session& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
+    const ImageId& colourFlags, const uint32_t sprites[4], const CoordsXY offsets[4], const CoordsXY boundsLengths[4],
+    const CoordsXYZ boundsOffsets[4]);
 
 void track_paint_util_left_quarter_turn_1_tile_tunnel(
     paint_session& session, Direction direction, uint16_t baseHeight, int8_t startOffset, uint8_t startTunnel, int8_t endOffset,

--- a/src/openrct2/ride/coaster/AirPoweredVerticalCoaster.cpp
+++ b/src/openrct2/ride/coaster/AirPoweredVerticalCoaster.cpp
@@ -164,13 +164,13 @@ enum
     SPR_AIR_POWERED_VERTICAL_RC_BANKED_QUARTER_TURN_5_FRONT_SE_NE_PART_0 = 22333,
 };
 
-static uint32_t air_powered_vertical_rc_get_support_colour(paint_session& session)
+static ImageId air_powered_vertical_rc_get_support_colour(paint_session& session)
 {
-    uint32_t colourFlags = session.TrackColours[SCHEME_SUPPORTS];
-    uint32_t trackColour = session.TrackColours[SCHEME_TRACK];
-    if (trackColour & IMAGE_TYPE_REMAP_2_PLUS)
+    auto colourFlags = session.TrackColours[SCHEME_SUPPORTS];
+    auto trackColour = session.TrackColours[SCHEME_TRACK];
+    if (trackColour.HasSecondary())
     {
-        colourFlags |= (trackColour & 0x9F000000);
+        colourFlags = colourFlags.WithSecondary(trackColour.GetSecondary());
     }
     return colourFlags;
 }
@@ -187,7 +187,7 @@ static void air_powered_vertical_rc_track_flat(
         SPR_AIR_POWERED_VERTICAL_RC_FLAT_NW_SE,
     };
 
-    uint32_t imageId = imageIds[direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 1 }, { 0, 6, height });
 
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -210,11 +210,11 @@ static void air_powered_vertical_rc_track_station(
     };
 
     PaintAddImageAsParentRotated(
-        session, direction, imageIds[direction][1] | session.TrackColours[SCHEME_MISC], { 0, 0, height - 2 }, { 32, 28, 1 },
-        { 0, 2, height });
+        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][1]), { 0, 0, height - 2 },
+        { 32, 28, 1 }, { 0, 2, height });
     PaintAddImageAsChildRotated(
-        session, direction, imageIds[direction][0] | session.TrackColours[SCHEME_TRACK], { 0, 0, height }, { 32, 20, 1 },
-        { 0, 6, height });
+        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]), { 0, 0, height },
+        { 32, 20, 1 }, { 0, 6, height });
 
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
 
@@ -329,12 +329,12 @@ static void air_powered_vertical_rc_track_flat_to_left_bank(
         { SPR_AIR_POWERED_VERTICAL_RC_FLAT_TO_LEFT_BANK_SE_NW, SPR_AIR_POWERED_VERTICAL_RC_FLAT_TO_LEFT_BANK_FRONT_SE_NW },
     };
 
-    uint32_t imageId = imageIds[direction][0] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
 
     if (direction == 0 || direction == 1)
     {
-        imageId = imageIds[direction][1] | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][1]);
         PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
     }
 
@@ -358,12 +358,12 @@ static void air_powered_vertical_rc_track_flat_to_right_bank(
         { SPR_AIR_POWERED_VERTICAL_RC_FLAT_TO_RIGHT_BANK_SE_NW, SPR_AIR_POWERED_VERTICAL_RC_FLAT_TO_LEFT_BANK_FRONT_SE_NW },
     };
 
-    uint32_t imageId = imageIds[direction][0] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
 
     if (direction == 2 || direction == 3)
     {
-        imageId = imageIds[direction][1] | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][1]);
         PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
     }
 
@@ -430,14 +430,14 @@ static void air_powered_vertical_rc_track_banked_right_quarter_turn_5(
 
     if (direction == 1 && trackSequence == 6)
     {
-        uint32_t imageId = SPR_AIR_POWERED_VERTICAL_RC_BANKED_QUARTER_TURN_5_FRONT_NW_SW_PART_4
-            | session.TrackColours[SCHEME_TRACK];
+        auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+            SPR_AIR_POWERED_VERTICAL_RC_BANKED_QUARTER_TURN_5_FRONT_NW_SW_PART_4);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
     }
     else if (direction == 3 && trackSequence == 0)
     {
-        uint32_t imageId = SPR_AIR_POWERED_VERTICAL_RC_BANKED_QUARTER_TURN_5_FRONT_SE_NE_PART_0
-            | session.TrackColours[SCHEME_TRACK];
+        auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+            SPR_AIR_POWERED_VERTICAL_RC_BANKED_QUARTER_TURN_5_FRONT_SE_NE_PART_0);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
     }
 
@@ -508,7 +508,7 @@ static void air_powered_vertical_rc_track_left_bank(
         SPR_AIR_POWERED_VERTICAL_RC_LEFT_BANK_SE_NW,
     };
 
-    uint32_t imageId = imageIds[direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction]);
     if (direction == 0 || direction == 1)
     {
         PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
@@ -544,7 +544,7 @@ static void air_powered_vertical_rc_track_brakes(
         SPR_AIR_POWERED_VERTICAL_RC_BRAKES_SW_NE,
     };
 
-    uint32_t imageId = imageIds[direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 1 }, { 0, 6, height });
 
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -654,8 +654,9 @@ static void air_powered_vertical_rc_track_vertical_slope_up(
         48, 64, 128, 176, 208, 240, 240,
     };
 
-    uint32_t supportsImageId = supportImageIds[trackSequence][direction] | air_powered_vertical_rc_get_support_colour(session);
-    uint32_t trackImageId = trackImageIds[trackSequence][direction] | session.TrackColours[SCHEME_TRACK];
+    auto supportsImageId = air_powered_vertical_rc_get_support_colour(session).WithIndex(
+        supportImageIds[trackSequence][direction]);
+    auto trackImageId = session.TrackColours[SCHEME_TRACK].WithIndex(trackImageIds[trackSequence][direction]);
     int8_t bbHeight;
     bool isDirection03 = (direction == 0 || direction == 3);
     switch (trackSequence)
@@ -730,14 +731,14 @@ static void air_powered_vertical_rc_track_vertical_slope_up(
         case 5:
             if (wooden_a_supports_paint_setup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]))
             {
-                uint32_t floorImageId;
+                ImageId floorImageId;
                 if (direction & 1)
                 {
-                    floorImageId = SPR_FLOOR_PLANKS_90_DEG | session.TrackColours[SCHEME_SUPPORTS];
+                    floorImageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_FLOOR_PLANKS_90_DEG);
                 }
                 else
                 {
-                    floorImageId = SPR_FLOOR_PLANKS | session.TrackColours[SCHEME_SUPPORTS];
+                    floorImageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_FLOOR_PLANKS);
                 }
                 PaintAddImageAsParent(session, floorImageId, { 0, 0, height }, { 26, 26, 126 }, { 3, 3, height });
                 PaintAddImageAsChildRotated(
@@ -787,15 +788,15 @@ static void air_powered_vertical_rc_track_vertical_up(
         { SPR_AIR_POWERED_VERTICAL_RC_VERTICAL_UP_SE_NW_SEQ_0, SPR_AIR_POWERED_VERTICAL_RC_VERTICAL_UP_SE_NW_SEQ_1 },
     };
 
-    uint32_t imageId;
+    ImageId imageId;
     switch (trackSequence)
     {
         case 0:
-            imageId = imageIds[direction][0] | air_powered_vertical_rc_get_support_colour(session);
+            imageId = air_powered_vertical_rc_get_support_colour(session).WithIndex(imageIds[direction][0]);
             PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 26, 26, 79 }, { 3, 3, height });
             break;
         case 1:
-            imageId = imageIds[direction][1] | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][1]);
             if (direction == 0 || direction == 3)
             {
                 PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 2, 20, 79 }, { 0, 6, height });
@@ -842,12 +843,12 @@ static void air_powered_vertical_rc_track_vertical_top(
         },
     };
 
-    uint32_t imageIdS, imageIdT;
+    ImageId imageIdS, imageIdT;
     switch (trackSequence)
     {
         case 0:
-            imageIdS = imageIds[direction][0] | air_powered_vertical_rc_get_support_colour(session);
-            imageIdT = imageIds[direction][1] | session.TrackColours[SCHEME_TRACK];
+            imageIdS = air_powered_vertical_rc_get_support_colour(session).WithIndex(imageIds[direction][0]);
+            imageIdT = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][1]);
             if (direction == 0)
             {
                 PaintAddImageAsParentRotated(session, direction, imageIdS, { 0, 0, height }, { 32, 20, 15 }, { 0, 6, height });
@@ -860,7 +861,7 @@ static void air_powered_vertical_rc_track_vertical_top(
             }
             break;
         case 1:
-            imageIdT = imageIds[direction][2] | session.TrackColours[SCHEME_TRACK];
+            imageIdT = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][2]);
             if (direction == 0)
             {
                 PaintAddImageAsParentRotated(session, direction, imageIdT, { 0, 0, height }, { 2, 20, 15 }, { 0, 6, height });
@@ -872,7 +873,7 @@ static void air_powered_vertical_rc_track_vertical_top(
             paint_util_set_vertical_tunnel(session, height + 80);
             break;
         case 2:
-            imageIdT = imageIds[direction][3] | session.TrackColours[SCHEME_TRACK];
+            imageIdT = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][3]);
             if (direction == 0)
             {
                 PaintAddImageAsParentRotated(session, direction, imageIdT, { 0, 0, height }, { 2, 20, 1 }, { 33, 6, height });
@@ -884,8 +885,8 @@ static void air_powered_vertical_rc_track_vertical_top(
             paint_util_set_vertical_tunnel(session, height + 80);
             break;
         case 3:
-            imageIdS = imageIds[direction][4] | air_powered_vertical_rc_get_support_colour(session);
-            imageIdT = imageIds[direction][5] | session.TrackColours[SCHEME_TRACK];
+            imageIdS = air_powered_vertical_rc_get_support_colour(session).WithIndex(imageIds[direction][4]);
+            imageIdT = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][5]);
             if (direction == 0)
             {
                 PaintAddImageAsParentRotated(session, direction, imageIdS, { 0, 0, height }, { 5, 20, 1 }, { 24, 6, height });
@@ -924,24 +925,21 @@ static void air_powered_vertical_rc_track_booster(
 {
     // The booster piece is borrowed from the Reverse Freefall Colour.
     // It has two track colours, instead of the one that the APVC has.
-    uint32_t colour = session.TrackColours[SCHEME_TRACK];
+    auto colour = session.TrackColours[SCHEME_TRACK];
     if (!trackElement.IsGhost() && !trackElement.IsHighlighted())
     {
-        // Replace remap colour 2 (bits 24-28) with a copy of remap colour 1 (bits 19-23).
-        colour_t colour1 = (colour >> 19) & 31;
-        colour &= ~0x1F000000;
-        colour |= (colour1 << 24);
+        colour = colour.WithSecondary(colour.GetPrimary());
     }
 
     if (direction & 1)
     {
-        uint32_t imageId = SPR_REVERSE_FREEFALL_RC_FLAT_NW_SE | colour;
+        auto imageId = colour.WithIndex(SPR_REVERSE_FREEFALL_RC_FLAT_NW_SE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 20, 32, 1 }, { 6, 0, height });
         paint_util_push_tunnel_right(session, height, TUNNEL_SQUARE_FLAT);
     }
     else
     {
-        uint32_t imageId = SPR_REVERSE_FREEFALL_RC_FLAT_SW_NE | colour;
+        auto imageId = colour.WithIndex(SPR_REVERSE_FREEFALL_RC_FLAT_SW_NE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 20, 1 }, { 0, 6, height });
         paint_util_push_tunnel_left(session, height, TUNNEL_SQUARE_FLAT);
     }
@@ -962,7 +960,7 @@ static void air_powered_vertical_rc_track_onride_photo(
         SPR_AIR_POWERED_VERTICAL_RC_FLAT_NW_SE,
     };
 
-    uint32_t imageId = imageIds[direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 1 }, { 0, 6, height });
 
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);

--- a/src/openrct2/ride/coaster/AlpineCoaster.cpp
+++ b/src/openrct2/ride/coaster/AlpineCoaster.cpp
@@ -36,22 +36,22 @@ namespace AlpineRC
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_FLAT + 0),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_FLAT + 0)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_FLAT + 1),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_FLAT + 1)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_FLAT + 2),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_FLAT + 2)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_FLAT + 3),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_FLAT + 3)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
@@ -69,13 +69,13 @@ namespace AlpineRC
                 case 0:
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_FLAT + 0),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_FLAT + 0)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_FLAT + 1),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_FLAT + 1)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
@@ -106,18 +106,18 @@ namespace AlpineRC
         if (trackElement.GetTrackType() == TrackElemType::EndStation)
         {
             PaintAddImageAsParentRotated(
-                session, direction, imageIds[direction][1] | session.TrackColours[SCHEME_TRACK], { 0, 0, height },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][1]), { 0, 0, height },
                 { 32, 20, 1 }, { 0, 6, height + 3 });
         }
         else
         {
             PaintAddImageAsParentRotated(
-                session, direction, imageIds[direction][0] | session.TrackColours[SCHEME_TRACK], { 0, 0, height },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]), { 0, 0, height },
                 { 32, 20, 1 }, { 0, 6, height + 3 });
         }
         PaintAddImageAsParentRotated(
-            session, direction, imageIds[direction][2] | session.TrackColours[SCHEME_MISC], { 0, 0, height - 2 }, { 32, 28, 2 },
-            { 0, 2, height });
+            session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][2]), { 0, 0, height - 2 },
+            { 32, 28, 2 }, { 0, 2, height });
         track_paint_util_draw_station_metal_supports(session, direction, height, session.TrackColours[SCHEME_SUPPORTS]);
         track_paint_util_draw_station_2(session, ride, direction, height, trackElement, 4, 7);
         paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -135,23 +135,25 @@ namespace AlpineRC
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_GENTLE + 8),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_GENTLE + 8)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_GENTLE + 9),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_GENTLE + 9)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_GENTLE + 10),
-                        { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
+                        session, direction,
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_GENTLE + 10)), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_GENTLE + 11),
-                        { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
+                        session, direction,
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_GENTLE + 11)), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -167,22 +169,22 @@ namespace AlpineRC
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE + 8),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE + 8)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE + 9),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE + 9)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE + 10),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE + 10)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE + 11),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE + 11)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
@@ -216,22 +218,22 @@ namespace AlpineRC
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_GENTLE + 0),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_GENTLE + 0)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_GENTLE + 1),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_GENTLE + 1)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_GENTLE + 2),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_GENTLE + 2)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_GENTLE + 3),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_GENTLE + 3)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
@@ -248,22 +250,22 @@ namespace AlpineRC
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE + 0),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE + 0)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE + 1),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE + 1)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE + 2),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE + 2)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE + 3),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE + 3)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
@@ -297,22 +299,22 @@ namespace AlpineRC
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_GENTLE + 4),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_GENTLE + 4)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_GENTLE + 5),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_GENTLE + 5)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_GENTLE + 6),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_GENTLE + 6)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_GENTLE + 7),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_GENTLE + 7)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
@@ -329,22 +331,22 @@ namespace AlpineRC
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE + 4),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE + 4)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE + 5),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE + 5)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE + 6),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE + 6)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE + 7),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE + 7)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
@@ -400,22 +402,26 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_CURVE + 0),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_CURVE + 0)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_CURVE + 3),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_CURVE + 3)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_CURVE + 6),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_CURVE + 6)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_CURVE + 9),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_CURVE + 9)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -439,22 +445,26 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_CURVE + 1),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_CURVE + 1)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_CURVE + 4),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_CURVE + 4)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_CURVE + 7),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_CURVE + 7)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_CURVE + 10),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_CURVE + 10)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 16, height });
                         break;
                 }
@@ -468,22 +478,26 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_CURVE + 2),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_CURVE + 2)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_CURVE + 5),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_CURVE + 5)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_CURVE + 8),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_CURVE + 8)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_CURVE + 11),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_CURVE + 11)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                 }
@@ -526,22 +540,26 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_MEDIUM_CURVE + 0),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_MEDIUM_CURVE + 0)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_MEDIUM_CURVE + 5),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_MEDIUM_CURVE + 5)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_MEDIUM_CURVE + 10),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_MEDIUM_CURVE + 10)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_MEDIUM_CURVE + 15),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_MEDIUM_CURVE + 15)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -565,22 +583,26 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_MEDIUM_CURVE + 1),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_MEDIUM_CURVE + 1)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_MEDIUM_CURVE + 6),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_MEDIUM_CURVE + 6)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_MEDIUM_CURVE + 11),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_MEDIUM_CURVE + 11)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_MEDIUM_CURVE + 16),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_MEDIUM_CURVE + 16)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                 }
@@ -596,22 +618,26 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_MEDIUM_CURVE + 2),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_MEDIUM_CURVE + 2)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_MEDIUM_CURVE + 7),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_MEDIUM_CURVE + 7)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 16, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_MEDIUM_CURVE + 12),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_MEDIUM_CURVE + 12)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_MEDIUM_CURVE + 17),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_MEDIUM_CURVE + 17)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 0, height });
                         break;
                 }
@@ -628,22 +654,26 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_MEDIUM_CURVE + 3),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_MEDIUM_CURVE + 3)),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_MEDIUM_CURVE + 8),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_MEDIUM_CURVE + 8)),
                             { 0, 0, height }, { 16, 32, 3 }, { 0, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_MEDIUM_CURVE + 13),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_MEDIUM_CURVE + 13)),
                             { 0, 0, height }, { 16, 32, 3 }, { 0, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_MEDIUM_CURVE + 18),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_MEDIUM_CURVE + 18)),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         break;
                 }
@@ -659,22 +689,26 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_MEDIUM_CURVE + 4),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_MEDIUM_CURVE + 4)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_MEDIUM_CURVE + 9),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_MEDIUM_CURVE + 9)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_MEDIUM_CURVE + 14),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_MEDIUM_CURVE + 14)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_MEDIUM_CURVE + 19),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_MEDIUM_CURVE + 19)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                 }
@@ -717,22 +751,26 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE + 0),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE + 0)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE + 4),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE + 4)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE + 8),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE + 8)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE + 12),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE + 12)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -752,22 +790,26 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE + 1),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE + 1)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE + 5),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE + 5)),
                             { 0, 0, height }, { 34, 16, 3 }, { 0, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE + 9),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE + 9)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE + 13),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE + 13)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                 }
@@ -783,22 +825,26 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE + 2),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE + 2)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE + 6),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE + 6)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 16, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE + 10),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE + 10)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE + 14),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE + 14)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 0, height });
                         break;
                 }
@@ -819,28 +865,32 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE + 3),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE + 3)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE + 7),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE + 7)),
                             { 0, 0, height }, { 16, 18, 3 }, { 0, 16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE + 11),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE + 11)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE + 15),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE + 15)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -867,22 +917,26 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE + 16),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE + 16)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE + 20),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE + 20)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE + 24),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE + 24)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE + 28),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE + 28)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -902,22 +956,26 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE + 17),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE + 17)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE + 21),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE + 21)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE + 25),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE + 25)),
                             { 0, 0, height }, { 34, 16, 3 }, { 0, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE + 29),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE + 29)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 0, height });
                         break;
                 }
@@ -933,22 +991,26 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE + 18),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE + 18)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE + 22),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE + 22)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE + 26),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE + 26)),
                             { 0, 0, height }, { 28, 28, 3 }, { 4, 4, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE + 30),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE + 30)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         break;
                 }
@@ -969,28 +1031,32 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE + 19),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE + 19)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE + 23),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE + 23)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE + 27),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE + 27)),
                             { 0, 0, height }, { 16, 18, 3 }, { 0, 16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE + 31),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE + 31)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1036,7 +1102,7 @@ namespace AlpineRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_FLAT_DIAGONAL + 3),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_FLAT_DIAGONAL + 3)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1048,7 +1114,7 @@ namespace AlpineRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_FLAT_DIAGONAL + 3),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_FLAT_DIAGONAL + 3)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1066,7 +1132,7 @@ namespace AlpineRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_FLAT_DIAGONAL + 0),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_FLAT_DIAGONAL + 0)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1078,7 +1144,7 @@ namespace AlpineRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_FLAT_DIAGONAL + 0),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_FLAT_DIAGONAL + 0)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1096,7 +1162,7 @@ namespace AlpineRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_FLAT_DIAGONAL + 2),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_FLAT_DIAGONAL + 2)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1108,7 +1174,7 @@ namespace AlpineRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_FLAT_DIAGONAL + 2),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_FLAT_DIAGONAL + 2)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1130,7 +1196,7 @@ namespace AlpineRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_FLAT_DIAGONAL + 1),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_FLAT_DIAGONAL + 1)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             metal_a_supports_paint_setup(
                                 session, METAL_SUPPORTS_FORK_ALT, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1156,7 +1222,7 @@ namespace AlpineRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_FLAT_DIAGONAL + 1),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_FLAT_DIAGONAL + 1)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             metal_a_supports_paint_setup(
                                 session, METAL_SUPPORTS_FORK_ALT, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1193,7 +1259,7 @@ namespace AlpineRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 11),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 11)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1205,7 +1271,7 @@ namespace AlpineRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 11),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 11)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1223,7 +1289,7 @@ namespace AlpineRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 8),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 8)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1235,7 +1301,7 @@ namespace AlpineRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 8),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 8)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1253,7 +1319,7 @@ namespace AlpineRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 10),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 10)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1265,7 +1331,7 @@ namespace AlpineRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 10),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 10)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1287,7 +1353,7 @@ namespace AlpineRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 1),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 1)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_FORK_ALT, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1313,7 +1379,7 @@ namespace AlpineRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 1),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 1)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_FORK_ALT, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1350,7 +1416,7 @@ namespace AlpineRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 7),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 7)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1362,7 +1428,7 @@ namespace AlpineRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 7),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 7)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1380,7 +1446,7 @@ namespace AlpineRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 4),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 4)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1392,7 +1458,7 @@ namespace AlpineRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 4),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 4)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1410,7 +1476,7 @@ namespace AlpineRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 6),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 6)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1422,7 +1488,7 @@ namespace AlpineRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 6),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 6)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1444,7 +1510,7 @@ namespace AlpineRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 5),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 5)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_FORK_ALT, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1470,7 +1536,7 @@ namespace AlpineRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 5),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 5)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_FORK_ALT, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1507,7 +1573,7 @@ namespace AlpineRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 3),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 3)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1519,7 +1585,7 @@ namespace AlpineRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 3),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 3)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1537,7 +1603,7 @@ namespace AlpineRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 0),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 0)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1549,7 +1615,7 @@ namespace AlpineRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 0),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 0)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1567,7 +1633,7 @@ namespace AlpineRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 2),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 2)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1579,7 +1645,7 @@ namespace AlpineRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 2),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 2)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1601,7 +1667,7 @@ namespace AlpineRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 1),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 1)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_FORK_ALT, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1627,7 +1693,7 @@ namespace AlpineRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 1),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 1)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_FORK_ALT, 0, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1664,7 +1730,7 @@ namespace AlpineRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 9),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 9)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1676,7 +1742,7 @@ namespace AlpineRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 9),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 9)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1694,7 +1760,7 @@ namespace AlpineRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 10),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 10)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1706,7 +1772,7 @@ namespace AlpineRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 10),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 10)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1724,7 +1790,7 @@ namespace AlpineRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 8),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 8)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1736,7 +1802,7 @@ namespace AlpineRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 8),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 8)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1758,7 +1824,7 @@ namespace AlpineRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 11),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 11)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_FORK_ALT, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1784,7 +1850,7 @@ namespace AlpineRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 11),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 11)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_FORK_ALT, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1821,7 +1887,7 @@ namespace AlpineRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 5),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 5)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1833,7 +1899,7 @@ namespace AlpineRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 5),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 5)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1850,7 +1916,7 @@ namespace AlpineRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 6),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 6)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1862,7 +1928,7 @@ namespace AlpineRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 6),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 6)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1879,7 +1945,7 @@ namespace AlpineRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 4),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 4)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1891,7 +1957,7 @@ namespace AlpineRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 4),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 4)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1912,7 +1978,7 @@ namespace AlpineRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 7),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 7)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_FORK_ALT, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1938,7 +2004,7 @@ namespace AlpineRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 7),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 7)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_FORK_ALT, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1976,7 +2042,7 @@ namespace AlpineRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 1),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 1)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1988,7 +2054,7 @@ namespace AlpineRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 1),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 1)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2006,7 +2072,7 @@ namespace AlpineRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 2),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 2)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2018,7 +2084,7 @@ namespace AlpineRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 2),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 2)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2036,7 +2102,7 @@ namespace AlpineRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 0),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 0)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2048,7 +2114,7 @@ namespace AlpineRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 0),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 0)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2070,7 +2136,7 @@ namespace AlpineRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 3),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 3)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_FORK_ALT, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2096,7 +2162,7 @@ namespace AlpineRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 3),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_DIAGONAL + 3)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_FORK_ALT, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2127,28 +2193,28 @@ namespace AlpineRC
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 0),
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 0)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 1),
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 1)),
                     { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 2),
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 2)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 3),
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 3)),
                     { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 4),
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 4)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 5),
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 5)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
         }
@@ -2172,29 +2238,31 @@ namespace AlpineRC
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 6),
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 6)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 7),
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 7)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 8),
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 8)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 9),
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 9)),
                     { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 10),
-                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 10)), { 0, 0, height },
+                    { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 11),
-                    { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 11)), { 0, 0, height },
+                    { 32, 1, 26 }, { 0, 27, height });
                 break;
         }
         if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -2231,29 +2299,35 @@ namespace AlpineRC
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 12),
-                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 12)), { 0, 0, height },
+                    { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 13),
-                    { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 13)), { 0, 0, height },
+                    { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 14),
-                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 14)), { 0, 0, height },
+                    { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 15),
-                    { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 15)), { 0, 0, height },
+                    { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 16),
-                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 16)), { 0, 0, height },
+                    { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 17),
-                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 17)), { 0, 0, height },
+                    { 32, 20, 3 }, { 0, 6, height });
                 break;
         }
         if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -2283,29 +2357,35 @@ namespace AlpineRC
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 18),
-                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 18)), { 0, 0, height },
+                    { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 19),
-                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 19)), { 0, 0, height },
+                    { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 20),
-                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 20)), { 0, 0, height },
+                    { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 21),
-                    { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 21)), { 0, 0, height },
+                    { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 22),
-                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 22)), { 0, 0, height },
+                    { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 23),
-                    { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 23)), { 0, 0, height },
+                    { 32, 1, 34 }, { 0, 27, height });
                 break;
         }
         if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -2335,29 +2415,35 @@ namespace AlpineRC
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 24),
-                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 24)), { 0, 0, height },
+                    { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 25),
-                    { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 25)), { 0, 0, height },
+                    { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 26),
-                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 26)), { 0, 0, height },
+                    { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 27),
-                    { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 27)), { 0, 0, height },
+                    { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 28),
-                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 28)), { 0, 0, height },
+                    { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 29),
-                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 29)), { 0, 0, height },
+                    { 32, 20, 3 }, { 0, 6, height });
                 break;
         }
         if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -2387,29 +2473,35 @@ namespace AlpineRC
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 30),
-                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 30)), { 0, 0, height },
+                    { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 31),
-                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 31)), { 0, 0, height },
+                    { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 32),
-                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 32)), { 0, 0, height },
+                    { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 33),
-                    { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 33)), { 0, 0, height },
+                    { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 34),
-                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 34)), { 0, 0, height },
+                    { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 35),
-                    { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 35)), { 0, 0, height },
+                    { 32, 1, 34 }, { 0, 27, height });
                 break;
         }
         if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -2467,23 +2559,27 @@ namespace AlpineRC
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 36),
-                    { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 36)), { 0, 0, height },
+                    { 32, 1, 26 }, { 0, 27, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 37),
-                    { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 37)), { 0, 0, height },
+                    { 32, 1, 26 }, { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 38),
-                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 38)), { 0, 0, height },
+                    { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 39),
-                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION + 39)), { 0, 0, height },
+                    { 32, 20, 3 }, { 0, 6, height });
                 break;
         }
         if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -2517,7 +2613,7 @@ namespace AlpineRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 4),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 4)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -2532,11 +2628,11 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 0),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 0)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 1),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 1)),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                         break;
                 }
@@ -2551,7 +2647,7 @@ namespace AlpineRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 3),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 3)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -2570,7 +2666,7 @@ namespace AlpineRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 2),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 2)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2604,7 +2700,7 @@ namespace AlpineRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 9),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 9)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -2619,7 +2715,7 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 5),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 5)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -2634,11 +2730,11 @@ namespace AlpineRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 7),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 7)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 8),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 8)),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                         break;
                 }
@@ -2657,7 +2753,7 @@ namespace AlpineRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 6),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 6)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2691,7 +2787,7 @@ namespace AlpineRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 6),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 6)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -2706,11 +2802,11 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 7),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 7)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 8),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 8)),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                         break;
                 }
@@ -2725,7 +2821,7 @@ namespace AlpineRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 5),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 5)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -2744,7 +2840,7 @@ namespace AlpineRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 9),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 9)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2778,7 +2874,7 @@ namespace AlpineRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 2),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 2)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -2793,7 +2889,7 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 3),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 3)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -2808,11 +2904,11 @@ namespace AlpineRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 0),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 0)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 1),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 1)),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                         break;
                 }
@@ -2831,7 +2927,7 @@ namespace AlpineRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 4),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 4)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2865,7 +2961,7 @@ namespace AlpineRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 14),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 14)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -2880,11 +2976,11 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 10),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 10)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 11),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 11)),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         break;
                 }
@@ -2899,7 +2995,7 @@ namespace AlpineRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 13),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 13)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -2918,7 +3014,7 @@ namespace AlpineRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 12),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 12)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2952,7 +3048,7 @@ namespace AlpineRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 19),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 19)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -2967,7 +3063,7 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 15),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 15)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -2982,11 +3078,11 @@ namespace AlpineRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 17),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 17)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 18),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 18)),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         break;
                 }
@@ -3005,7 +3101,7 @@ namespace AlpineRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 16),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 16)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3039,7 +3135,7 @@ namespace AlpineRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 24),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 24)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -3054,11 +3150,11 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 20),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 20)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 21),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 21)),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         break;
                 }
@@ -3073,7 +3169,7 @@ namespace AlpineRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 23),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 23)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -3092,7 +3188,7 @@ namespace AlpineRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 22),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 22)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3126,7 +3222,7 @@ namespace AlpineRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 29),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 29)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -3141,7 +3237,7 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 25),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 25)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -3156,11 +3252,11 @@ namespace AlpineRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 27),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 27)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 28),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 28)),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         break;
                 }
@@ -3179,7 +3275,7 @@ namespace AlpineRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 26),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 26)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3213,7 +3309,7 @@ namespace AlpineRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 26),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 26)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -3227,11 +3323,11 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 27),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 27)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 28),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 28)),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         break;
                 }
@@ -3245,7 +3341,7 @@ namespace AlpineRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 25),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 25)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -3263,7 +3359,7 @@ namespace AlpineRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 29),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 29)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3298,7 +3394,7 @@ namespace AlpineRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 22),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 22)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -3312,7 +3408,7 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 23),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 23)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -3326,11 +3422,11 @@ namespace AlpineRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 20),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 20)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 21),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 21)),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         break;
                 }
@@ -3348,7 +3444,7 @@ namespace AlpineRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 24),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 24)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3383,7 +3479,7 @@ namespace AlpineRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 16),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 16)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -3398,11 +3494,11 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 17),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 17)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 18),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 18)),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         break;
                 }
@@ -3417,7 +3513,7 @@ namespace AlpineRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 15),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 15)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -3436,7 +3532,7 @@ namespace AlpineRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 19),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 19)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3470,7 +3566,7 @@ namespace AlpineRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 12),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 12)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -3485,7 +3581,7 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 13),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 13)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -3500,11 +3596,11 @@ namespace AlpineRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 10),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 10)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 11),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 11)),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         break;
                 }
@@ -3523,7 +3619,7 @@ namespace AlpineRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 14),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 14)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3557,7 +3653,7 @@ namespace AlpineRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 33),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 33)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -3572,7 +3668,7 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 30),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 30)),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                         break;
                 }
@@ -3587,7 +3683,7 @@ namespace AlpineRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 32),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 32)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -3606,7 +3702,7 @@ namespace AlpineRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 31),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 31)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3640,7 +3736,7 @@ namespace AlpineRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 31),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 31)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -3655,7 +3751,7 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 32),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 32)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -3670,7 +3766,7 @@ namespace AlpineRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 30),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 30)),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                         break;
                 }
@@ -3689,7 +3785,7 @@ namespace AlpineRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 33),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_BANK_TRANSITION_DIAGONAL + 33)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3723,29 +3819,29 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_CURVE_BANKED + 0), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_CURVE_BANKED + 0)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_CURVE_BANKED + 1), { 0, 0, height },
-                            { 32, 1, 26 }, { 0, 27, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_CURVE_BANKED + 1)),
+                            { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_CURVE_BANKED + 4), { 0, 0, height },
-                            { 32, 1, 26 }, { 0, 27, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_CURVE_BANKED + 4)),
+                            { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_CURVE_BANKED + 7), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_CURVE_BANKED + 7)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_CURVE_BANKED + 11),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_CURVE_BANKED + 11)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -3770,25 +3866,25 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_CURVE_BANKED + 2), { 0, 0, height },
-                            { 16, 16, 3 }, { 16, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_CURVE_BANKED + 2)),
+                            { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_CURVE_BANKED + 5), { 0, 0, height },
-                            { 16, 16, 1 }, { 0, 0, height + 27 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_CURVE_BANKED + 5)),
+                            { 0, 0, height }, { 16, 16, 1 }, { 0, 0, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_CURVE_BANKED + 8), { 0, 0, height },
-                            { 16, 16, 3 }, { 0, 16, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_CURVE_BANKED + 8)),
+                            { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_CURVE_BANKED + 12),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_CURVE_BANKED + 12)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 16, height });
                         break;
                 }
@@ -3803,29 +3899,29 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_CURVE_BANKED + 3), { 0, 0, height },
-                            { 20, 32, 3 }, { 6, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_CURVE_BANKED + 3)),
+                            { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_CURVE_BANKED + 6), { 0, 0, height },
-                            { 1, 32, 26 }, { 27, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_CURVE_BANKED + 6)),
+                            { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_CURVE_BANKED + 9), { 0, 0, height },
-                            { 20, 32, 3 }, { 6, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_CURVE_BANKED + 9)),
+                            { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_CURVE_BANKED + 10),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_CURVE_BANKED + 10)),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_CURVE_BANKED + 13),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_CURVE_BANKED + 13)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                 }
@@ -3869,29 +3965,29 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 0),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 0)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 1),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 1)),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 6),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 6)),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 11),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 11)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 17),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 17)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -3916,25 +4012,25 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 2),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 2)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 7),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 7)),
                             { 0, 0, height }, { 32, 16, 1 }, { 0, 0, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 12),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 12)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 18),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 18)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                 }
@@ -3951,25 +4047,25 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 3),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 3)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 8),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 8)),
                             { 0, 0, height }, { 16, 16, 1 }, { 16, 16, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 13),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 13)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 19),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 19)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 0, height });
                         break;
                 }
@@ -3987,25 +4083,25 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 4),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 4)),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 9),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 9)),
                             { 0, 0, height }, { 16, 32, 1 }, { 0, 0, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 14),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 14)),
                             { 0, 0, height }, { 16, 32, 3 }, { 0, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 20),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 20)),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         break;
                 }
@@ -4022,29 +4118,29 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 5),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 5)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 10),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 10)),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 15),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 15)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 16),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 16)),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 21),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_MEDIUM_CURVE_BANKED + 21)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                 }
@@ -4088,25 +4184,25 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 0), { 0, 0, height },
-                            { 32, 1, 26 }, { 0, 27, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 0)),
+                            { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 4), { 0, 0, height },
-                            { 32, 1, 26 }, { 0, 27, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 4)),
+                            { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 8), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 8)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 12),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 12)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -4127,25 +4223,25 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 1), { 0, 0, height },
-                            { 32, 16, 3 }, { 0, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 1)),
+                            { 0, 0, height }, { 32, 16, 3 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 5), { 0, 0, height },
-                            { 34, 16, 0 }, { 0, 0, height + 27 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 5)),
+                            { 0, 0, height }, { 34, 16, 0 }, { 0, 0, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 9), { 0, 0, height },
-                            { 32, 16, 3 }, { 0, 16, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 9)),
+                            { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 13),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 13)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                 }
@@ -4162,25 +4258,25 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 2), { 0, 0, height },
-                            { 16, 16, 3 }, { 0, 16, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 2)),
+                            { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 6), { 0, 0, height },
-                            { 16, 16, 0 }, { 16, 16, height + 27 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 6)),
+                            { 0, 0, height }, { 16, 16, 0 }, { 16, 16, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 10),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 10)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 14),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 14)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 0, height });
                         break;
                 }
@@ -4202,23 +4298,23 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 3), { 0, 0, height },
-                            { 16, 16, 3 }, { 16, 16, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 3)),
+                            { 0, 0, height }, { 16, 16, 3 }, { 16, 16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 7), { 0, 0, height },
-                            { 16, 18, 0 }, { 0, 16, height + 27 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 7)),
+                            { 0, 0, height }, { 16, 18, 0 }, { 0, 16, height + 27 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 11),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 11)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4226,7 +4322,7 @@ namespace AlpineRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 15),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 15)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4254,25 +4350,25 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 16),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 16)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 20),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 20)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 24),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 24)),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 28),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 28)),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                 }
@@ -4293,25 +4389,25 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 17),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 17)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 21),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 21)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 25),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 25)),
                             { 0, 0, height }, { 34, 16, 0 }, { 0, 0, height + 27 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 29),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 29)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 0, height });
                         break;
                 }
@@ -4328,25 +4424,25 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 18),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 18)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 22),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 22)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 26),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 26)),
                             { 0, 0, height }, { 28, 28, 0 }, { 4, 4, height + 27 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 30),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 30)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         break;
                 }
@@ -4368,7 +4464,7 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 19),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 19)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4376,7 +4472,7 @@ namespace AlpineRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 23),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 23)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4384,7 +4480,7 @@ namespace AlpineRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 27),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 27)),
                             { 0, 0, height }, { 16, 18, 0 }, { 0, 16, height + 27 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4392,7 +4488,7 @@ namespace AlpineRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 31),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE_BANKED + 31)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4436,26 +4532,26 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_SMALL_CURVE + 0), { 0, 6, height },
-                            { 32, 20, 3 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_SMALL_CURVE + 0)),
+                            { 0, 6, height }, { 32, 20, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_SMALL_CURVE + 2), { 0, 6, height },
-                            { 32, 20, 3 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_SMALL_CURVE + 2)),
+                            { 0, 6, height }, { 32, 20, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_SMALL_CURVE + 4), { 0, 6, height },
-                            { 32, 20, 3 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_SMALL_CURVE + 4)),
+                            { 0, 6, height }, { 32, 20, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_SMALL_CURVE + 6), { 0, 6, height },
-                            { 32, 20, 3 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_SMALL_CURVE + 6)),
+                            { 0, 6, height }, { 32, 20, 3 });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -4482,26 +4578,26 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_SMALL_CURVE + 1), { 6, 0, height },
-                            { 20, 32, 3 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_SMALL_CURVE + 1)),
+                            { 6, 0, height }, { 20, 32, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_SMALL_CURVE + 3), { 6, 0, height },
-                            { 20, 32, 3 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_SMALL_CURVE + 3)),
+                            { 6, 0, height }, { 20, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_SMALL_CURVE + 5), { 6, 0, height },
-                            { 20, 32, 3 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_SMALL_CURVE + 5)),
+                            { 6, 0, height }, { 20, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_SMALL_CURVE + 7), { 6, 0, height },
-                            { 20, 32, 3 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_SMALL_CURVE + 7)),
+                            { 6, 0, height }, { 20, 32, 3 });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -4536,25 +4632,25 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_SMALL_CURVE + 8), { 0, 6, height },
-                            { 32, 20, 3 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_SMALL_CURVE + 8)),
+                            { 0, 6, height }, { 32, 20, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_SMALL_CURVE + 10),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_SMALL_CURVE + 10)),
                             { 0, 6, height }, { 32, 20, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_SMALL_CURVE + 12),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_SMALL_CURVE + 12)),
                             { 0, 6, height }, { 32, 20, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_SMALL_CURVE + 14),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_SMALL_CURVE + 14)),
                             { 0, 6, height }, { 32, 20, 3 });
                         break;
                 }
@@ -4582,15 +4678,15 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_SMALL_CURVE + 9), { 6, 0, height },
-                            { 20, 32, 3 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_SMALL_CURVE + 9)),
+                            { 6, 0, height }, { 20, 32, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_SMALL_CURVE + 11),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_SMALL_CURVE + 11)),
                             { 6, 0, height }, { 20, 32, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4598,7 +4694,7 @@ namespace AlpineRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_SMALL_CURVE + 13),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_SMALL_CURVE + 13)),
                             { 6, 0, height }, { 20, 32, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 4, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4606,7 +4702,7 @@ namespace AlpineRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_SMALL_CURVE + 15),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_SMALL_CURVE + 15)),
                             { 6, 0, height }, { 20, 32, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4657,25 +4753,25 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 0),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 0)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 5),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 5)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 10),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 10)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 15),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 15)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -4700,25 +4796,25 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 1),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 1)),
                             { 0, 0, height }, { 32, 16, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 6),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 6)),
                             { 0, 0, height }, { 32, 16, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 11),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 11)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 16),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 16)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                 }
@@ -4735,25 +4831,25 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 2),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 2)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 7),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 7)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 16, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 12),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 12)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 17),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 17)),
                             { 0, 0, height }, { 16, 16, 3 });
                         break;
                 }
@@ -4771,25 +4867,25 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 3),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 3)),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 8),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 8)),
                             { 0, 0, height }, { 16, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 13),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 13)),
                             { 0, 0, height }, { 16, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 18),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 18)),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         break;
                 }
@@ -4806,25 +4902,25 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 4),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 4)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 9),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 9)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 14),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 14)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 19),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 19)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                 }
@@ -4860,25 +4956,25 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 20),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 20)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 25),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 25)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 30),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 30)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 35),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 35)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -4903,25 +4999,25 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 21),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 21)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 26),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 26)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 31),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 31)),
                             { 0, 0, height }, { 32, 16, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 36),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 36)),
                             { 0, 0, height }, { 32, 16, 3 });
                         break;
                 }
@@ -4938,25 +5034,25 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 22),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 22)),
                             { 0, 0, height }, { 16, 16, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 27),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 27)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 32),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 32)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 37),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 37)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         break;
                 }
@@ -4974,25 +5070,25 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 23),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 23)),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 28),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 28)),
                             { 0, 0, height }, { 16, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 33),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 33)),
                             { 0, 0, height }, { 16, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 38),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 38)),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         break;
                 }
@@ -5009,25 +5105,25 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 24),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 24)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 29),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 29)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 34),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 34)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 39),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_GENTLE_MEDIUM_CURVE + 39)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                 }
@@ -5078,22 +5174,22 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_S_BEND + 0),
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_S_BEND + 0)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_S_BEND + 4),
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_S_BEND + 4)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_S_BEND + 3),
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_S_BEND + 3)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_S_BEND + 7),
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_S_BEND + 7)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -5114,26 +5210,26 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_S_BEND + 1),
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_S_BEND + 1)),
                             { 0, 0, height }, { 32, 26, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_S_BEND + 5),
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_S_BEND + 5)),
                             { 0, 0, height }, { 32, 26, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 6, 1, height - 1, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_S_BEND + 2),
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_S_BEND + 2)),
                             { 0, 0, height }, { 32, 26, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_S_BEND + 6),
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_S_BEND + 6)),
                             { 0, 0, height }, { 32, 26, 3 }, { 0, 6, height });
                         break;
                 }
@@ -5149,24 +5245,24 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_S_BEND + 2),
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_S_BEND + 2)),
                             { 0, 0, height }, { 32, 26, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_S_BEND + 6),
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_S_BEND + 6)),
                             { 0, 0, height }, { 32, 26, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_S_BEND + 1),
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_S_BEND + 1)),
                             { 0, 0, height }, { 32, 26, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_S_BEND + 5),
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_S_BEND + 5)),
                             { 0, 0, height }, { 32, 26, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 6, 1, height - 1, session.TrackColours[SCHEME_SUPPORTS]);
@@ -5184,22 +5280,22 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_S_BEND + 3),
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_S_BEND + 3)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_S_BEND + 7),
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_S_BEND + 7)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_S_BEND + 0),
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_S_BEND + 0)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_S_BEND + 4),
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_S_BEND + 4)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -5234,22 +5330,22 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_S_BEND + 8),
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_S_BEND + 8)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_S_BEND + 12),
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_S_BEND + 12)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_S_BEND + 11),
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_S_BEND + 11)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_S_BEND + 15),
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_S_BEND + 15)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -5270,26 +5366,26 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_S_BEND + 9),
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_S_BEND + 9)),
                             { 0, 0, height }, { 32, 26, 3 }, { 0, 6, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_S_BEND + 13),
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_S_BEND + 13)),
                             { 0, 0, height }, { 32, 26, 3 }, { 0, 6, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_S_BEND + 10),
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_S_BEND + 10)),
                             { 0, 0, height }, { 32, 26, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_S_BEND + 14),
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_S_BEND + 14)),
                             { 0, 0, height }, { 32, 26, 3 });
                         break;
                 }
@@ -5305,24 +5401,24 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_S_BEND + 10),
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_S_BEND + 10)),
                             { 0, 0, height }, { 32, 26, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_S_BEND + 14),
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_S_BEND + 14)),
                             { 0, 0, height }, { 32, 26, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_S_BEND + 9),
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_S_BEND + 9)),
                             { 0, 0, height }, { 32, 26, 3 }, { 0, 6, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_S_BEND + 13),
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_S_BEND + 13)),
                             { 0, 0, height }, { 32, 26, 3 }, { 0, 6, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -5340,22 +5436,22 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_S_BEND + 11),
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_S_BEND + 11)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_S_BEND + 15),
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_S_BEND + 15)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_S_BEND + 8),
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_S_BEND + 8)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_S_BEND + 12),
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_S_BEND + 12)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -5390,25 +5486,30 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 0),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 0)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 1),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 1)),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 4),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 4)),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 7),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 7)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 11),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 11)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -5433,22 +5534,26 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 2),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 2)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 5),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 5)),
                             { 0, 0, height }, { 16, 16, 1 }, { 0, 0, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 8),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 8)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 12),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 12)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 16, height });
                         break;
                 }
@@ -5462,25 +5567,30 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 3),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 3)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 6),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 6)),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 9),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 9)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 10),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 10)),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 13),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 13)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height + 8 });
                         break;
                 }
@@ -5507,25 +5617,30 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 11),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 11)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 0),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 0)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 1),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 1)),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 4),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 4)),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 7),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 7)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                 }
@@ -5555,22 +5670,26 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 12),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 12)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 2),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 2)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 5),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 5)),
                             { 0, 0, height }, { 16, 16, 1 }, { 0, 0, height + 27 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 8),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 8)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         break;
                 }
@@ -5584,25 +5703,30 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 13),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 13)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height + 8 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 3),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 3)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 6),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 6)),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 9),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 9)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 10),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 10)),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                 }
@@ -5633,25 +5757,30 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 14),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 14)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 17),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 17)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 21),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 21)),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 24),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 24)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 25),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 25)),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                 }
@@ -5676,22 +5805,26 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 15),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 15)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 18),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 18)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 22),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 22)),
                             { 0, 0, height }, { 16, 16, 1 }, { 0, 0, height + 27 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 26),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 26)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         break;
                 }
@@ -5705,25 +5838,30 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 16),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 16)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height + 8 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 19),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 19)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 20),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 20)),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 23),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 23)),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 27),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 27)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                 }
@@ -5750,25 +5888,30 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 17),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 17)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 21),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 21)),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 24),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 24)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 25),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 25)),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 14),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 14)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                 }
@@ -5798,22 +5941,26 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 18),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 18)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 22),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 22)),
                             { 0, 0, height }, { 16, 16, 1 }, { 0, 0, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 26),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 26)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 15),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 15)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 16, height });
                         break;
                 }
@@ -5827,25 +5974,30 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 19),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 19)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 20),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 20)),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 23),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 23)),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 27),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 27)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_SMALL_HELIX + 16),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_SMALL_HELIX + 16)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height + 8 });
                         break;
                 }
@@ -5902,25 +6054,30 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 0),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 0)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 1),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 1)),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 6),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 6)),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 11),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 11)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 17),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 17)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -5945,22 +6102,26 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 2),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 2)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 7),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 7)),
                             { 0, 0, height }, { 32, 16, 1 }, { 0, 0, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 12),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 12)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 18),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 18)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                 }
@@ -5976,22 +6137,26 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 3),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 3)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 8),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 8)),
                             { 0, 0, height }, { 16, 16, 1 }, { 16, 16, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 13),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 13)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 19),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 19)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 0, height });
                         break;
                 }
@@ -6008,22 +6173,26 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 4),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 4)),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 9),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 9)),
                             { 0, 0, height }, { 16, 32, 1 }, { 0, 0, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 14),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 14)),
                             { 0, 0, height }, { 16, 32, 3 }, { 0, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 20),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 20)),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         break;
                 }
@@ -6039,25 +6208,30 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 5),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 5)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 10),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 10)),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 15),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 15)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 16),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 16)),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 21),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 21)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height + 8 });
                         break;
                 }
@@ -6084,25 +6258,30 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 17),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 17)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 0),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 0)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 1),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 1)),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 6),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 6)),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 11),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 11)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                 }
@@ -6132,22 +6311,26 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 18),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 18)),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 2),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 2)),
                             { 0, 0, height }, { 16, 32, 3 }, { 0, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 7),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 7)),
                             { 0, 0, height }, { 16, 32, 1 }, { 0, 0, height + 27 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 12),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 12)),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         break;
                 }
@@ -6163,22 +6346,26 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 19),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 19)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 3),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 3)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 8),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 8)),
                             { 0, 0, height }, { 16, 16, 1 }, { 16, 16, height + 27 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 13),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 13)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         break;
                 }
@@ -6195,22 +6382,26 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 20),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 20)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 4),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 4)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 9),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 9)),
                             { 0, 0, height }, { 32, 16, 1 }, { 0, 0, height + 27 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 14),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 14)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 0, height });
                         break;
                 }
@@ -6226,25 +6417,30 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 21),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 21)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height + 8 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 5),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 5)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 10),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 10)),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 15),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 15)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 16),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 16)),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                 }
@@ -6274,25 +6470,30 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 22),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 22)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 27),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 27)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 33),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 33)),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 38),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 38)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 39),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 39)),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                 }
@@ -6317,22 +6518,26 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 23),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 23)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 28),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 28)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 34),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 34)),
                             { 0, 0, height }, { 32, 16, 1 }, { 0, 0, height + 27 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 40),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 40)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 0, height });
                         break;
                 }
@@ -6348,22 +6553,26 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 24),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 24)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 29),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 29)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 35),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 35)),
                             { 0, 0, height }, { 16, 16, 1 }, { 16, 16, height + 27 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 41),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 41)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         break;
                 }
@@ -6380,22 +6589,26 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 25),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 25)),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 30),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 30)),
                             { 0, 0, height }, { 16, 32, 3 }, { 0, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 36),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 36)),
                             { 0, 0, height }, { 16, 32, 1 }, { 0, 0, height + 27 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 42),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 42)),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         break;
                 }
@@ -6411,31 +6624,36 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 26),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 26)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height + 8 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 4, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 31),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 31)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 32),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 32)),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK, 4, 5, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 37),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 37)),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 4, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 43),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 43)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK, 4, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -6461,25 +6679,30 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 27),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 27)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 33),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 33)),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 38),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 38)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 39),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 39)),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 22),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 22)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                 }
@@ -6509,22 +6732,26 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 28),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 28)),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 34),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 34)),
                             { 0, 0, height }, { 16, 32, 1 }, { 0, 0, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 40),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 40)),
                             { 0, 0, height }, { 16, 32, 3 }, { 0, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 23),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 23)),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         break;
                 }
@@ -6540,22 +6767,26 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 29),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 29)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 35),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 35)),
                             { 0, 0, height }, { 16, 16, 1 }, { 16, 16, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 41),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 41)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 24),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 24)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 0, height });
                         break;
                 }
@@ -6572,22 +6803,26 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 30),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 30)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 36),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 36)),
                             { 0, 0, height }, { 32, 16, 1 }, { 0, 0, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 42),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 42)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 25),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 25)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                 }
@@ -6603,31 +6838,36 @@ namespace AlpineRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 31),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 31)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 32),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 32)),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK, 4, 5, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 37),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 37)),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 4, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 43),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 43)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK, 4, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_LARGE_HELIX + 26),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_LARGE_HELIX + 26)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height + 8 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 4, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -6681,14 +6921,14 @@ namespace AlpineRC
             case 0:
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_FLAT + 0), { 0, 0, height },
-                    { 32, 20, 3 }, { 0, 6, height });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_FLAT + 0)),
+                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 1:
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_FLAT + 1), { 0, 0, height },
-                    { 32, 20, 3 }, { 0, 6, height });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_FLAT + 1)),
+                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
         }
         if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -6715,29 +6955,29 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 0),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 0)),
                             { 0, 6, height }, { 32, 20, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 2),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 2)),
                             { 0, 6, height }, { 32, 20, 3 });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 3),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 3)),
                             { 0, 6, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 5),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 5)),
                             { 0, 6, height }, { 32, 20, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 7),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 7)),
                             { 0, 6, height }, { 32, 20, 3 });
                         break;
                 }
@@ -6765,25 +7005,25 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 1),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 1)),
                             { 6, 0, height }, { 20, 32, 3 }, { 0, 6, height - 6 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 4),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 4)),
                             { 6, 0, height }, { 20, 32, 3 }, { 0, 6, height - 6 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 6),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 6)),
                             { 6, 0, height }, { 20, 32, 3 }, { 0, 6, height - 6 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 8),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 8)),
                             { 6, 0, height }, { 20, 32, 3 }, { 0, 6, height - 6 });
                         break;
                 }
@@ -6819,29 +7059,29 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 9),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 9)),
                             { 0, 6, height }, { 32, 20, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 11),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 11)),
                             { 0, 6, height }, { 32, 20, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 13),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 13)),
                             { 0, 6, height }, { 32, 20, 3 });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 14),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 14)),
                             { 0, 6, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 16),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 16)),
                             { 0, 6, height }, { 32, 20, 3 });
                         break;
                 }
@@ -6869,25 +7109,25 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 10),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 10)),
                             { 6, 0, height }, { 20, 32, 3 }, { 0, 6, height - 6 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 12),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 12)),
                             { 6, 0, height }, { 20, 32, 3 }, { 0, 6, height - 6 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 15),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 15)),
                             { 6, 0, height }, { 20, 32, 3 }, { 0, 6, height - 6 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 17),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 17)),
                             { 6, 0, height }, { 20, 32, 3 }, { 0, 6, height - 6 });
                         break;
                 }
@@ -6923,25 +7163,25 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 12),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 12)),
                             { 0, 6, height }, { 32, 20, 3 }, { 0, 6, height - 6 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 15),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 15)),
                             { 0, 6, height }, { 32, 20, 3 }, { 0, 6, height - 6 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 17),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 17)),
                             { 0, 6, height }, { 32, 20, 3 }, { 0, 6, height - 6 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 10),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 10)),
                             { 0, 6, height }, { 32, 20, 3 }, { 0, 6, height - 6 });
                         break;
                 }
@@ -6969,29 +7209,29 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 11),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 11)),
                             { 6, 0, height }, { 20, 32, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 13),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 13)),
                             { 6, 0, height }, { 20, 32, 3 });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 14),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 14)),
                             { 6, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 16),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 16)),
                             { 6, 0, height }, { 20, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 9),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 9)),
                             { 6, 0, height }, { 20, 32, 3 });
                         break;
                 }
@@ -7027,25 +7267,25 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 8),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 8)),
                             { 0, 6, height }, { 32, 20, 3 }, { 0, 6, height - 6 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 1),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 1)),
                             { 0, 6, height }, { 32, 20, 3 }, { 0, 6, height - 6 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 4),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 4)),
                             { 0, 6, height }, { 32, 20, 3 }, { 0, 6, height - 6 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 6),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 6)),
                             { 0, 6, height }, { 32, 20, 3 }, { 0, 6, height - 6 });
                         break;
                 }
@@ -7073,29 +7313,29 @@ namespace AlpineRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 7),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 7)),
                             { 6, 0, height }, { 20, 32, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 0),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 0)),
                             { 6, 0, height }, { 20, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 2),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 2)),
                             { 6, 0, height }, { 20, 32, 3 });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 3),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 3)),
                             { 6, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 5),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_ALPINE_TRACK_TURN_BANK_TRANSITION + 5)),
                             { 6, 0, height }, { 20, 32, 3 });
                         break;
                 }

--- a/src/openrct2/ride/coaster/BobsleighCoaster.cpp
+++ b/src/openrct2/ride/coaster/BobsleighCoaster.cpp
@@ -42,19 +42,19 @@ static void bobsleigh_rc_track_flat(
             case 0:
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14576, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14576), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14578, { 0, 0, height }, { 32, 1, 26 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14578), { 0, 0, height }, { 32, 1, 26 },
                     { 0, 27, height });
                 break;
             case 1:
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14577, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14577), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14579, { 0, 0, height }, { 32, 1, 26 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14579), { 0, 0, height }, { 32, 1, 26 },
                     { 0, 27, height });
                 break;
         }
@@ -70,19 +70,19 @@ static void bobsleigh_rc_track_flat(
             case 0:
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14572, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14572), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14574, { 0, 0, height }, { 32, 1, 26 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14574), { 0, 0, height }, { 32, 1, 26 },
                     { 0, 27, height });
                 break;
             case 1:
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14573, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14573), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14575, { 0, 0, height }, { 32, 1, 26 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14575), { 0, 0, height }, { 32, 1, 26 },
                     { 0, 27, height });
                 break;
         }
@@ -109,10 +109,11 @@ static void bobsleigh_rc_track_station(
     };
 
     PaintAddImageAsParentRotated(
-        session, direction, imageIds[direction][0] | session.TrackColours[SCHEME_TRACK], { 0, 0, height }, { 32, 20, 1 },
-        { 0, 6, height + 3 });
+        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]), { 0, 0, height },
+        { 32, 20, 1 }, { 0, 6, height + 3 });
     PaintAddImageAsParentRotated(
-        session, direction, imageIds[direction][1] | session.TrackColours[SCHEME_MISC], { 0, 0, height }, { 32, 32, 1 });
+        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][1]), { 0, 0, height },
+        { 32, 32, 1 });
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], 0);
     track_paint_util_draw_station(session, ride, direction, height, trackElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -131,34 +132,34 @@ static void bobsleigh_rc_track_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14634, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14634), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14638, { 0, 0, height }, { 32, 1, 50 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14638), { 0, 0, height }, { 32, 1, 50 },
                     { 0, 27, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14635, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14635), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14639, { 0, 0, height }, { 32, 1, 50 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14639), { 0, 0, height }, { 32, 1, 50 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14636, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14636), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14640, { 0, 0, height }, { 32, 1, 50 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14640), { 0, 0, height }, { 32, 1, 50 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14637, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14637), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14641, { 0, 0, height }, { 32, 1, 50 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14641), { 0, 0, height }, { 32, 1, 50 },
                     { 0, 27, height });
                 break;
         }
@@ -173,34 +174,34 @@ static void bobsleigh_rc_track_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14610, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14610), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14614, { 0, 0, height }, { 32, 1, 50 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14614), { 0, 0, height }, { 32, 1, 50 },
                     { 0, 27, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14611, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14611), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14615, { 0, 0, height }, { 32, 1, 50 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14615), { 0, 0, height }, { 32, 1, 50 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14612, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14612), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14616, { 0, 0, height }, { 32, 1, 50 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14616), { 0, 0, height }, { 32, 1, 50 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14613, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14613), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14617, { 0, 0, height }, { 32, 1, 50 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14617), { 0, 0, height }, { 32, 1, 50 },
                     { 0, 27, height });
                 break;
         }
@@ -233,34 +234,34 @@ static void bobsleigh_rc_track_flat_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14618, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14618), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14622, { 0, 0, height }, { 32, 1, 42 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14622), { 0, 0, height }, { 32, 1, 42 },
                     { 0, 27, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14619, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14619), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14623, { 0, 0, height }, { 32, 1, 42 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14623), { 0, 0, height }, { 32, 1, 42 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14620, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14620), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14624, { 0, 0, height }, { 32, 1, 42 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14624), { 0, 0, height }, { 32, 1, 42 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14621, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14621), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14625, { 0, 0, height }, { 32, 1, 42 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14625), { 0, 0, height }, { 32, 1, 42 },
                     { 0, 27, height });
                 break;
         }
@@ -275,34 +276,34 @@ static void bobsleigh_rc_track_flat_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14594, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14594), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14598, { 0, 0, height }, { 32, 1, 42 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14598), { 0, 0, height }, { 32, 1, 42 },
                     { 0, 27, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14595, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14595), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14599, { 0, 0, height }, { 32, 1, 42 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14599), { 0, 0, height }, { 32, 1, 42 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14596, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14596), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14600, { 0, 0, height }, { 32, 1, 42 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14600), { 0, 0, height }, { 32, 1, 42 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14597, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14597), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14601, { 0, 0, height }, { 32, 1, 42 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14601), { 0, 0, height }, { 32, 1, 42 },
                     { 0, 27, height });
                 break;
         }
@@ -335,34 +336,34 @@ static void bobsleigh_rc_track_25_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14626, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14626), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14630, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14630), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14627, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14627), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14631, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14631), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14628, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14628), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14632, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14632), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14629, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14629), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14633, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14633), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
         }
@@ -377,34 +378,34 @@ static void bobsleigh_rc_track_25_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14602, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14602), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14606, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14606), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14603, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14603), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14607, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14607), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14604, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14604), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14608, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14608), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14605, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14605), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 14609, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14609), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
         }
@@ -462,35 +463,35 @@ static void bobsleigh_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14707, { 0, 2, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14707), { 0, 2, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14727, { 0, 2, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14727), { 0, 2, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14712, { 0, 2, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14712), { 0, 2, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14732, { 0, 2, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14732), { 0, 2, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14717, { 0, 2, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14717), { 0, 2, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14737, { 0, 2, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14737), { 0, 2, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14702, { 0, 2, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14702), { 0, 2, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14722, { 0, 2, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14722), { 0, 2, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -510,35 +511,35 @@ static void bobsleigh_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14706, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14706), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14726, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14726), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14711, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14711), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14731, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14731), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14716, { 0, 16, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14716), { 0, 16, height },
+                        { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14736, { 0, 16, height }, { 32, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14736), { 0, 16, height },
+                        { 32, 16, 0 }, { 0, 16, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14701, { 0, 16, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14701), { 0, 16, height },
+                        { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14721, { 0, 16, height }, { 32, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14721), { 0, 16, height },
+                        { 32, 16, 0 }, { 0, 16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -553,35 +554,35 @@ static void bobsleigh_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14705, { 0, 16, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14705), { 0, 16, height },
+                        { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14725, { 0, 16, height }, { 16, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14725), { 0, 16, height },
+                        { 16, 16, 0 }, { 0, 16, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14710, { 16, 16, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14710), { 16, 16, height },
+                        { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14730, { 16, 16, height }, { 16, 16, 0 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14730), { 16, 16, height },
+                        { 16, 16, 0 }, { 16, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14715, { 16, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14715), { 16, 0, height },
+                        { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14735, { 16, 0, height }, { 16, 16, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14735), { 16, 0, height },
+                        { 16, 16, 0 }, { 16, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14700, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14700), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14720, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14720), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 0, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -596,35 +597,35 @@ static void bobsleigh_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14704, { 16, 0, height }, { 16, 34, 2 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14704), { 16, 0, height },
+                        { 16, 34, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14724, { 16, 0, height }, { 16, 34, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14724), { 16, 0, height },
+                        { 16, 34, 0 }, { 16, 0, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14709, { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14709), { 0, 0, height },
+                        { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14729, { 0, 0, height }, { 16, 32, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14729), { 0, 0, height },
+                        { 16, 32, 0 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14714, { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14714), { 0, 0, height },
+                        { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14734, { 0, 0, height }, { 16, 32, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14734), { 0, 0, height },
+                        { 16, 32, 0 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14699, { 16, 0, height }, { 16, 32, 2 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14699), { 16, 0, height },
+                        { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14719, { 16, 0, height }, { 16, 32, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14719), { 16, 0, height },
+                        { 16, 32, 0 }, { 16, 0, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -639,35 +640,35 @@ static void bobsleigh_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14703, { 2, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14703), { 2, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14723, { 2, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14723), { 2, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14708, { 2, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14708), { 2, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14728, { 2, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14728), { 2, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14713, { 2, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14713), { 2, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14733, { 2, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14733), { 2, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14698, { 2, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14698), { 2, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14718, { 2, 0, height }, { 30, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14718), { 2, 0, height },
+                        { 30, 32, 0 }, { 6, 0, height + 27 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -705,34 +706,34 @@ static void bobsleigh_rc_track_flat_to_left_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14642, { 0, 0, height }, { 32, 20, 2 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14642), { 0, 0, height }, { 32, 20, 2 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14646, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14646), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14643, { 0, 0, height }, { 32, 20, 2 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14643), { 0, 0, height }, { 32, 20, 2 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14647, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14647), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14644, { 0, 0, height }, { 32, 20, 2 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14644), { 0, 0, height }, { 32, 20, 2 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14648, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14648), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14645, { 0, 0, height }, { 32, 20, 2 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14645), { 0, 0, height }, { 32, 20, 2 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14649, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14649), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
     }
@@ -755,34 +756,34 @@ static void bobsleigh_rc_track_flat_to_right_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14650, { 0, 0, height }, { 32, 20, 2 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14650), { 0, 0, height }, { 32, 20, 2 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14654, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14654), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14651, { 0, 0, height }, { 32, 20, 2 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14651), { 0, 0, height }, { 32, 20, 2 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14655, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14655), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14652, { 0, 0, height }, { 32, 20, 2 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14652), { 0, 0, height }, { 32, 20, 2 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14656, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14656), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14653, { 0, 0, height }, { 32, 20, 2 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14653), { 0, 0, height }, { 32, 20, 2 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14657, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14657), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
     }
@@ -805,34 +806,34 @@ static void bobsleigh_rc_track_left_bank_to_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14652, { 0, 0, height }, { 32, 20, 2 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14652), { 0, 0, height }, { 32, 20, 2 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14656, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14656), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14653, { 0, 0, height }, { 32, 20, 2 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14653), { 0, 0, height }, { 32, 20, 2 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14657, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14657), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14650, { 0, 0, height }, { 32, 20, 2 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14650), { 0, 0, height }, { 32, 20, 2 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14654, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14654), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14651, { 0, 0, height }, { 32, 20, 2 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14651), { 0, 0, height }, { 32, 20, 2 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14655, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14655), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
     }
@@ -855,34 +856,34 @@ static void bobsleigh_rc_track_right_bank_to_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14644, { 0, 0, height }, { 32, 20, 2 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14644), { 0, 0, height }, { 32, 20, 2 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14648, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14648), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14645, { 0, 0, height }, { 32, 20, 2 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14645), { 0, 0, height }, { 32, 20, 2 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14649, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14649), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14642, { 0, 0, height }, { 32, 20, 2 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14642), { 0, 0, height }, { 32, 20, 2 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14646, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14646), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14643, { 0, 0, height }, { 32, 20, 2 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14643), { 0, 0, height }, { 32, 20, 2 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14647, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14647), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
     }
@@ -908,35 +909,35 @@ static void bobsleigh_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14747, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14747), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14767, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14767), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14752, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14752), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14772, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14772), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14757, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14757), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14777, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14777), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14742, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14742), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14762, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14762), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -956,35 +957,35 @@ static void bobsleigh_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14746, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14746), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14766, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14766), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14751, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14751), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14771, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14771), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14756, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14756), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14776, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14776), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14741, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14741), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14761, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14761), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -999,35 +1000,35 @@ static void bobsleigh_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14745, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14745), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14765, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14765), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 16, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14750, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14750), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14770, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14770), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14755, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14755), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14775, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14775), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14740, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14740), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14760, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14760), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 0, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1042,35 +1043,35 @@ static void bobsleigh_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14744, { 0, 0, height }, { 16, 32, 2 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14744), { 0, 0, height },
+                        { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14764, { 0, 0, height }, { 16, 32, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14764), { 0, 0, height },
+                        { 16, 32, 0 }, { 16, 0, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14749, { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14749), { 0, 0, height },
+                        { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14769, { 0, 0, height }, { 16, 32, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14769), { 0, 0, height },
+                        { 16, 32, 0 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14754, { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14754), { 0, 0, height },
+                        { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14774, { 0, 0, height }, { 16, 32, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14774), { 0, 0, height },
+                        { 16, 32, 0 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14739, { 0, 0, height }, { 16, 32, 2 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14739), { 0, 0, height },
+                        { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14759, { 0, 0, height }, { 16, 32, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14759), { 0, 0, height },
+                        { 16, 32, 0 }, { 16, 0, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1085,35 +1086,35 @@ static void bobsleigh_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14743, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14743), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14763, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14763), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14748, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14748), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14768, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14768), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14753, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14753), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14773, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14773), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14738, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14738), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14758, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14758), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1151,34 +1152,34 @@ static void bobsleigh_rc_track_left_bank_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14674, { 0, 0, height }, { 32, 20, 2 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14674), { 0, 0, height }, { 32, 20, 2 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14678, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14678), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14675, { 0, 0, height }, { 32, 20, 2 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14675), { 0, 0, height }, { 32, 20, 2 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14679, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14679), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14676, { 0, 0, height }, { 32, 20, 2 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14676), { 0, 0, height }, { 32, 20, 2 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14680, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14680), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14677, { 0, 0, height }, { 32, 20, 2 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14677), { 0, 0, height }, { 32, 20, 2 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14681, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14681), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
     }
@@ -1208,34 +1209,34 @@ static void bobsleigh_rc_track_right_bank_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14682, { 0, 0, height }, { 32, 20, 2 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14682), { 0, 0, height }, { 32, 20, 2 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14686, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14686), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14683, { 0, 0, height }, { 32, 20, 2 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14683), { 0, 0, height }, { 32, 20, 2 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14687, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14687), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14684, { 0, 0, height }, { 32, 20, 2 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14684), { 0, 0, height }, { 32, 20, 2 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14688, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14688), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14685, { 0, 0, height }, { 32, 20, 2 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14685), { 0, 0, height }, { 32, 20, 2 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14689, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14689), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
     }
@@ -1265,34 +1266,34 @@ static void bobsleigh_rc_track_25_deg_up_to_left_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14658, { 0, 0, height }, { 32, 20, 2 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14658), { 0, 0, height }, { 32, 20, 2 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14662, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14662), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14659, { 0, 0, height }, { 32, 20, 2 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14659), { 0, 0, height }, { 32, 20, 2 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14663, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14663), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14660, { 0, 0, height }, { 32, 20, 2 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14660), { 0, 0, height }, { 32, 20, 2 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14664, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14664), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14661, { 0, 0, height }, { 32, 20, 2 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14661), { 0, 0, height }, { 32, 20, 2 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14665, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14665), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
     }
@@ -1322,34 +1323,34 @@ static void bobsleigh_rc_track_25_deg_up_to_right_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14666, { 0, 0, height }, { 32, 20, 2 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14666), { 0, 0, height }, { 32, 20, 2 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14670, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14670), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14667, { 0, 0, height }, { 32, 20, 2 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14667), { 0, 0, height }, { 32, 20, 2 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14671, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14671), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14668, { 0, 0, height }, { 32, 20, 2 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14668), { 0, 0, height }, { 32, 20, 2 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14672, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14672), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14669, { 0, 0, height }, { 32, 20, 2 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14669), { 0, 0, height }, { 32, 20, 2 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14673, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14673), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
     }
@@ -1411,34 +1412,34 @@ static void bobsleigh_rc_track_left_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14690, { 0, 0, height }, { 32, 20, 2 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14690), { 0, 0, height }, { 32, 20, 2 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14694, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14694), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14691, { 0, 0, height }, { 32, 20, 2 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14691), { 0, 0, height }, { 32, 20, 2 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14695, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14695), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14692, { 0, 0, height }, { 32, 20, 2 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14692), { 0, 0, height }, { 32, 20, 2 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14696, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14696), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14693, { 0, 0, height }, { 32, 20, 2 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14693), { 0, 0, height }, { 32, 20, 2 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14697, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14697), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
     }
@@ -1472,35 +1473,35 @@ static void bobsleigh_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14826, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14826), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14842, { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14842), { 0, 0, height },
+                        { 32, 27, 0 }, { 0, 2, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14830, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14830), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14846, { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14846), { 0, 0, height },
+                        { 32, 27, 0 }, { 0, 2, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14829, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14829), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14845, { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14845), { 0, 0, height },
+                        { 32, 27, 0 }, { 0, 2, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14833, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14833), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14849, { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14849), { 0, 0, height },
+                        { 32, 27, 0 }, { 0, 2, height + 27 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1517,39 +1518,39 @@ static void bobsleigh_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14827, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14827), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14843, { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14843), { 0, 0, height },
+                        { 32, 26, 0 }, { 0, 0, height + 27 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14831, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14831), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14847, { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14847), { 0, 0, height },
+                        { 32, 26, 0 }, { 0, 0, height + 27 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 6, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14828, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14828), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14844, { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14844), { 0, 0, height },
+                        { 32, 26, 0 }, { 0, 6, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14832, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14832), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14848, { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14848), { 0, 0, height },
+                        { 32, 26, 0 }, { 0, 6, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1564,37 +1565,37 @@ static void bobsleigh_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14828, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14828), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14844, { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14844), { 0, 0, height },
+                        { 32, 26, 0 }, { 0, 6, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14832, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14832), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14848, { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14848), { 0, 0, height },
+                        { 32, 26, 0 }, { 0, 6, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14827, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14827), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14843, { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14843), { 0, 0, height },
+                        { 32, 26, 0 }, { 0, 0, height + 27 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14831, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14831), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14847, { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14847), { 0, 0, height },
+                        { 32, 26, 0 }, { 0, 0, height + 27 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 6, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -1611,35 +1612,35 @@ static void bobsleigh_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14829, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14829), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14845, { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14845), { 0, 0, height },
+                        { 32, 27, 0 }, { 0, 2, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14833, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14833), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14849, { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14849), { 0, 0, height },
+                        { 32, 27, 0 }, { 0, 2, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14826, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14826), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14842, { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14842), { 0, 0, height },
+                        { 32, 27, 0 }, { 0, 2, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14830, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14830), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14846, { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14846), { 0, 0, height },
+                        { 32, 27, 0 }, { 0, 2, height + 27 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1671,35 +1672,35 @@ static void bobsleigh_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14834, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14834), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14850, { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14850), { 0, 0, height },
+                        { 32, 27, 0 }, { 0, 2, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14838, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14838), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14854, { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14854), { 0, 0, height },
+                        { 32, 27, 0 }, { 0, 2, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14837, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14837), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14853, { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14853), { 0, 0, height },
+                        { 32, 27, 0 }, { 0, 2, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14841, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14841), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14857, { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14857), { 0, 0, height },
+                        { 32, 27, 0 }, { 0, 2, height + 27 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1716,39 +1717,39 @@ static void bobsleigh_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14835, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14835), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14851, { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14851), { 0, 0, height },
+                        { 32, 26, 0 }, { 0, 6, height + 27 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14839, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14839), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14855, { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14855), { 0, 0, height },
+                        { 32, 26, 0 }, { 0, 6, height + 27 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14836, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14836), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14852, { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14852), { 0, 0, height },
+                        { 32, 26, 0 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14840, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14840), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14856, { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14856), { 0, 0, height },
+                        { 32, 26, 0 }, { 0, 0, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1763,37 +1764,37 @@ static void bobsleigh_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14836, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14836), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14852, { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14852), { 0, 0, height },
+                        { 32, 26, 0 }, { 0, 0, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14840, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14840), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14856, { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14856), { 0, 0, height },
+                        { 32, 26, 0 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14835, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14835), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14851, { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14851), { 0, 0, height },
+                        { 32, 26, 0 }, { 0, 6, height + 27 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14839, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14839), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14855, { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14855), { 0, 0, height },
+                        { 32, 26, 0 }, { 0, 6, height + 27 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -1810,35 +1811,35 @@ static void bobsleigh_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14837, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14837), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14853, { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14853), { 0, 0, height },
+                        { 32, 27, 0 }, { 0, 2, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14841, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14841), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14857, { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14857), { 0, 0, height },
+                        { 32, 27, 0 }, { 0, 2, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14834, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14834), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14850, { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14850), { 0, 0, height },
+                        { 32, 27, 0 }, { 0, 2, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14838, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14838), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14854, { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14854), { 0, 0, height },
+                        { 32, 27, 0 }, { 0, 2, height + 27 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1870,35 +1871,35 @@ static void bobsleigh_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14783, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14783), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14795, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14795), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14786, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14786), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14798, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14798), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14789, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14789), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14801, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14801), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14780, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14780), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14792, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14792), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1918,35 +1919,35 @@ static void bobsleigh_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14782, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14782), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14794, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14794), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 0, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14785, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14785), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14797, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14797), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14788, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14788), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14800, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14800), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 16, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14779, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14779), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14791, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14791), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1958,35 +1959,35 @@ static void bobsleigh_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14781, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14781), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14793, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14793), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14784, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14784), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14796, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14796), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14787, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14787), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14799, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14799), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14778, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14778), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14790, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14790), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2027,35 +2028,35 @@ static void bobsleigh_rc_track_left_quarter_turn_3_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14807, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14807), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14819, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14819), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14810, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14810), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14822, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14822), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14813, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14813), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14825, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14825), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14804, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14804), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14816, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14816), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2075,35 +2076,35 @@ static void bobsleigh_rc_track_left_quarter_turn_3_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14806, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14806), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14818, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14818), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 0, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14809, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14809), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14821, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14821), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14812, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14812), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14824, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14824), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 16, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14803, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14803), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14815, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14815), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2115,35 +2116,35 @@ static void bobsleigh_rc_track_left_quarter_turn_3_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14805, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14805), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14817, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14817), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14808, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14808), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14820, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14820), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14811, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14811), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14823, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14823), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14802, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14802), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14814, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14814), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2184,35 +2185,35 @@ static void bobsleigh_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14887, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14887), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14899, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14899), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14890, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14890), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14902, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14902), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14893, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14893), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14905, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14905), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14884, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14884), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height + 8 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14896, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14896), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2233,35 +2234,35 @@ static void bobsleigh_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14886, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14886), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14898, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14898), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 0, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14889, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14889), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14901, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14901), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14892, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14892), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14904, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14904), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 16, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14883, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14883), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14895, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14895), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2273,35 +2274,35 @@ static void bobsleigh_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14885, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14885), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14897, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14897), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14888, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14888), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14900, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14900), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14891, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14891), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14903, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14903), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14882, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14882), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14894, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14894), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2324,35 +2325,35 @@ static void bobsleigh_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14884, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14884), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14896, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14896), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14887, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14887), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14899, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14899), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14890, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14890), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14902, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14902), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14893, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14893), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14905, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14905), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2378,35 +2379,35 @@ static void bobsleigh_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14883, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14883), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14895, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14895), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 16, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14886, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14886), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14898, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14898), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14889, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14889), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14901, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14901), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14892, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14892), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14904, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14904), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 0, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2418,35 +2419,35 @@ static void bobsleigh_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14882, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14882), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height + 8 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14894, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14894), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14885, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14885), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14897, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14897), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14888, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14888), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14900, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14900), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14891, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14891), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14903, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14903), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2474,35 +2475,35 @@ static void bobsleigh_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14858, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14858), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14870, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14870), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14861, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14861), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14873, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14873), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14864, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14864), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14876, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14876), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14867, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14867), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14879, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14879), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2523,35 +2524,35 @@ static void bobsleigh_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14859, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14859), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14871, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14871), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 16, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14862, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14862), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14874, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14874), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14865, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14865), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14877, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14877), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14868, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14868), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14880, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14880), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 0, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2563,35 +2564,35 @@ static void bobsleigh_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14860, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14860), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height + 8 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14872, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14872), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14863, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14863), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14875, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14875), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14866, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14866), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14878, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14878), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14869, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14869), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14881, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14881), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2614,35 +2615,35 @@ static void bobsleigh_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14861, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14861), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14873, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14873), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14864, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14864), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14876, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14876), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14867, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14867), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14879, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14879), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14858, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14858), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14870, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14870), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2668,35 +2669,35 @@ static void bobsleigh_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14862, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14862), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14874, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14874), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 0, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14865, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14865), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14877, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14877), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14868, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14868), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14880, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14880), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 16, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14859, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14859), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14871, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14871), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2708,35 +2709,35 @@ static void bobsleigh_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14863, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14863), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14875, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14875), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14866, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14866), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14878, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14878), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14869, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14869), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14881, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14881), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14860, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14860), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height + 8 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14872, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14872), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2793,35 +2794,35 @@ static void bobsleigh_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14955, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14955), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14975, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14975), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14960, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14960), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14980, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14980), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14965, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14965), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14985, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14985), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14950, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14950), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14970, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14970), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2842,35 +2843,35 @@ static void bobsleigh_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14954, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14954), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14974, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14974), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14959, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14959), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14979, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14979), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14964, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14964), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14984, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14984), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14949, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14949), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14969, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14969), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2885,35 +2886,35 @@ static void bobsleigh_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14953, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14953), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14973, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14973), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 16, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14958, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14958), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14978, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14978), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14963, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14963), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14983, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14983), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14948, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14948), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14968, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14968), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 0, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2928,35 +2929,35 @@ static void bobsleigh_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14952, { 0, 0, height }, { 16, 32, 2 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14952), { 0, 0, height },
+                        { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14972, { 0, 0, height }, { 16, 32, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14972), { 0, 0, height },
+                        { 16, 32, 0 }, { 16, 0, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14957, { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14957), { 0, 0, height },
+                        { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14977, { 0, 0, height }, { 16, 32, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14977), { 0, 0, height },
+                        { 16, 32, 0 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14962, { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14962), { 0, 0, height },
+                        { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14982, { 0, 0, height }, { 16, 32, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14982), { 0, 0, height },
+                        { 16, 32, 0 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14947, { 0, 0, height }, { 16, 32, 2 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14947), { 0, 0, height },
+                        { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14967, { 0, 0, height }, { 16, 32, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14967), { 0, 0, height },
+                        { 16, 32, 0 }, { 16, 0, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2971,35 +2972,35 @@ static void bobsleigh_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14951, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14951), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14971, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14971), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14956, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14956), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14976, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14976), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14961, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14961), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14981, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14981), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14946, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14946), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height + 8 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14966, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14966), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3022,35 +3023,35 @@ static void bobsleigh_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14950, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14950), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14970, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14970), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14955, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14955), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14975, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14975), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14960, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14960), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14980, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14980), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14965, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14965), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14985, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14985), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3076,35 +3077,35 @@ static void bobsleigh_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14949, { 0, 0, height }, { 16, 32, 2 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14949), { 0, 0, height },
+                        { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14969, { 0, 0, height }, { 16, 32, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14969), { 0, 0, height },
+                        { 16, 32, 0 }, { 16, 0, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14954, { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14954), { 0, 0, height },
+                        { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14974, { 0, 0, height }, { 16, 32, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14974), { 0, 0, height },
+                        { 16, 32, 0 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14959, { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14959), { 0, 0, height },
+                        { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14979, { 0, 0, height }, { 16, 32, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14979), { 0, 0, height },
+                        { 16, 32, 0 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14964, { 0, 0, height }, { 16, 32, 2 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14964), { 0, 0, height },
+                        { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14984, { 0, 0, height }, { 16, 32, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14984), { 0, 0, height },
+                        { 16, 32, 0 }, { 16, 0, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3119,35 +3120,35 @@ static void bobsleigh_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14948, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14948), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14968, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14968), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14953, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14953), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14973, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14973), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14958, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14958), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14978, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14978), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 16, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14963, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14963), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14983, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14983), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3162,35 +3163,35 @@ static void bobsleigh_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14947, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14947), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14967, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14967), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14952, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14952), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14972, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14972), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14957, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14957), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14977, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14977), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14962, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14962), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14982, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14982), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3205,35 +3206,35 @@ static void bobsleigh_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14946, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14946), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height + 8 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14966, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14966), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14951, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14951), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14971, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14971), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14956, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14956), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14976, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14976), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14961, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14961), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14981, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14981), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3261,35 +3262,35 @@ static void bobsleigh_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14906, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14906), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14926, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14926), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14911, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14911), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14931, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14931), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14916, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14916), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14936, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14936), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14921, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14921), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14941, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14941), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3310,35 +3311,35 @@ static void bobsleigh_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14907, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14907), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14927, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14927), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14912, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14912), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14932, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14932), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14917, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14917), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14937, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14937), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14922, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14922), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14942, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14942), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3353,35 +3354,35 @@ static void bobsleigh_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14908, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14908), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14928, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14928), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14913, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14913), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14933, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14933), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14918, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14918), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14938, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14938), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 16, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14923, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14923), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14943, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14943), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3396,35 +3397,35 @@ static void bobsleigh_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14909, { 0, 0, height }, { 16, 32, 2 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14909), { 0, 0, height },
+                        { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14929, { 0, 0, height }, { 16, 32, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14929), { 0, 0, height },
+                        { 16, 32, 0 }, { 16, 0, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14914, { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14914), { 0, 0, height },
+                        { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14934, { 0, 0, height }, { 16, 32, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14934), { 0, 0, height },
+                        { 16, 32, 0 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14919, { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14919), { 0, 0, height },
+                        { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14939, { 0, 0, height }, { 16, 32, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14939), { 0, 0, height },
+                        { 16, 32, 0 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14924, { 0, 0, height }, { 16, 32, 2 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14924), { 0, 0, height },
+                        { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14944, { 0, 0, height }, { 16, 32, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14944), { 0, 0, height },
+                        { 16, 32, 0 }, { 16, 0, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3439,35 +3440,35 @@ static void bobsleigh_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14910, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14910), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height + 8 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14930, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14930), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14915, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14915), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14935, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14935), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14920, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14920), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14940, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14940), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14925, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14925), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14945, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14945), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3490,35 +3491,35 @@ static void bobsleigh_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14911, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14911), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14931, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14931), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14916, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14916), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14936, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14936), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14921, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14921), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14941, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14941), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14906, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14906), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14926, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14926), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3544,35 +3545,35 @@ static void bobsleigh_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14912, { 0, 0, height }, { 16, 32, 2 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14912), { 0, 0, height },
+                        { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14932, { 0, 0, height }, { 16, 32, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14932), { 0, 0, height },
+                        { 16, 32, 0 }, { 16, 0, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14917, { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14917), { 0, 0, height },
+                        { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14937, { 0, 0, height }, { 16, 32, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14937), { 0, 0, height },
+                        { 16, 32, 0 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14922, { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14922), { 0, 0, height },
+                        { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14942, { 0, 0, height }, { 16, 32, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14942), { 0, 0, height },
+                        { 16, 32, 0 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14907, { 0, 0, height }, { 16, 32, 2 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14907), { 0, 0, height },
+                        { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14927, { 0, 0, height }, { 16, 32, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14927), { 0, 0, height },
+                        { 16, 32, 0 }, { 16, 0, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3587,35 +3588,35 @@ static void bobsleigh_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14913, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14913), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14933, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14933), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 16, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14918, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14918), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14938, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14938), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14923, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14923), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14943, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14943), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14908, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14908), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14928, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14928), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 0, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3630,35 +3631,35 @@ static void bobsleigh_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14914, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14914), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14934, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14934), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14919, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14919), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14939, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14939), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14924, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14924), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14944, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14944), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14909, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14909), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14929, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14929), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3673,35 +3674,35 @@ static void bobsleigh_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14915, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14915), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14935, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14935), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14920, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14920), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14940, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14940), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14925, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14925), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14945, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14945), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14910, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14910), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height + 8 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 14930, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14930), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3756,19 +3757,19 @@ static void bobsleigh_rc_track_brakes(
         case 0:
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14582, { 0, 0, height }, { 32, 20, 2 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14582), { 0, 0, height }, { 32, 20, 2 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14584, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14584), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 1:
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14583, { 0, 0, height }, { 32, 20, 2 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14583), { 0, 0, height }, { 32, 20, 2 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14585, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14585), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
     }
@@ -3793,19 +3794,21 @@ static void bobsleigh_rc_track_block_brakes(
         case 0:
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | _BobsleighBlockBrakeImages[direction][isClosed],
-                { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
+                session, direction,
+                session.TrackColours[SCHEME_TRACK].WithIndex(_BobsleighBlockBrakeImages[direction][isClosed]), { 0, 0, height },
+                { 32, 20, 2 }, { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14590, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14590), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 1:
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | _BobsleighBlockBrakeImages[direction][isClosed],
-                { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
+                session, direction,
+                session.TrackColours[SCHEME_TRACK].WithIndex(_BobsleighBlockBrakeImages[direction][isClosed]), { 0, 0, height },
+                { 32, 20, 2 }, { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14591, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14591), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
     }
@@ -3827,51 +3830,51 @@ static void bobsleigh_rc_track_on_ride_photo(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14572, { 0, 0, height }, { 32, 20, 0 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14572), { 0, 0, height }, { 32, 20, 0 },
                 { 0, 6, height + 3 });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14574, { 0, 0, height }, { 32, 20, 0 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14574), { 0, 0, height }, { 32, 20, 0 },
                 { 0, 6, height + 3 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14573, { 0, 0, height }, { 32, 20, 0 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14573), { 0, 0, height }, { 32, 20, 0 },
                 { 0, 6, height + 3 });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14575, { 0, 0, height }, { 32, 20, 0 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14575), { 0, 0, height }, { 32, 20, 0 },
                 { 0, 6, height + 3 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14572, { 0, 0, height }, { 32, 20, 0 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14572), { 0, 0, height }, { 32, 20, 0 },
                 { 0, 6, height + 3 });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14574, { 0, 0, height }, { 32, 20, 0 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14574), { 0, 0, height }, { 32, 20, 0 },
                 { 0, 6, height + 3 });
 
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14573, { 0, 0, height }, { 32, 20, 0 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14573), { 0, 0, height }, { 32, 20, 0 },
                 { 0, 6, height + 3 });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 14575, { 0, 0, height }, { 32, 20, 0 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(14575), { 0, 0, height }, { 32, 20, 0 },
                 { 0, 6, height + 3 });
 
             break;

--- a/src/openrct2/ride/coaster/BolligerMabillardTrack.hpp
+++ b/src/openrct2/ride/coaster/BolligerMabillardTrack.hpp
@@ -46,8 +46,8 @@ static void bolliger_mabillard_track_flat(
             17489,
         };
         PaintAddImageAsParentRotated(
-            session, direction, session.TrackColours[SCHEME_TRACK] | imageIds[direction], { 0, 0, height }, { 32, 20, 3 },
-            { 0, 6, height });
+            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction]), { 0, 0, height },
+            { 32, 20, 3 }, { 0, 6, height });
 
         if (track_paint_util_should_paint_supports(session.MapPosition))
         {
@@ -64,8 +64,8 @@ static void bolliger_mabillard_track_flat(
         };
 
         PaintAddImageAsParentRotated(
-            session, direction, session.TrackColours[SCHEME_TRACK] | imageIds[direction], { 0, 0, height }, { 32, 20, 3 },
-            { 0, 6, height });
+            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction]), { 0, 0, height },
+            { 32, 20, 3 }, { 0, 6, height });
 
         if (track_paint_util_should_paint_supports(session.MapPosition))
         {
@@ -94,17 +94,19 @@ static void bolliger_mabillard_track_station(
     {
         bool isClosed = trackElement.BlockBrakeClosed();
         PaintAddImageAsParentRotated(
-            session, direction, _BolligerMabillardBlockBrakeImages[direction][isClosed] | session.TrackColours[SCHEME_TRACK],
+            session, direction,
+            session.TrackColours[SCHEME_TRACK].WithIndex(_BolligerMabillardBlockBrakeImages[direction][isClosed]),
             { 0, 0, height }, { 32, 20, 1 }, { 0, 6, height + 3 });
     }
     else
     {
         PaintAddImageAsParentRotated(
-            session, direction, imageIds[direction][0] | session.TrackColours[SCHEME_TRACK], { 0, 0, height }, { 32, 20, 1 },
-            { 0, 6, height + 3 });
+            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]), { 0, 0, height },
+            { 32, 20, 1 }, { 0, 6, height + 3 });
     }
     PaintAddImageAsParentRotated(
-        session, direction, imageIds[direction][1] | session.TrackColours[SCHEME_MISC], { 0, 0, height }, { 32, 32, 1 });
+        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][1]), { 0, 0, height },
+        { 32, 32, 1 });
     track_paint_util_draw_station_metal_supports_2(
         session, direction, height, session.TrackColours[SCHEME_SUPPORTS], supportType);
 
@@ -126,22 +128,22 @@ static void bolliger_mabillard_track_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17498, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17498), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17499, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17499), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17500, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17500), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17501, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17501), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -156,22 +158,22 @@ static void bolliger_mabillard_track_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17204, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17204), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17205, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17205), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17206, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17206), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17207, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17207), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -204,22 +206,22 @@ static void bolliger_mabillard_track_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17514, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17514), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17515, { 0, 0, height }, { 32, 1, 98 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17515), { 0, 0, height }, { 32, 1, 98 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17516, { 0, 0, height }, { 32, 1, 98 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17516), { 0, 0, height }, { 32, 1, 98 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17517, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17517), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -234,22 +236,22 @@ static void bolliger_mabillard_track_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17220, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17220), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17221, { 0, 0, height }, { 32, 1, 98 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17221), { 0, 0, height }, { 32, 1, 98 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17222, { 0, 0, height }, { 32, 1, 98 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17222), { 0, 0, height }, { 32, 1, 98 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17223, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17223), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -282,22 +284,22 @@ static void bolliger_mabillard_track_flat_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17490, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17490), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17491, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17491), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17492, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17492), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17493, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17493), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -312,22 +314,22 @@ static void bolliger_mabillard_track_flat_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17196, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17196), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17197, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17197), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17198, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17198), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17199, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17199), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -360,28 +362,28 @@ static void bolliger_mabillard_track_25_deg_up_to_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17502, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17502), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17503, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17503), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17506, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17506), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17504, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17504), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17507, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17507), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17505, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17505), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -396,28 +398,28 @@ static void bolliger_mabillard_track_25_deg_up_to_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17208, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17208), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17209, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17209), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17212, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17212), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17210, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17210), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17213, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17213), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17211, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17211), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -450,28 +452,28 @@ static void bolliger_mabillard_track_60_deg_up_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17508, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17508), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17509, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17509), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17512, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17512), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17510, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17510), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17513, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17513), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17511, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17511), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -486,28 +488,28 @@ static void bolliger_mabillard_track_60_deg_up_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17214, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17214), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17215, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17215), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17218, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17218), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17216, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17216), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17219, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17219), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17217, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17217), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -540,22 +542,22 @@ static void bolliger_mabillard_track_25_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17494, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17494), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17495, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17495), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17496, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17496), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17497, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17497), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -570,22 +572,22 @@ static void bolliger_mabillard_track_25_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17200, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17200), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17201, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17201), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17202, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17202), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17203, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17203), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -671,23 +673,23 @@ static void bolliger_mabillard_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17259, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17259), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17264, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17264), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17269, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17269), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17254, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17254), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -707,23 +709,23 @@ static void bolliger_mabillard_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17258, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17258), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17263, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17263), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17268, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17268), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17253, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17253), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -738,23 +740,23 @@ static void bolliger_mabillard_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17257, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17257), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17262, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17262), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17267, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17267), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17252, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17252), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -769,23 +771,23 @@ static void bolliger_mabillard_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17256, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17256), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17261, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17261), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17266, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17266), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17251, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17251), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -800,23 +802,23 @@ static void bolliger_mabillard_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17255, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17255), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17260, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17260), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17265, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17265), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17250, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17250), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -855,28 +857,28 @@ static void bolliger_mabillard_track_flat_to_left_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17156, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17156), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17164, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17164), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17157, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17157), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17165, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17165), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17158, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17158), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17159, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17159), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -899,28 +901,28 @@ static void bolliger_mabillard_track_flat_to_right_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17160, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17160), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17161, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17161), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17162, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17162), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17166, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17166), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17163, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17163), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17167, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17167), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
     }
@@ -943,28 +945,28 @@ static void bolliger_mabillard_track_left_bank_to_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17162, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17162), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17166, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17166), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17163, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17163), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17167, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17167), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17160, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17160), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17161, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17161), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -987,28 +989,28 @@ static void bolliger_mabillard_track_right_bank_to_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17158, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17158), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17159, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17159), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17156, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17156), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17164, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17164), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17157, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17157), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17165, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17165), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
     }
@@ -1034,29 +1036,29 @@ static void bolliger_mabillard_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17279, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17279), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17290, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17290), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(session, supportType, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17284, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17284), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(session, supportType, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17289, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17289), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(session, supportType, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17274, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17274), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(session, supportType, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1076,23 +1078,23 @@ static void bolliger_mabillard_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17278, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17278), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17283, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17283), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17288, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17288), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17273, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17273), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1107,23 +1109,23 @@ static void bolliger_mabillard_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17277, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17277), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17282, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17282), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17287, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17287), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17272, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17272), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1138,23 +1140,23 @@ static void bolliger_mabillard_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17276, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17276), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17281, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17281), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17286, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17286), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17271, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17271), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1169,26 +1171,26 @@ static void bolliger_mabillard_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17275, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17275), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17280, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17280), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17285, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17285), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17291, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17291), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17270, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17270), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1227,28 +1229,28 @@ static void bolliger_mabillard_track_left_bank_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17168, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17168), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17172, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17172), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17169, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17169), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17173, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17173), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17170, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17170), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17171, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17171), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -1278,28 +1280,28 @@ static void bolliger_mabillard_track_right_bank_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17174, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17174), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17175, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17175), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17176, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17176), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17178, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17178), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17177, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17177), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17179, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17179), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
     }
@@ -1329,28 +1331,28 @@ static void bolliger_mabillard_track_25_deg_up_to_left_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17180, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17180), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17184, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17184), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17181, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17181), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17185, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17185), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17182, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17182), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17183, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17183), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -1380,28 +1382,28 @@ static void bolliger_mabillard_track_25_deg_up_to_right_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17186, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17186), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17187, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17187), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17188, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17188), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17190, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17190), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17189, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17189), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17191, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17191), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
     }
@@ -1467,22 +1469,22 @@ static void bolliger_mabillard_track_left_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17192, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17192), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17193, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17193), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17194, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17194), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17195, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17195), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -1516,23 +1518,23 @@ static void bolliger_mabillard_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17344, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17344), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17349, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17349), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17354, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17354), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17359, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17359), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1552,21 +1554,23 @@ static void bolliger_mabillard_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17345, { 0, 0, height }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17345), { 0, 0, height },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17350, { 0, 0, height }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17350), { 0, 0, height },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17355, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17355), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17360, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17360), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1581,22 +1585,23 @@ static void bolliger_mabillard_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17346, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17346), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17351, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17351), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17356, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17356), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17361, { 0, 0, height }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17361), { 0, 0, height },
+                        { 16, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1611,21 +1616,23 @@ static void bolliger_mabillard_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17347, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17347), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17352, { 0, 0, height }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17352), { 0, 0, height },
+                        { 16, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17357, { 0, 0, height }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17357), { 0, 0, height },
+                        { 16, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17362, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17362), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1640,23 +1647,23 @@ static void bolliger_mabillard_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17348, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17348), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17353, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17353), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17358, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17358), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17363, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17363), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1688,23 +1695,23 @@ static void bolliger_mabillard_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17324, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17324), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17329, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17329), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17334, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17334), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17339, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17339), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1724,21 +1731,23 @@ static void bolliger_mabillard_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17325, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17325), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17330, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17330), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17335, { 0, 0, height }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17335), { 0, 0, height },
+                        { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17340, { 0, 0, height }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17340), { 0, 0, height },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1753,22 +1762,23 @@ static void bolliger_mabillard_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17326, { 0, 0, height }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17326), { 0, 0, height },
+                        { 16, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17331, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17331), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17336, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17336), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17341, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17341), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1783,21 +1793,23 @@ static void bolliger_mabillard_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17327, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17327), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17332, { 0, 0, height }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17332), { 0, 0, height },
+                        { 16, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17337, { 0, 0, height }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17337), { 0, 0, height },
+                        { 16, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17342, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17342), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1812,23 +1824,23 @@ static void bolliger_mabillard_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17328, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17328), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17333, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17333), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17338, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17338), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17343, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17343), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1880,23 +1892,23 @@ static void bolliger_mabillard_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17308, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17308), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17312, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17312), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17311, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17311), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17315, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17315), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1913,23 +1925,25 @@ static void bolliger_mabillard_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17309, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17309), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(session, supportType, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17313, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17313), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(session, supportType, 6, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17310, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17310), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17314, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17314), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1944,22 +1958,24 @@ static void bolliger_mabillard_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17310, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17310), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17314, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17314), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17309, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17309), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(session, supportType, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17313, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17313), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(session, supportType, 6, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1975,23 +1991,23 @@ static void bolliger_mabillard_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17311, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17311), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17315, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17315), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17308, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17308), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17312, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17312), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2023,23 +2039,23 @@ static void bolliger_mabillard_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17316, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17316), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17320, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17320), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17319, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17319), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17323, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17323), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2056,23 +2072,25 @@ static void bolliger_mabillard_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17317, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17317), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(session, supportType, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17321, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17321), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(session, supportType, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17318, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17318), { 0, 0, height },
+                        { 32, 26, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17322, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17322), { 0, 0, height },
+                        { 32, 26, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2087,22 +2105,24 @@ static void bolliger_mabillard_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17318, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17318), { 0, 0, height },
+                        { 32, 26, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17322, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17322), { 0, 0, height },
+                        { 32, 26, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17317, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17317), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(session, supportType, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17321, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17321), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(session, supportType, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2118,23 +2138,23 @@ static void bolliger_mabillard_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17319, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17319), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17323, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17323), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17316, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17316), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17320, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17320), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2166,22 +2186,26 @@ static void bolliger_mabillard_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17594, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17594), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(session, supportType, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17602, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17602), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(session, supportType, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17601, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17601), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(session, supportType, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17609, { 0, 6, height }, { 32, 20, 7 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17609), { 0, 6, height },
+                        { 32, 20, 7 });
                     metal_a_supports_paint_setup(session, supportType, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2201,22 +2225,26 @@ static void bolliger_mabillard_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17595, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17595), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(session, supportType, 4, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17603, { 0, 14, height }, { 32, 2, 63 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17603), { 0, 14, height },
+                        { 32, 2, 63 });
                     metal_a_supports_paint_setup(session, supportType, 4, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17600, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17600), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(session, supportType, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17608, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17608), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(session, supportType, 4, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2232,23 +2260,23 @@ static void bolliger_mabillard_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17596, { 16, 0, height }, { 3, 16, 119 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17596), { 16, 0, height },
+                        { 3, 16, 119 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17604, { 12, 0, height }, { 3, 16, 119 },
-                        { 12, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17604), { 12, 0, height },
+                        { 3, 16, 119 }, { 12, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17599, { 10, 16, height }, { 4, 16, 119 },
-                        { 10, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17599), { 10, 16, height },
+                        { 4, 16, 119 }, { 10, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17607, { 16, 16, height }, { 2, 16, 119 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17607), { 16, 16, height },
+                        { 2, 16, 119 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2260,19 +2288,23 @@ static void bolliger_mabillard_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17597, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17597), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17605, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17605), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17598, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17598), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17606, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17606), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2293,19 +2325,23 @@ static void bolliger_mabillard_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17598, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17598), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17606, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17606), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17597, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17597), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17605, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17605), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2320,23 +2356,23 @@ static void bolliger_mabillard_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17599, { 10, 16, height }, { 4, 16, 119 },
-                        { 10, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17599), { 10, 16, height },
+                        { 4, 16, 119 }, { 10, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17607, { 16, 16, height }, { 2, 16, 119 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17607), { 16, 16, height },
+                        { 2, 16, 119 }, { 16, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17596, { 16, 0, height }, { 3, 16, 119 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17596), { 16, 0, height },
+                        { 3, 16, 119 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17604, { 12, 0, height }, { 3, 16, 119 },
-                        { 12, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17604), { 12, 0, height },
+                        { 3, 16, 119 }, { 12, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2348,22 +2384,26 @@ static void bolliger_mabillard_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17600, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17600), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(session, supportType, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17608, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17608), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(session, supportType, 4, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17595, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17595), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(session, supportType, 4, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17603, { 0, 14, height }, { 32, 2, 63 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17603), { 0, 14, height },
+                        { 32, 2, 63 });
                     metal_a_supports_paint_setup(session, supportType, 4, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2379,22 +2419,26 @@ static void bolliger_mabillard_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17601, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17601), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(session, supportType, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17609, { 0, 6, height }, { 32, 20, 7 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17609), { 0, 6, height },
+                        { 32, 20, 7 });
                     metal_a_supports_paint_setup(session, supportType, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17594, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17594), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(session, supportType, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17602, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17602), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(session, supportType, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2429,19 +2473,23 @@ static void bolliger_mabillard_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17625, { 0, 6, height }, { 32, 20, 7 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17625), { 0, 6, height },
+                        { 32, 20, 7 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17617, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17617), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17618, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17618), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17610, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17610), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2456,22 +2504,26 @@ static void bolliger_mabillard_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17624, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17624), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(session, supportType, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17616, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17616), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(session, supportType, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17619, { 0, 14, height }, { 32, 2, 63 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17619), { 0, 14, height },
+                        { 32, 2, 63 });
                     metal_a_supports_paint_setup(session, supportType, 4, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17611, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17611), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(session, supportType, 4, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2482,23 +2534,23 @@ static void bolliger_mabillard_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17623, { 16, 16, height }, { 2, 16, 119 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17623), { 16, 16, height },
+                        { 2, 16, 119 }, { 16, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17615, { 10, 16, height }, { 4, 16, 119 },
-                        { 10, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17615), { 10, 16, height },
+                        { 4, 16, 119 }, { 10, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17620, { 12, 0, height }, { 3, 16, 119 },
-                        { 12, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17620), { 12, 0, height },
+                        { 3, 16, 119 }, { 12, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17612, { 16, 0, height }, { 2, 16, 119 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17612), { 16, 0, height },
+                        { 2, 16, 119 }, { 16, 0, height });
                     break;
             }
             paint_util_set_general_support_height(session, height + 168, 0x20);
@@ -2508,19 +2560,23 @@ static void bolliger_mabillard_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17622, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17622), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17614, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17614), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17621, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17621), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17613, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17613), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_general_support_height(session, height + 48, 0x20);
@@ -2536,19 +2592,23 @@ static void bolliger_mabillard_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17621, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17621), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17613, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17613), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17622, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17622), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17614, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17614), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_general_support_height(session, height + 48, 0x20);
@@ -2558,23 +2618,23 @@ static void bolliger_mabillard_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17620, { 12, 0, height }, { 3, 16, 119 },
-                        { 12, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17620), { 12, 0, height },
+                        { 3, 16, 119 }, { 12, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17612, { 16, 0, height }, { 2, 16, 119 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17612), { 16, 0, height },
+                        { 2, 16, 119 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17623, { 16, 16, height }, { 2, 16, 119 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17623), { 16, 16, height },
+                        { 2, 16, 119 }, { 16, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17615, { 10, 16, height }, { 4, 16, 119 },
-                        { 10, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17615), { 10, 16, height },
+                        { 4, 16, 119 }, { 10, 16, height });
                     break;
             }
             paint_util_set_general_support_height(session, height + 168, 0x20);
@@ -2584,22 +2644,26 @@ static void bolliger_mabillard_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17619, { 0, 14, height }, { 32, 2, 63 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17619), { 0, 14, height },
+                        { 32, 2, 63 });
                     metal_a_supports_paint_setup(session, supportType, 4, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17611, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17611), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(session, supportType, 4, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17624, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17624), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(session, supportType, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17616, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17616), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(session, supportType, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2610,19 +2674,23 @@ static void bolliger_mabillard_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17618, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17618), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17610, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17610), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17625, { 0, 6, height }, { 32, 20, 7 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17625), { 0, 6, height },
+                        { 32, 20, 7 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17617, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17617), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2654,23 +2722,23 @@ static void bolliger_mabillard_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17229, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17229), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17232, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17232), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17235, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17235), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17226, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17226), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2690,23 +2758,23 @@ static void bolliger_mabillard_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17228, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17228), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17231, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17231), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17234, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17234), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17225, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17225), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2718,23 +2786,23 @@ static void bolliger_mabillard_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17227, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17227), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17230, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17230), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17233, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17233), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17224, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17224), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2776,26 +2844,26 @@ static void bolliger_mabillard_track_left_quarter_turn_3_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17241, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17241), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17248, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17248), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17244, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17244), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17247, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17247), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17238, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17238), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2815,23 +2883,23 @@ static void bolliger_mabillard_track_left_quarter_turn_3_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17240, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17240), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17243, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17243), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17246, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17246), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17237, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17237), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2843,26 +2911,26 @@ static void bolliger_mabillard_track_left_quarter_turn_3_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17239, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17239), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17242, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17242), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17245, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17245), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17249, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17249), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17236, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17236), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2904,19 +2972,23 @@ static void bolliger_mabillard_track_left_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17375, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17375), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17377, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17377), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17379, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17379), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17373, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17373), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2939,19 +3011,23 @@ static void bolliger_mabillard_track_left_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17374, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17374), { 6, 0, height },
+                        { 20, 32, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17376, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17376), { 6, 0, height },
+                        { 20, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17378, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17378), { 6, 0, height },
+                        { 20, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17372, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17372), { 6, 0, height },
+                        { 20, 32, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2983,19 +3059,23 @@ static void bolliger_mabillard_track_right_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17364, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17364), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17366, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17366), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17368, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17368), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17370, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17370), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3018,22 +3098,26 @@ static void bolliger_mabillard_track_right_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17365, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17365), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(session, supportType, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17367, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17367), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(session, supportType, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17369, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17369), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(session, supportType, 4, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17371, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17371), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(session, supportType, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3085,26 +3169,26 @@ static void bolliger_mabillard_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17399, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17399), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17406, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17406), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17402, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17402), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17405, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17405), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17396, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17396), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3125,23 +3209,23 @@ static void bolliger_mabillard_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17398, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17398), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17401, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17401), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17404, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17404), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17395, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17395), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3153,26 +3237,26 @@ static void bolliger_mabillard_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17397, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17397), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17400, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17400), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17403, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17403), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17407, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17407), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17394, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17394), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 8 });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3195,26 +3279,26 @@ static void bolliger_mabillard_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17396, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17396), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17399, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17399), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17406, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17406), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17402, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17402), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17405, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17405), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3240,23 +3324,23 @@ static void bolliger_mabillard_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17395, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17395), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17398, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17398), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17401, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17401), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17404, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17404), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3268,26 +3352,26 @@ static void bolliger_mabillard_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17394, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17394), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17397, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17397), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17400, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17400), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17403, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17403), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17407, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17407), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3315,26 +3399,26 @@ static void bolliger_mabillard_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17380, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17380), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17383, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17383), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17386, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17386), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17389, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17389), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17393, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17393), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3355,23 +3439,23 @@ static void bolliger_mabillard_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17381, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17381), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17384, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17384), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17387, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17387), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17390, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17390), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3383,26 +3467,26 @@ static void bolliger_mabillard_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17382, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17382), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17385, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17385), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17392, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17392), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17388, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17388), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17391, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17391), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3425,26 +3509,26 @@ static void bolliger_mabillard_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17383, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17383), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17386, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17386), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17389, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17389), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17393, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17393), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17380, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17380), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3470,23 +3554,23 @@ static void bolliger_mabillard_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17384, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17384), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17387, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17387), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17390, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17390), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17381, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17381), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3498,26 +3582,26 @@ static void bolliger_mabillard_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17385, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17385), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17392, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17392), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17388, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17388), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17391, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17391), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17382, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17382), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3575,26 +3659,26 @@ static void bolliger_mabillard_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17439, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17439), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17450, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17450), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17444, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17444), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17449, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17449), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17434, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17434), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3615,23 +3699,23 @@ static void bolliger_mabillard_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17438, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17438), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17443, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17443), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17448, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17448), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17433, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17433), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3646,23 +3730,23 @@ static void bolliger_mabillard_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17437, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17437), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17442, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17442), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17447, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17447), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17432, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17432), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3677,23 +3761,23 @@ static void bolliger_mabillard_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17436, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17436), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17441, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17441), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17446, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17446), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17431, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17431), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3708,26 +3792,26 @@ static void bolliger_mabillard_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17435, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17435), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17440, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17440), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17445, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17445), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17451, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17451), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17430, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17430), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 8 });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3750,26 +3834,26 @@ static void bolliger_mabillard_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17434, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17434), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17439, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17439), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17450, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17450), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17444, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17444), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17449, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17449), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3795,23 +3879,23 @@ static void bolliger_mabillard_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17433, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17433), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17438, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17438), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17443, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17443), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17448, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17448), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3826,23 +3910,23 @@ static void bolliger_mabillard_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17432, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17432), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17437, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17437), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17442, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17442), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17447, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17447), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3857,23 +3941,23 @@ static void bolliger_mabillard_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17431, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17431), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17436, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17436), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17441, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17441), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17446, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17446), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3888,26 +3972,26 @@ static void bolliger_mabillard_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17430, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17430), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17435, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17435), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17440, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17440), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17445, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17445), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17451, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17451), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3935,26 +4019,26 @@ static void bolliger_mabillard_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17408, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17408), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17413, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17413), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17418, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17418), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17423, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17423), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17429, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17429), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3975,23 +4059,23 @@ static void bolliger_mabillard_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17409, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17409), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17414, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17414), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17419, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17419), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17424, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17424), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4006,23 +4090,23 @@ static void bolliger_mabillard_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17410, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17410), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17415, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17415), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17420, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17420), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17425, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17425), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4037,23 +4121,23 @@ static void bolliger_mabillard_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17411, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17411), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17416, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17416), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17421, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17421), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17426, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17426), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4068,29 +4152,29 @@ static void bolliger_mabillard_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17412, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17412), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 8 });
                     metal_a_supports_paint_setup(session, supportType, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17417, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17417), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17428, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17428), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(session, supportType, 4, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17422, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17422), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(session, supportType, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17427, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17427), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(session, supportType, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4113,26 +4197,26 @@ static void bolliger_mabillard_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17413, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17413), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17418, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17418), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17423, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17423), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17429, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17429), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17408, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17408), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4158,23 +4242,23 @@ static void bolliger_mabillard_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17414, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17414), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17419, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17419), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17424, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17424), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17409, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17409), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4189,23 +4273,23 @@ static void bolliger_mabillard_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17415, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17415), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17420, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17420), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17425, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17425), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17410, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17410), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4220,23 +4304,23 @@ static void bolliger_mabillard_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17416, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17416), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17421, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17421), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17426, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17426), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17411, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17411), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4251,29 +4335,29 @@ static void bolliger_mabillard_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17417, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17417), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17428, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17428), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(session, supportType, 4, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17422, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17422), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(session, supportType, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17427, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17427), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(session, supportType, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17412, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17412), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     metal_a_supports_paint_setup(session, supportType, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4328,34 +4412,34 @@ static void bolliger_mabillard_track_left_quarter_turn_1_60_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17301, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17301), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17305, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17305), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17302, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17302), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17306, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17306), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17303, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17303), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17307, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17307), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17300, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17300), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17304, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17304), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
     }
@@ -4373,34 +4457,34 @@ static void bolliger_mabillard_track_right_quarter_turn_1_60_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17292, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17292), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17296, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17296), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17293, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17293), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17297, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17297), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17294, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17294), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17298, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17298), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17295, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17295), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17299, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17299), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
     }
@@ -4437,13 +4521,13 @@ static void bolliger_mabillard_track_brakes(
         case 0:
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17148, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17148), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17149, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17149), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -4466,22 +4550,22 @@ static void bolliger_mabillard_track_25_deg_up_left_banked(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17914, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17914), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17915, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17915), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17916, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17916), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17917, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17917), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -4511,22 +4595,22 @@ static void bolliger_mabillard_track_25_deg_up_right_banked(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17918, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17918), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17919, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17919), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17920, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17920), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17921, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17921), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -4556,38 +4640,38 @@ static void bolliger_mabillard_track_on_ride_photo(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
             metal_a_supports_paint_setup(session, supportType, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(session, supportType, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17146, { 0, 0, height }, { 32, 20, 0 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17146), { 0, 0, height }, { 32, 20, 0 },
                 { 0, 6, height + 3 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
             metal_a_supports_paint_setup(session, supportType, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(session, supportType, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17147, { 0, 0, height }, { 32, 20, 0 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17147), { 0, 0, height }, { 32, 20, 0 },
                 { 0, 6, height + 3 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
             metal_a_supports_paint_setup(session, supportType, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(session, supportType, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17146, { 0, 0, height }, { 32, 20, 0 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17146), { 0, 0, height }, { 32, 20, 0 },
                 { 0, 6, height + 3 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
             metal_a_supports_paint_setup(session, supportType, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(session, supportType, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17147, { 0, 0, height }, { 32, 20, 0 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17147), { 0, 0, height }, { 32, 20, 0 },
                 { 0, 6, height + 3 });
             break;
     }
@@ -4627,23 +4711,23 @@ static void bolliger_mabillard_track_90_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17526, { 0, 0, height }, { 2, 20, 31 },
-                        { 4, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17526), { 0, 0, height },
+                        { 2, 20, 31 }, { 4, 6, height + 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17527, { 0, 0, height }, { 2, 20, 31 },
-                        { 24, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17527), { 0, 0, height },
+                        { 2, 20, 31 }, { 24, 6, height + 8 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17528, { 0, 0, height }, { 2, 20, 31 },
-                        { 24, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17528), { 0, 0, height },
+                        { 2, 20, 31 }, { 24, 6, height + 8 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17529, { 0, 0, height }, { 2, 20, 31 },
-                        { 4, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17529), { 0, 0, height },
+                        { 2, 20, 31 }, { 4, 6, height + 8 });
                     break;
             }
             paint_util_set_vertical_tunnel(session, height + 32);
@@ -4676,23 +4760,23 @@ static void bolliger_mabillard_track_60_deg_up_to_90_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17518, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17518), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17519, { 0, 0, height }, { 2, 20, 55 },
-                        { 24, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17519), { 0, 0, height },
+                        { 2, 20, 55 }, { 24, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17520, { 0, 0, height }, { 2, 20, 55 },
-                        { 24, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17520), { 0, 0, height },
+                        { 2, 20, 55 }, { 24, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17521, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17521), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -4727,22 +4811,22 @@ static void bolliger_mabillard_track_90_deg_up_to_60_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17522, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17522), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height + 8 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17523, { 0, 0, height }, { 2, 20, 31 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17523), { 0, 0, height }, { 2, 20, 31 },
                 { 24, 6, height + 8 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17524, { 0, 0, height }, { 2, 20, 31 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17524), { 0, 0, height }, { 2, 20, 31 },
                 { 24, 6, height + 8 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17525, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17525), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height + 8 });
             break;
     }
@@ -4772,23 +4856,23 @@ static void bolliger_mabillard_track_60_deg_down_to_90_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17524, { 0, 0, height }, { 2, 20, 31 },
-                        { 24, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17524), { 0, 0, height },
+                        { 2, 20, 31 }, { 24, 6, height + 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17525, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17525), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17522, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17522), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17523, { 0, 0, height }, { 2, 20, 31 },
-                        { 24, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17523), { 0, 0, height },
+                        { 2, 20, 31 }, { 24, 6, height + 8 });
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -4816,23 +4900,23 @@ static void bolliger_mabillard_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17546, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17546), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17550, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17550), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17554, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17554), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17558, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17558), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4849,23 +4933,23 @@ static void bolliger_mabillard_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17547, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17547), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17551, { 0, 0, height }, { 34, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17551), { 0, 0, height },
+                        { 34, 16, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17555, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17555), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17559, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17559), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4880,23 +4964,23 @@ static void bolliger_mabillard_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17548, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17548), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17552, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17552), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17556, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17556), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17560, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17560), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4914,26 +4998,26 @@ static void bolliger_mabillard_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17549, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17549), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     metal_a_supports_paint_setup(session, supportType, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17553, { 0, 0, height }, { 16, 18, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17553), { 0, 0, height },
+                        { 16, 18, 3 }, { 0, 16, height });
                     metal_a_supports_paint_setup(session, supportType, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17557, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17557), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     metal_a_supports_paint_setup(session, supportType, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17561, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17561), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     metal_a_supports_paint_setup(session, supportType, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4959,23 +5043,23 @@ static void bolliger_mabillard_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17530, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17530), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17534, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17534), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17538, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17538), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17542, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17542), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4992,23 +5076,23 @@ static void bolliger_mabillard_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17531, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17531), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17535, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17535), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17539, { 0, 0, height }, { 34, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17539), { 0, 0, height },
+                        { 34, 16, 3 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17543, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17543), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5023,23 +5107,23 @@ static void bolliger_mabillard_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17532, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17532), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17536, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17536), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17540, { 0, 0, height }, { 28, 28, 3 },
-                        { 4, 4, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17540), { 0, 0, height },
+                        { 28, 28, 3 }, { 4, 4, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17544, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17544), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5057,26 +5141,26 @@ static void bolliger_mabillard_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17533, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17533), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     metal_a_supports_paint_setup(session, supportType, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17537, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17537), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     metal_a_supports_paint_setup(session, supportType, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17541, { 0, 0, height }, { 16, 18, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17541), { 0, 0, height },
+                        { 16, 18, 3 }, { 0, 16, height });
                     metal_a_supports_paint_setup(session, supportType, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17545, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17545), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     metal_a_supports_paint_setup(session, supportType, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -5122,23 +5206,23 @@ static void bolliger_mabillard_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17578, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17578), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17582, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17582), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17586, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17586), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17590, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17590), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -5155,23 +5239,23 @@ static void bolliger_mabillard_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17579, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17579), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17583, { 0, 0, height }, { 34, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17583), { 0, 0, height },
+                        { 34, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17587, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17587), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17591, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17591), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5186,23 +5270,23 @@ static void bolliger_mabillard_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17580, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17580), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17584, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17584), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17588, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17588), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17592, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17592), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5220,26 +5304,26 @@ static void bolliger_mabillard_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17581, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17581), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     metal_a_supports_paint_setup(session, supportType, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17585, { 0, 0, height }, { 16, 18, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17585), { 0, 0, height },
+                        { 16, 18, 0 }, { 0, 16, height + 27 });
                     metal_a_supports_paint_setup(session, supportType, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17589, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17589), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     metal_a_supports_paint_setup(session, supportType, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17593, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17593), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     metal_a_supports_paint_setup(session, supportType, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -5265,23 +5349,23 @@ static void bolliger_mabillard_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17562, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17562), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17566, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17566), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17570, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17570), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17574, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17574), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -5298,23 +5382,23 @@ static void bolliger_mabillard_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17563, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17563), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17567, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17567), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17571, { 0, 0, height }, { 34, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17571), { 0, 0, height },
+                        { 34, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17575, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17575), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5329,23 +5413,23 @@ static void bolliger_mabillard_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17564, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17564), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17568, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17568), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17572, { 0, 0, height }, { 28, 28, 0 },
-                        { 4, 4, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17572), { 0, 0, height },
+                        { 28, 28, 0 }, { 4, 4, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17576, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17576), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5363,26 +5447,26 @@ static void bolliger_mabillard_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17565, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17565), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     metal_a_supports_paint_setup(session, supportType, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17569, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17569), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     metal_a_supports_paint_setup(session, supportType, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17573, { 0, 0, height }, { 16, 18, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17573), { 0, 0, height },
+                        { 16, 18, 0 }, { 0, 16, height + 27 });
                     metal_a_supports_paint_setup(session, supportType, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17577, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17577), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     metal_a_supports_paint_setup(session, supportType, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -5430,8 +5514,8 @@ static void bolliger_mabillard_track_diag_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17861, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17861), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5441,8 +5525,8 @@ static void bolliger_mabillard_track_diag_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17791, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17791), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5457,8 +5541,8 @@ static void bolliger_mabillard_track_diag_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17858, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17858), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5468,8 +5552,8 @@ static void bolliger_mabillard_track_diag_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17788, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17788), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5484,8 +5568,8 @@ static void bolliger_mabillard_track_diag_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17860, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17860), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5495,8 +5579,8 @@ static void bolliger_mabillard_track_diag_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17790, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17790), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5514,8 +5598,8 @@ static void bolliger_mabillard_track_diag_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17859, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17859), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(session, supportType, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
@@ -5535,8 +5619,8 @@ static void bolliger_mabillard_track_diag_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17789, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17789), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(session, supportType, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
@@ -5568,8 +5652,8 @@ static void bolliger_mabillard_track_diag_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17873, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17873), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5579,8 +5663,8 @@ static void bolliger_mabillard_track_diag_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17803, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17803), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5595,8 +5679,8 @@ static void bolliger_mabillard_track_diag_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17870, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17870), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5606,8 +5690,8 @@ static void bolliger_mabillard_track_diag_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17800, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17800), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5622,8 +5706,8 @@ static void bolliger_mabillard_track_diag_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17872, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17872), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5633,8 +5717,8 @@ static void bolliger_mabillard_track_diag_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17802, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17802), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5652,8 +5736,8 @@ static void bolliger_mabillard_track_diag_25_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17871, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17871), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(session, supportType, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
@@ -5673,8 +5757,8 @@ static void bolliger_mabillard_track_diag_25_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17801, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17801), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(session, supportType, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
@@ -5706,8 +5790,8 @@ static void bolliger_mabillard_track_diag_60_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17885, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17885), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5717,8 +5801,8 @@ static void bolliger_mabillard_track_diag_60_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17815, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17815), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5733,8 +5817,8 @@ static void bolliger_mabillard_track_diag_60_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17882, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17882), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5744,8 +5828,8 @@ static void bolliger_mabillard_track_diag_60_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17812, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17812), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5760,8 +5844,8 @@ static void bolliger_mabillard_track_diag_60_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17884, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17884), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5771,8 +5855,8 @@ static void bolliger_mabillard_track_diag_60_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17814, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17814), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5791,8 +5875,8 @@ static void bolliger_mabillard_track_diag_60_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17883, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17883), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, supportType, 0, 36, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5816,8 +5900,8 @@ static void bolliger_mabillard_track_diag_60_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17813, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17813), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, supportType, 0, 36, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5852,8 +5936,8 @@ static void bolliger_mabillard_track_diag_flat_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17865, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17865), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5863,8 +5947,8 @@ static void bolliger_mabillard_track_diag_flat_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17795, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17795), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5879,8 +5963,8 @@ static void bolliger_mabillard_track_diag_flat_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17862, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17862), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5890,8 +5974,8 @@ static void bolliger_mabillard_track_diag_flat_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17792, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17792), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5906,8 +5990,8 @@ static void bolliger_mabillard_track_diag_flat_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17864, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17864), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5917,8 +6001,8 @@ static void bolliger_mabillard_track_diag_flat_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17794, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17794), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5936,8 +6020,8 @@ static void bolliger_mabillard_track_diag_flat_to_25_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17863, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17863), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(session, supportType, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
@@ -5957,8 +6041,8 @@ static void bolliger_mabillard_track_diag_flat_to_25_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17793, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17793), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(session, supportType, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
@@ -5990,8 +6074,8 @@ static void bolliger_mabillard_track_diag_25_deg_up_to_60_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17877, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17877), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6001,8 +6085,8 @@ static void bolliger_mabillard_track_diag_25_deg_up_to_60_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17807, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17807), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6017,8 +6101,8 @@ static void bolliger_mabillard_track_diag_25_deg_up_to_60_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17874, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17874), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6028,8 +6112,8 @@ static void bolliger_mabillard_track_diag_25_deg_up_to_60_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17804, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17804), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6044,8 +6128,8 @@ static void bolliger_mabillard_track_diag_25_deg_up_to_60_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17876, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17876), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6055,8 +6139,8 @@ static void bolliger_mabillard_track_diag_25_deg_up_to_60_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17806, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17806), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6075,8 +6159,8 @@ static void bolliger_mabillard_track_diag_25_deg_up_to_60_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17875, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17875), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, supportType, 0, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6100,8 +6184,8 @@ static void bolliger_mabillard_track_diag_25_deg_up_to_60_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17805, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17805), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, supportType, 0, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6136,8 +6220,8 @@ static void bolliger_mabillard_track_diag_60_deg_up_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17881, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17881), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6147,8 +6231,8 @@ static void bolliger_mabillard_track_diag_60_deg_up_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17811, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17811), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6163,8 +6247,8 @@ static void bolliger_mabillard_track_diag_60_deg_up_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17878, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17878), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6174,8 +6258,8 @@ static void bolliger_mabillard_track_diag_60_deg_up_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17808, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17808), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6190,8 +6274,8 @@ static void bolliger_mabillard_track_diag_60_deg_up_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17880, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17880), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6201,8 +6285,8 @@ static void bolliger_mabillard_track_diag_60_deg_up_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17810, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17810), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6221,8 +6305,8 @@ static void bolliger_mabillard_track_diag_60_deg_up_to_25_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17879, { -16, -16, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17879), { -16, -16, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         metal_b_supports_paint_setup(
                             session, supportType, 0, 21, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6246,8 +6330,8 @@ static void bolliger_mabillard_track_diag_60_deg_up_to_25_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17809, { -16, -16, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17809), { -16, -16, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         metal_b_supports_paint_setup(
                             session, supportType, 0, 21, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6282,8 +6366,8 @@ static void bolliger_mabillard_track_diag_25_deg_up_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17869, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17869), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6293,8 +6377,8 @@ static void bolliger_mabillard_track_diag_25_deg_up_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17799, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17799), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6309,8 +6393,8 @@ static void bolliger_mabillard_track_diag_25_deg_up_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17866, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17866), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6320,8 +6404,8 @@ static void bolliger_mabillard_track_diag_25_deg_up_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17796, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17796), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6336,8 +6420,8 @@ static void bolliger_mabillard_track_diag_25_deg_up_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17868, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17868), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6347,8 +6431,8 @@ static void bolliger_mabillard_track_diag_25_deg_up_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17798, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17798), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6366,8 +6450,8 @@ static void bolliger_mabillard_track_diag_25_deg_up_to_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17867, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17867), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(session, supportType, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
@@ -6387,8 +6471,8 @@ static void bolliger_mabillard_track_diag_25_deg_up_to_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17797, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17797), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(session, supportType, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
@@ -6420,8 +6504,8 @@ static void bolliger_mabillard_track_diag_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17871, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17871), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6431,8 +6515,8 @@ static void bolliger_mabillard_track_diag_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17801, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17801), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6447,8 +6531,8 @@ static void bolliger_mabillard_track_diag_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17872, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17872), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6458,8 +6542,8 @@ static void bolliger_mabillard_track_diag_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17802, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17802), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6474,8 +6558,8 @@ static void bolliger_mabillard_track_diag_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17870, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17870), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6485,8 +6569,8 @@ static void bolliger_mabillard_track_diag_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17800, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17800), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6504,8 +6588,8 @@ static void bolliger_mabillard_track_diag_25_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17873, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17873), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(session, supportType, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
@@ -6525,8 +6609,8 @@ static void bolliger_mabillard_track_diag_25_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17803, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17803), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(session, supportType, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
@@ -6558,8 +6642,8 @@ static void bolliger_mabillard_track_diag_60_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17883, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17883), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6569,8 +6653,8 @@ static void bolliger_mabillard_track_diag_60_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17813, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17813), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6585,8 +6669,8 @@ static void bolliger_mabillard_track_diag_60_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17884, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17884), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6596,8 +6680,8 @@ static void bolliger_mabillard_track_diag_60_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17814, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17814), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6612,8 +6696,8 @@ static void bolliger_mabillard_track_diag_60_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17882, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17882), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6623,8 +6707,8 @@ static void bolliger_mabillard_track_diag_60_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17812, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17812), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6643,8 +6727,8 @@ static void bolliger_mabillard_track_diag_60_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17885, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17885), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, supportType, 0, 28, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6668,8 +6752,8 @@ static void bolliger_mabillard_track_diag_60_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17815, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17815), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, supportType, 0, 28, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6704,8 +6788,8 @@ static void bolliger_mabillard_track_diag_flat_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17867, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17867), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6715,8 +6799,8 @@ static void bolliger_mabillard_track_diag_flat_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17797, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17797), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6730,8 +6814,8 @@ static void bolliger_mabillard_track_diag_flat_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17868, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17868), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6741,8 +6825,8 @@ static void bolliger_mabillard_track_diag_flat_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17798, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17798), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6756,8 +6840,8 @@ static void bolliger_mabillard_track_diag_flat_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17866, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17866), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6767,8 +6851,8 @@ static void bolliger_mabillard_track_diag_flat_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17796, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17796), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6785,8 +6869,8 @@ static void bolliger_mabillard_track_diag_flat_to_25_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17869, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17869), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(session, supportType, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
@@ -6806,8 +6890,8 @@ static void bolliger_mabillard_track_diag_flat_to_25_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17799, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17799), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(session, supportType, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
@@ -6840,8 +6924,8 @@ static void bolliger_mabillard_track_diag_25_deg_down_to_60_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17879, { -16, -16, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17879), { -16, -16, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         break;
                 }
             }
@@ -6851,8 +6935,8 @@ static void bolliger_mabillard_track_diag_25_deg_down_to_60_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17809, { -16, -16, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17809), { -16, -16, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         break;
                 }
             }
@@ -6867,8 +6951,8 @@ static void bolliger_mabillard_track_diag_25_deg_down_to_60_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17880, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17880), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6878,8 +6962,8 @@ static void bolliger_mabillard_track_diag_25_deg_down_to_60_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17810, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17810), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6894,8 +6978,8 @@ static void bolliger_mabillard_track_diag_25_deg_down_to_60_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17878, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17878), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6905,8 +6989,8 @@ static void bolliger_mabillard_track_diag_25_deg_down_to_60_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17808, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17808), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6925,8 +7009,8 @@ static void bolliger_mabillard_track_diag_25_deg_down_to_60_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17881, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17881), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, supportType, 0, 17, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6950,8 +7034,8 @@ static void bolliger_mabillard_track_diag_25_deg_down_to_60_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17811, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17811), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, supportType, 0, 17, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6986,8 +7070,8 @@ static void bolliger_mabillard_track_diag_60_deg_down_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17875, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17875), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6997,8 +7081,8 @@ static void bolliger_mabillard_track_diag_60_deg_down_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17805, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17805), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7013,8 +7097,8 @@ static void bolliger_mabillard_track_diag_60_deg_down_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17876, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17876), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7024,8 +7108,8 @@ static void bolliger_mabillard_track_diag_60_deg_down_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17806, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17806), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7040,8 +7124,8 @@ static void bolliger_mabillard_track_diag_60_deg_down_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17874, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17874), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7051,8 +7135,8 @@ static void bolliger_mabillard_track_diag_60_deg_down_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17804, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17804), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7070,8 +7154,8 @@ static void bolliger_mabillard_track_diag_60_deg_down_to_25_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17877, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17877), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(session, supportType, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
@@ -7091,8 +7175,8 @@ static void bolliger_mabillard_track_diag_60_deg_down_to_25_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17807, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17807), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(session, supportType, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
@@ -7124,8 +7208,8 @@ static void bolliger_mabillard_track_diag_25_deg_down_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17863, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17863), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7135,8 +7219,8 @@ static void bolliger_mabillard_track_diag_25_deg_down_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17793, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17793), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7151,8 +7235,8 @@ static void bolliger_mabillard_track_diag_25_deg_down_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17864, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17864), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7162,8 +7246,8 @@ static void bolliger_mabillard_track_diag_25_deg_down_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17794, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17794), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7178,8 +7262,8 @@ static void bolliger_mabillard_track_diag_25_deg_down_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17862, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17862), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7189,8 +7273,8 @@ static void bolliger_mabillard_track_diag_25_deg_down_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17792, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17792), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7208,8 +7292,8 @@ static void bolliger_mabillard_track_diag_25_deg_down_to_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17865, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17865), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(session, supportType, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
@@ -7229,8 +7313,8 @@ static void bolliger_mabillard_track_diag_25_deg_down_to_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17795, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17795), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(session, supportType, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
@@ -7262,8 +7346,8 @@ static void bolliger_mabillard_track_diag_flat_to_60_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17889, { -16, -16, height }, { 32, 32, 4 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17889), { -16, -16, height },
+                            { 32, 32, 4 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7273,8 +7357,8 @@ static void bolliger_mabillard_track_diag_flat_to_60_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17819, { -16, -16, height }, { 32, 32, 4 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17819), { -16, -16, height },
+                            { 32, 32, 4 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7289,8 +7373,8 @@ static void bolliger_mabillard_track_diag_flat_to_60_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17886, { -16, -16, height }, { 32, 32, 4 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17886), { -16, -16, height },
+                            { 32, 32, 4 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7300,8 +7384,8 @@ static void bolliger_mabillard_track_diag_flat_to_60_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17816, { -16, -16, height }, { 32, 32, 4 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17816), { -16, -16, height },
+                            { 32, 32, 4 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7316,8 +7400,8 @@ static void bolliger_mabillard_track_diag_flat_to_60_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17888, { -16, -16, height }, { 32, 32, 4 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17888), { -16, -16, height },
+                            { 32, 32, 4 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7327,8 +7411,8 @@ static void bolliger_mabillard_track_diag_flat_to_60_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17818, { -16, -16, height }, { 32, 32, 4 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17818), { -16, -16, height },
+                            { 32, 32, 4 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7346,8 +7430,8 @@ static void bolliger_mabillard_track_diag_flat_to_60_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17887, { -16, -16, height }, { 32, 32, 4 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17887), { -16, -16, height },
+                            { 32, 32, 4 }, { -16, -16, height });
                         metal_b_supports_paint_setup(session, supportType, 0, 5, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
@@ -7367,8 +7451,8 @@ static void bolliger_mabillard_track_diag_flat_to_60_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17817, { -16, -16, height }, { 32, 32, 4 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17817), { -16, -16, height },
+                            { 32, 32, 4 }, { -16, -16, height });
                         metal_b_supports_paint_setup(session, supportType, 0, 5, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
@@ -7400,8 +7484,8 @@ static void bolliger_mabillard_track_diag_60_deg_up_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17893, { -16, -16, height }, { 32, 32, 4 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17893), { -16, -16, height },
+                            { 32, 32, 4 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7411,8 +7495,8 @@ static void bolliger_mabillard_track_diag_60_deg_up_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17823, { -16, -16, height }, { 32, 32, 4 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17823), { -16, -16, height },
+                            { 32, 32, 4 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7427,8 +7511,8 @@ static void bolliger_mabillard_track_diag_60_deg_up_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17890, { -16, -16, height }, { 32, 32, 4 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17890), { -16, -16, height },
+                            { 32, 32, 4 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7438,8 +7522,8 @@ static void bolliger_mabillard_track_diag_60_deg_up_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17820, { -16, -16, height }, { 32, 32, 4 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17820), { -16, -16, height },
+                            { 32, 32, 4 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7454,8 +7538,8 @@ static void bolliger_mabillard_track_diag_60_deg_up_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17892, { -16, -16, height }, { 32, 32, 4 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17892), { -16, -16, height },
+                            { 32, 32, 4 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7465,8 +7549,8 @@ static void bolliger_mabillard_track_diag_60_deg_up_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17822, { -16, -16, height }, { 32, 32, 4 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17822), { -16, -16, height },
+                            { 32, 32, 4 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7485,8 +7569,8 @@ static void bolliger_mabillard_track_diag_60_deg_up_to_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17891, { -16, -16, height }, { 32, 32, 4 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17891), { -16, -16, height },
+                            { 32, 32, 4 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, supportType, 0, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7510,8 +7594,8 @@ static void bolliger_mabillard_track_diag_60_deg_up_to_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17821, { -16, -16, height }, { 32, 32, 4 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17821), { -16, -16, height },
+                            { 32, 32, 4 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, supportType, 0, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7546,8 +7630,8 @@ static void bolliger_mabillard_track_diag_flat_to_60_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17891, { -16, -16, height }, { 32, 32, 4 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17891), { -16, -16, height },
+                            { 32, 32, 4 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7557,8 +7641,8 @@ static void bolliger_mabillard_track_diag_flat_to_60_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17821, { -16, -16, height }, { 32, 32, 4 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17821), { -16, -16, height },
+                            { 32, 32, 4 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7573,8 +7657,8 @@ static void bolliger_mabillard_track_diag_flat_to_60_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17892, { -16, -16, height }, { 32, 32, 4 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17892), { -16, -16, height },
+                            { 32, 32, 4 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7584,8 +7668,8 @@ static void bolliger_mabillard_track_diag_flat_to_60_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17822, { -16, -16, height }, { 32, 32, 4 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17822), { -16, -16, height },
+                            { 32, 32, 4 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7600,8 +7684,8 @@ static void bolliger_mabillard_track_diag_flat_to_60_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17890, { -16, -16, height }, { 32, 32, 4 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17890), { -16, -16, height },
+                            { 32, 32, 4 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7611,8 +7695,8 @@ static void bolliger_mabillard_track_diag_flat_to_60_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17820, { -16, -16, height }, { 32, 32, 4 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17820), { -16, -16, height },
+                            { 32, 32, 4 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7631,8 +7715,8 @@ static void bolliger_mabillard_track_diag_flat_to_60_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17893, { -16, -16, height }, { 32, 32, 4 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17893), { -16, -16, height },
+                            { 32, 32, 4 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, supportType, 0, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7656,8 +7740,8 @@ static void bolliger_mabillard_track_diag_flat_to_60_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17823, { -16, -16, height }, { 32, 32, 4 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17823), { -16, -16, height },
+                            { 32, 32, 4 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, supportType, 0, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7692,8 +7776,8 @@ static void bolliger_mabillard_track_diag_60_deg_down_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17887, { -16, -16, height }, { 32, 32, 4 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17887), { -16, -16, height },
+                            { 32, 32, 4 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7703,8 +7787,8 @@ static void bolliger_mabillard_track_diag_60_deg_down_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17817, { -16, -16, height }, { 32, 32, 4 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17817), { -16, -16, height },
+                            { 32, 32, 4 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7719,8 +7803,8 @@ static void bolliger_mabillard_track_diag_60_deg_down_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17888, { -16, -16, height }, { 32, 32, 4 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17888), { -16, -16, height },
+                            { 32, 32, 4 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7730,8 +7814,8 @@ static void bolliger_mabillard_track_diag_60_deg_down_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17818, { -16, -16, height }, { 32, 32, 4 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17818), { -16, -16, height },
+                            { 32, 32, 4 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7746,8 +7830,8 @@ static void bolliger_mabillard_track_diag_60_deg_down_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17886, { -16, -16, height }, { 32, 32, 4 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17886), { -16, -16, height },
+                            { 32, 32, 4 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7757,8 +7841,8 @@ static void bolliger_mabillard_track_diag_60_deg_down_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17816, { -16, -16, height }, { 32, 32, 4 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17816), { -16, -16, height },
+                            { 32, 32, 4 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7776,8 +7860,8 @@ static void bolliger_mabillard_track_diag_60_deg_down_to_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17889, { -16, -16, height }, { 32, 32, 4 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17889), { -16, -16, height },
+                            { 32, 32, 4 }, { -16, -16, height });
                         metal_b_supports_paint_setup(session, supportType, 0, 5, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
@@ -7797,8 +7881,8 @@ static void bolliger_mabillard_track_diag_60_deg_down_to_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17819, { -16, -16, height }, { 32, 32, 4 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17819), { -16, -16, height },
+                            { 32, 32, 4 }, { -16, -16, height });
                         metal_b_supports_paint_setup(session, supportType, 0, 5, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
@@ -7828,8 +7912,8 @@ static void bolliger_mabillard_track_diag_flat_to_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17831, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17831), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7841,11 +7925,11 @@ static void bolliger_mabillard_track_diag_flat_to_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17828, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17828), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17832, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17832), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7857,8 +7941,8 @@ static void bolliger_mabillard_track_diag_flat_to_left_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17830, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17830), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7873,8 +7957,8 @@ static void bolliger_mabillard_track_diag_flat_to_left_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17829, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17829), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_a_supports_paint_setup(session, supportType, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -7903,8 +7987,8 @@ static void bolliger_mabillard_track_diag_flat_to_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17836, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17836), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7916,8 +8000,8 @@ static void bolliger_mabillard_track_diag_flat_to_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17833, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17833), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7929,11 +8013,11 @@ static void bolliger_mabillard_track_diag_flat_to_right_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17835, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17835), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17837, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17837), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7948,8 +8032,8 @@ static void bolliger_mabillard_track_diag_flat_to_right_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17834, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17834), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_a_supports_paint_setup(session, supportType, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -7978,8 +8062,8 @@ static void bolliger_mabillard_track_diag_left_bank_to_flat(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17834, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17834), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7991,11 +8075,11 @@ static void bolliger_mabillard_track_diag_left_bank_to_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17835, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17835), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17837, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17837), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8007,8 +8091,8 @@ static void bolliger_mabillard_track_diag_left_bank_to_flat(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17833, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17833), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8023,8 +8107,8 @@ static void bolliger_mabillard_track_diag_left_bank_to_flat(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17836, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17836), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_a_supports_paint_setup(session, supportType, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -8053,8 +8137,8 @@ static void bolliger_mabillard_track_diag_right_bank_to_flat(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17829, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17829), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8066,8 +8150,8 @@ static void bolliger_mabillard_track_diag_right_bank_to_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17830, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17830), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8079,11 +8163,11 @@ static void bolliger_mabillard_track_diag_right_bank_to_flat(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17828, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17828), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17832, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17832), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8098,8 +8182,8 @@ static void bolliger_mabillard_track_diag_right_bank_to_flat(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17831, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17831), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_a_supports_paint_setup(session, supportType, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -8128,8 +8212,8 @@ static void bolliger_mabillard_track_diag_left_bank_to_25_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17851, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17851), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8141,11 +8225,11 @@ static void bolliger_mabillard_track_diag_left_bank_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17848, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17848), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17852, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17852), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8157,8 +8241,8 @@ static void bolliger_mabillard_track_diag_left_bank_to_25_deg_up(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17850, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17850), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8173,8 +8257,8 @@ static void bolliger_mabillard_track_diag_left_bank_to_25_deg_up(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17849, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17849), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(session, supportType, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -8203,8 +8287,8 @@ static void bolliger_mabillard_track_diag_right_bank_to_25_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17856, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17856), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8216,8 +8300,8 @@ static void bolliger_mabillard_track_diag_right_bank_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17853, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17853), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8229,11 +8313,11 @@ static void bolliger_mabillard_track_diag_right_bank_to_25_deg_up(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17855, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17855), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17857, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17857), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8248,8 +8332,8 @@ static void bolliger_mabillard_track_diag_right_bank_to_25_deg_up(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17854, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17854), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(session, supportType, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -8278,8 +8362,8 @@ static void bolliger_mabillard_track_diag_25_deg_up_to_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17841, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17841), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8291,11 +8375,11 @@ static void bolliger_mabillard_track_diag_25_deg_up_to_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17838, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17838), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17842, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17842), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8307,8 +8391,8 @@ static void bolliger_mabillard_track_diag_25_deg_up_to_left_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17840, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17840), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8323,8 +8407,8 @@ static void bolliger_mabillard_track_diag_25_deg_up_to_left_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17839, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17839), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(session, supportType, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -8353,8 +8437,8 @@ static void bolliger_mabillard_track_diag_25_deg_up_to_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17846, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17846), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8366,8 +8450,8 @@ static void bolliger_mabillard_track_diag_25_deg_up_to_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17843, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17843), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8379,11 +8463,11 @@ static void bolliger_mabillard_track_diag_25_deg_up_to_right_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17845, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17845), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17847, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17847), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8398,8 +8482,8 @@ static void bolliger_mabillard_track_diag_25_deg_up_to_right_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17844, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17844), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(session, supportType, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -8428,8 +8512,8 @@ static void bolliger_mabillard_track_diag_left_bank_to_25_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17844, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17844), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8440,11 +8524,11 @@ static void bolliger_mabillard_track_diag_left_bank_to_25_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17845, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17845), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17847, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17847), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8455,8 +8539,8 @@ static void bolliger_mabillard_track_diag_left_bank_to_25_deg_down(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17843, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17843), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8470,8 +8554,8 @@ static void bolliger_mabillard_track_diag_left_bank_to_25_deg_down(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17846, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17846), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(session, supportType, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -8501,8 +8585,8 @@ static void bolliger_mabillard_track_diag_right_bank_to_25_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17839, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17839), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8513,8 +8597,8 @@ static void bolliger_mabillard_track_diag_right_bank_to_25_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17840, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17840), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8525,11 +8609,11 @@ static void bolliger_mabillard_track_diag_right_bank_to_25_deg_down(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17838, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17838), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17842, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17842), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8543,8 +8627,8 @@ static void bolliger_mabillard_track_diag_right_bank_to_25_deg_down(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17841, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17841), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(session, supportType, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -8574,8 +8658,8 @@ static void bolliger_mabillard_track_diag_25_deg_down_to_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17854, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17854), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8587,11 +8671,11 @@ static void bolliger_mabillard_track_diag_25_deg_down_to_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17855, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17855), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17857, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17857), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8603,8 +8687,8 @@ static void bolliger_mabillard_track_diag_25_deg_down_to_left_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17853, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17853), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8619,8 +8703,8 @@ static void bolliger_mabillard_track_diag_25_deg_down_to_left_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17856, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17856), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(session, supportType, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -8649,8 +8733,8 @@ static void bolliger_mabillard_track_diag_25_deg_down_to_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17849, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17849), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8662,8 +8746,8 @@ static void bolliger_mabillard_track_diag_25_deg_down_to_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17850, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17850), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8675,11 +8759,11 @@ static void bolliger_mabillard_track_diag_25_deg_down_to_right_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17848, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17848), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17852, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17852), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8694,8 +8778,8 @@ static void bolliger_mabillard_track_diag_25_deg_down_to_right_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17851, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17851), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(session, supportType, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -8724,8 +8808,8 @@ static void bolliger_mabillard_track_diag_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17827, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17827), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8737,8 +8821,8 @@ static void bolliger_mabillard_track_diag_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17824, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17824), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8750,8 +8834,8 @@ static void bolliger_mabillard_track_diag_left_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17826, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17826), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8766,8 +8850,8 @@ static void bolliger_mabillard_track_diag_left_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17825, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17825), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_a_supports_paint_setup(session, supportType, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -8796,8 +8880,8 @@ static void bolliger_mabillard_track_diag_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17825, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17825), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8809,8 +8893,8 @@ static void bolliger_mabillard_track_diag_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17826, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17826), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8822,8 +8906,8 @@ static void bolliger_mabillard_track_diag_right_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17824, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17824), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8838,8 +8922,8 @@ static void bolliger_mabillard_track_diag_right_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17827, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17827), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_a_supports_paint_setup(session, supportType, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -8868,22 +8952,26 @@ static void bolliger_mabillard_track_left_bank_to_left_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17725, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17725), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17727, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17727), { 0, 6, height },
+                        { 32, 20, 3 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17731, { 0, 6, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17731), { 0, 6, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17729, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17729), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17723, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17723), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -8906,19 +8994,23 @@ static void bolliger_mabillard_track_left_bank_to_left_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17724, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17724), { 6, 0, height },
+                        { 20, 32, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17726, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17726), { 6, 0, height },
+                        { 20, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17728, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17728), { 6, 0, height },
+                        { 20, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17722, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17722), { 6, 0, height },
+                        { 20, 32, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -8950,22 +9042,26 @@ static void bolliger_mabillard_track_right_bank_to_right_quarter_turn_3_25_deg_u
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17714, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17714), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17716, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17716), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17718, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17718), { 0, 6, height },
+                        { 32, 20, 3 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17730, { 0, 6, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17730), { 0, 6, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17720, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17720), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -8988,22 +9084,26 @@ static void bolliger_mabillard_track_right_bank_to_right_quarter_turn_3_25_deg_u
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17715, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17715), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(session, supportType, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17717, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17717), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(session, supportType, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17719, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17719), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(session, supportType, 4, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17721, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17721), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(session, supportType, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -9035,22 +9135,26 @@ static void bolliger_mabillard_track_left_quarter_turn_3_25_deg_down_to_left_ban
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17717, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17717), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(session, supportType, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17719, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17719), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(session, supportType, 4, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17721, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17721), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(session, supportType, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17715, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17715), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(session, supportType, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -9073,22 +9177,26 @@ static void bolliger_mabillard_track_left_quarter_turn_3_25_deg_down_to_left_ban
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17716, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17716), { 6, 0, height },
+                        { 20, 32, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17718, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17718), { 6, 0, height },
+                        { 20, 32, 3 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17730, { 6, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17730), { 6, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17720, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17720), { 6, 0, height },
+                        { 20, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17714, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17714), { 6, 0, height },
+                        { 20, 32, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -9120,19 +9228,23 @@ static void bolliger_mabillard_track_right_quarter_turn_3_25_deg_down_to_right_b
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17722, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17722), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17724, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17724), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17726, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17726), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17728, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17728), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -9155,22 +9267,26 @@ static void bolliger_mabillard_track_right_quarter_turn_3_25_deg_down_to_right_b
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17723, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17723), { 6, 0, height },
+                        { 20, 32, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17725, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17725), { 6, 0, height },
+                        { 20, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17727, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17727), { 6, 0, height },
+                        { 20, 32, 3 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17731, { 6, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17731), { 6, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17729, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17729), { 6, 0, height },
+                        { 20, 32, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -9202,15 +9318,15 @@ static void bolliger_mabillard_track_block_brakes(
         case 2:
             PaintAddImageAsParentRotated(
                 session, direction,
-                session.TrackColours[SCHEME_TRACK] | _BolligerMabillardBlockBrakeImages[direction][isClosed], { 0, 0, height },
-                { 32, 20, 3 }, { 0, 6, height });
+                session.TrackColours[SCHEME_TRACK].WithIndex(_BolligerMabillardBlockBrakeImages[direction][isClosed]),
+                { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
             break;
         case 1:
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction,
-                session.TrackColours[SCHEME_TRACK] | _BolligerMabillardBlockBrakeImages[direction][isClosed], { 0, 0, height },
-                { 32, 20, 3 }, { 0, 6, height });
+                session.TrackColours[SCHEME_TRACK].WithIndex(_BolligerMabillardBlockBrakeImages[direction][isClosed]),
+                { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
             break;
     }
     if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -9235,20 +9351,23 @@ static void bolliger_mabillard_track_left_banked_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18025, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18025), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18027, { 0, 6, height }, { 32, 1, 34 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18027), { 0, 6, height },
+                        { 32, 1, 34 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18029, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18029), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18023, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18023), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -9271,21 +9390,23 @@ static void bolliger_mabillard_track_left_banked_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18024, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18024), { 6, 0, height },
+                        { 20, 32, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18026, { 6, 0, height }, { 1, 32, 34 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18026), { 6, 0, height },
+                        { 1, 32, 34 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18028, { 6, 0, height }, { 1, 32, 34 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18028), { 6, 0, height },
+                        { 1, 32, 34 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18022, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18022), { 6, 0, height },
+                        { 20, 32, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -9317,20 +9438,23 @@ static void bolliger_mabillard_track_right_banked_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18014, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18014), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18016, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18016), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18018, { 0, 6, height }, { 32, 1, 34 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18018), { 0, 6, height },
+                        { 32, 1, 34 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18020, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18020), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -9353,24 +9477,26 @@ static void bolliger_mabillard_track_right_banked_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18015, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18015), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(session, supportType, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18017, { 6, 0, height }, { 1, 32, 34 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18017), { 6, 0, height },
+                        { 1, 32, 34 }, { 27, 0, height });
                     metal_a_supports_paint_setup(session, supportType, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18019, { 6, 0, height }, { 1, 32, 34 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18019), { 6, 0, height },
+                        { 1, 32, 34 }, { 27, 0, height });
                     metal_a_supports_paint_setup(session, supportType, 4, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18021, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18021), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(session, supportType, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -9422,23 +9548,23 @@ static void bolliger_mabillard_track_left_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17978, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17978), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17983, { 0, 0, height }, { 32, 1, 34 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17983), { 0, 0, height },
+                        { 32, 1, 34 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17988, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17988), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17993, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17993), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -9458,22 +9584,23 @@ static void bolliger_mabillard_track_left_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17979, { 0, 0, height }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17979), { 0, 0, height },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17984, { 0, 0, height }, { 1, 1, 34 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17984), { 0, 0, height }, { 1, 1, 34 },
                         { 30, 30, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17989, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17989), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17994, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17994), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -9488,22 +9615,23 @@ static void bolliger_mabillard_track_left_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17980, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17980), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17985, { 0, 0, height }, { 1, 1, 34 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17985), { 0, 0, height }, { 1, 1, 34 },
                         { 30, 30, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17990, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17990), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17995, { 0, 0, height }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17995), { 0, 0, height },
+                        { 16, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -9518,23 +9646,23 @@ static void bolliger_mabillard_track_left_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17981, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17981), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17986, { 0, 0, height }, { 1, 1, 34 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17986), { 0, 0, height }, { 1, 1, 34 },
                         { 30, 30, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17991, { 0, 0, height }, { 1, 32, 34 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17991), { 0, 0, height },
+                        { 1, 32, 34 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17996, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17996), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -9549,23 +9677,23 @@ static void bolliger_mabillard_track_left_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17982, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17982), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17987, { 0, 0, height }, { 1, 32, 34 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17987), { 0, 0, height },
+                        { 1, 32, 34 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17992, { 0, 0, height }, { 1, 32, 34 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17992), { 0, 0, height },
+                        { 1, 32, 34 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17997, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17997), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -9597,23 +9725,23 @@ static void bolliger_mabillard_track_right_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17958, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17958), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17963, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17963), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17968, { 0, 0, height }, { 32, 1, 34 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17968), { 0, 0, height },
+                        { 32, 1, 34 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17973, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17973), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -9633,22 +9761,23 @@ static void bolliger_mabillard_track_right_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17959, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17959), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17964, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17964), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17969, { 0, 0, height }, { 1, 1, 34 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17969), { 0, 0, height }, { 1, 1, 34 },
                         { 30, 30, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17974, { 0, 0, height }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17974), { 0, 0, height },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -9663,22 +9792,23 @@ static void bolliger_mabillard_track_right_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17960, { 0, 0, height }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17960), { 0, 0, height },
+                        { 16, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17965, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17965), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17970, { 0, 0, height }, { 1, 1, 34 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17970), { 0, 0, height }, { 1, 1, 34 },
                         { 30, 30, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17975, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17975), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -9693,23 +9823,23 @@ static void bolliger_mabillard_track_right_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17961, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17961), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17966, { 0, 0, height }, { 1, 32, 34 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17966), { 0, 0, height },
+                        { 1, 32, 34 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17971, { 0, 0, height }, { 1, 1, 34 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17971), { 0, 0, height }, { 1, 1, 34 },
                         { 30, 30, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17976, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17976), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -9724,23 +9854,23 @@ static void bolliger_mabillard_track_right_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17962, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17962), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17967, { 0, 0, height }, { 1, 32, 34 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17967), { 0, 0, height },
+                        { 1, 32, 34 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17972, { 0, 0, height }, { 1, 32, 34 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17972), { 0, 0, height },
+                        { 1, 32, 34 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17977, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17977), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -9789,25 +9919,25 @@ static void bolliger_mabillard_track_25_deg_up_to_left_banked_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17922, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17922), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17923, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17923), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17930, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17930), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17924, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17924), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17925, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17925), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -9837,25 +9967,25 @@ static void bolliger_mabillard_track_25_deg_up_to_right_banked_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17926, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17926), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17927, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17927), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17928, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17928), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17931, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17931), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17929, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17929), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -9885,25 +10015,25 @@ static void bolliger_mabillard_track_left_banked_25_deg_up_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17932, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17932), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17933, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17933), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17940, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17940), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17934, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17934), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17935, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17935), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -9933,25 +10063,25 @@ static void bolliger_mabillard_track_right_banked_25_deg_up_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17936, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17936), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17937, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17937), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17938, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17938), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17941, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17941), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17939, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17939), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -10017,22 +10147,22 @@ static void bolliger_mabillard_track_left_banked_flat_to_left_banked_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17942, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17942), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17943, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17943), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17944, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17944), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17945, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17945), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -10062,22 +10192,22 @@ static void bolliger_mabillard_track_right_banked_flat_to_right_banked_25_deg_up
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17946, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17946), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17947, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17947), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17948, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17948), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17949, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17949), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -10107,22 +10237,22 @@ static void bolliger_mabillard_track_left_banked_25_deg_up_to_left_banked_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17950, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17950), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17951, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17951), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17952, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17952), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17953, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17953), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -10152,22 +10282,22 @@ static void bolliger_mabillard_track_right_banked_25_deg_up_to_right_banked_flat
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17954, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17954), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17955, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17955), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17956, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17956), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17957, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17957), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -10233,25 +10363,25 @@ static void bolliger_mabillard_track_flat_to_left_banked_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17894, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17894), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17895, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17895), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17902, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17902), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17896, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17896), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17897, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17897), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -10281,25 +10411,25 @@ static void bolliger_mabillard_track_flat_to_right_banked_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17898, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17898), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17899, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17899), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17900, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17900), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17903, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17903), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17901, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17901), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -10329,25 +10459,25 @@ static void bolliger_mabillard_track_left_banked_25_deg_up_to_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17904, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17904), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17905, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17905), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17912, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17912), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17906, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17906), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17907, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17907), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -10377,25 +10507,25 @@ static void bolliger_mabillard_track_right_banked_25_deg_up_to_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17908, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17908), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17909, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17909), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17910, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17910), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17913, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17913), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17911, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17911), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -10464,29 +10594,29 @@ static void bolliger_mabillard_track_left_quarter_turn_1_90_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17998, { 0, 0, height }, { 2, 20, 63 },
-                        { 4, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17998), { 0, 0, height },
+                        { 2, 20, 63 }, { 4, 6, height + 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17999, { 0, 0, height }, { 2, 20, 63 },
-                        { 4, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17999), { 0, 0, height },
+                        { 2, 20, 63 }, { 4, 6, height + 8 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18007, { 0, 0, height }, { 2, 20, 63 },
-                        { 24, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18007), { 0, 0, height },
+                        { 2, 20, 63 }, { 24, 6, height + 8 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18008, { 0, 0, height }, { 2, 20, 63 },
-                        { 24, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18008), { 0, 0, height },
+                        { 2, 20, 63 }, { 24, 6, height + 8 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18001, { 0, 0, height }, { 2, 20, 63 },
-                        { 4, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18001), { 0, 0, height },
+                        { 2, 20, 63 }, { 4, 6, height + 8 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18009, { 0, 0, height }, { 2, 20, 63 },
-                        { 24, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18009), { 0, 0, height },
+                        { 2, 20, 63 }, { 24, 6, height + 8 });
                     break;
             }
             paint_util_set_vertical_tunnel(session, height + 96);
@@ -10511,29 +10641,29 @@ static void bolliger_mabillard_track_right_quarter_turn_1_90_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18002, { 0, 0, height }, { 2, 20, 63 },
-                        { 4, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18002), { 0, 0, height },
+                        { 2, 20, 63 }, { 4, 6, height + 8 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18010, { 0, 0, height }, { 2, 20, 63 },
-                        { 24, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18010), { 0, 0, height },
+                        { 2, 20, 63 }, { 24, 6, height + 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18011, { 0, 0, height }, { 2, 20, 63 },
-                        { 24, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18011), { 0, 0, height },
+                        { 2, 20, 63 }, { 24, 6, height + 8 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18004, { 0, 0, height }, { 2, 20, 63 },
-                        { 4, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18004), { 0, 0, height },
+                        { 2, 20, 63 }, { 4, 6, height + 8 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18012, { 0, 0, height }, { 2, 20, 63 },
-                        { 24, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18012), { 0, 0, height },
+                        { 2, 20, 63 }, { 24, 6, height + 8 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18005, { 0, 0, height }, { 2, 20, 63 },
-                        { 4, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18005), { 0, 0, height },
+                        { 2, 20, 63 }, { 4, 6, height + 8 });
                     break;
             }
             paint_util_set_vertical_tunnel(session, height + 96);
@@ -10576,28 +10706,28 @@ static void bolliger_mabillard_track_flat_to_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17464, { 0, 0, height }, { 32, 27, 4 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17464), { 0, 0, height }, { 32, 27, 4 },
                     { 0, 2, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17465, { 0, 0, height }, { 1, 24, 43 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17465), { 0, 0, height }, { 1, 24, 43 },
                     { 29, 4, height + 2 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17468, { 0, 0, height }, { 32, 2, 43 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17468), { 0, 0, height }, { 32, 2, 43 },
                     { 0, 4, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17466, { 0, 0, height }, { 1, 24, 43 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17466), { 0, 0, height }, { 1, 24, 43 },
                     { 29, 4, height + 2 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17469, { 0, 0, height }, { 32, 2, 43 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17469), { 0, 0, height }, { 32, 2, 43 },
                     { 0, 4, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17467, { 0, 0, height }, { 32, 27, 4 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17467), { 0, 0, height }, { 32, 27, 4 },
                     { 0, 2, height });
                 break;
         }
@@ -10609,28 +10739,28 @@ static void bolliger_mabillard_track_flat_to_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17452, { 0, 0, height }, { 32, 27, 4 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17452), { 0, 0, height }, { 32, 27, 4 },
                     { 0, 2, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17453, { 0, 0, height }, { 1, 24, 43 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17453), { 0, 0, height }, { 1, 24, 43 },
                     { 29, 4, height + 2 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17456, { 0, 0, height }, { 32, 2, 43 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17456), { 0, 0, height }, { 32, 2, 43 },
                     { 0, 4, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17454, { 0, 0, height }, { 1, 24, 43 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17454), { 0, 0, height }, { 1, 24, 43 },
                     { 29, 4, height + 2 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17457, { 0, 0, height }, { 32, 2, 43 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17457), { 0, 0, height }, { 32, 2, 43 },
                     { 0, 4, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17455, { 0, 0, height }, { 32, 27, 4 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17455), { 0, 0, height }, { 32, 27, 4 },
                     { 0, 2, height });
                 break;
         }
@@ -10660,28 +10790,28 @@ static void bolliger_mabillard_track_60_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17470, { 0, 0, height }, { 32, 27, 4 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17470), { 0, 0, height }, { 32, 27, 4 },
                     { 0, 2, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17471, { 0, 0, height }, { 1, 24, 43 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17471), { 0, 0, height }, { 1, 24, 43 },
                     { 29, 4, height + 2 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17474, { 0, 0, height }, { 32, 2, 43 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17474), { 0, 0, height }, { 32, 2, 43 },
                     { 0, 4, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17472, { 0, 0, height }, { 1, 24, 43 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17472), { 0, 0, height }, { 1, 24, 43 },
                     { 29, 4, height + 2 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17475, { 0, 0, height }, { 32, 2, 43 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17475), { 0, 0, height }, { 32, 2, 43 },
                     { 0, 4, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17473, { 0, 0, height }, { 32, 27, 4 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17473), { 0, 0, height }, { 32, 27, 4 },
                     { 0, 2, height });
                 break;
         }
@@ -10693,28 +10823,28 @@ static void bolliger_mabillard_track_60_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17458, { 0, 0, height }, { 32, 27, 4 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17458), { 0, 0, height }, { 32, 27, 4 },
                     { 0, 2, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17459, { 0, 0, height }, { 1, 24, 43 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17459), { 0, 0, height }, { 1, 24, 43 },
                     { 29, 4, height + 2 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17462, { 0, 0, height }, { 32, 2, 43 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17462), { 0, 0, height }, { 32, 2, 43 },
                     { 0, 4, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17460, { 0, 0, height }, { 1, 24, 43 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17460), { 0, 0, height }, { 1, 24, 43 },
                     { 29, 4, height + 2 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17463, { 0, 0, height }, { 32, 2, 43 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17463), { 0, 0, height }, { 32, 2, 43 },
                     { 0, 4, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17461, { 0, 0, height }, { 32, 27, 4 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17461), { 0, 0, height }, { 32, 27, 4 },
                     { 0, 2, height });
                 break;
         }
@@ -10760,28 +10890,28 @@ static void bolliger_mabillard_track_brake_for_drop(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17482, { 0, 0, height }, { 1, 24, 43 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17482), { 0, 0, height }, { 1, 24, 43 },
                 { 29, 4, height + 2 });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17485, { 0, 0, height }, { 32, 2, 43 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17485), { 0, 0, height }, { 32, 2, 43 },
                 { 0, 4, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17483, { 0, 0, height }, { 32, 27, 4 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17483), { 0, 0, height }, { 32, 27, 4 },
                 { 0, 2, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17480, { 0, 0, height }, { 32, 27, 4 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17480), { 0, 0, height }, { 32, 27, 4 },
                 { 0, 2, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17481, { 0, 0, height }, { 1, 24, 43 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17481), { 0, 0, height }, { 1, 24, 43 },
                 { 29, 4, height + 2 });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17484, { 0, 0, height }, { 32, 2, 43 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17484), { 0, 0, height }, { 32, 2, 43 },
                 { 0, 4, height });
             break;
     }
@@ -10812,19 +10942,23 @@ static void bolliger_mabillard_track_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17626, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17626), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17634, { 0, 6, height }, { 32, 20, 11 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17634), { 0, 6, height },
+                        { 32, 20, 11 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17633, { 0, 6, height }, { 32, 20, 9 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17633), { 0, 6, height },
+                        { 32, 20, 9 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17641, { 0, 6, height }, { 32, 20, 7 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17641), { 0, 6, height },
+                        { 32, 20, 7 });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -10841,25 +10975,26 @@ static void bolliger_mabillard_track_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17627, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17627), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(session, supportType, 4, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17635, { 0, 14, height }, { 3, 20, 63 },
-                        { 28, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17635), { 0, 14, height },
+                        { 3, 20, 63 }, { 28, 6, height });
                     metal_a_supports_paint_setup(session, supportType, 4, 15, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17632, { 0, 6, height }, { 3, 20, 63 },
-                        { 28, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17632), { 0, 6, height },
+                        { 3, 20, 63 }, { 28, 6, height });
                     metal_a_supports_paint_setup(session, supportType, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17640, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17640), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(session, supportType, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -10871,21 +11006,23 @@ static void bolliger_mabillard_track_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17628, { 16, 0, height }, { 2, 16, 119 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17628), { 16, 0, height },
+                        { 2, 16, 119 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17636, { 12, 0, height }, { 3, 16, 119 },
-                        { 12, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17636), { 12, 0, height },
+                        { 3, 16, 119 }, { 12, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17631, { 10, 16, height }, { 4, 12, 119 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17631), { 10, 16, height },
+                        { 4, 12, 119 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17639, { 16, 16, height }, { 2, 16, 119 },
-                        { 15, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17639), { 16, 16, height },
+                        { 2, 16, 119 }, { 15, 6, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -10900,19 +11037,23 @@ static void bolliger_mabillard_track_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17629, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17629), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17637, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17637), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17630, { 0, 16, height + 32 }, { 32, 12, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17630), { 0, 16, height + 32 },
+                        { 32, 12, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17638, { 0, 16, height + 32 }, { 32, 12, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17638), { 0, 16, height + 32 },
+                        { 32, 12, 3 });
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -10946,23 +11087,23 @@ static void bolliger_mabillard_track_left_corkscrew_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17690, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17690), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 4 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17693, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17693), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 4 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17696, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17696), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 4 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17699, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17699), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 4 });
                     break;
             }
 
@@ -10979,23 +11120,23 @@ static void bolliger_mabillard_track_left_corkscrew_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17691, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17691), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17694, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17694), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17697, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17697), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17700, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17700), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -11006,23 +11147,23 @@ static void bolliger_mabillard_track_left_corkscrew_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17692, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17692), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 24 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17695, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17695), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 24 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17698, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17698), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 24 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17701, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17701), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 24 });
                     break;
             }
 
@@ -11057,23 +11198,23 @@ static void bolliger_mabillard_track_right_corkscrew_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17702, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17702), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 4 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17705, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17705), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 4 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17708, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17708), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 4 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17711, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17711), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 4 });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11091,23 +11232,23 @@ static void bolliger_mabillard_track_right_corkscrew_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17703, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17703), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17706, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17706), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17709, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17709), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17712, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17712), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -11118,23 +11259,23 @@ static void bolliger_mabillard_track_right_corkscrew_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17704, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17704), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 24 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17707, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17707), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 24 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17710, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17710), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 24 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17713, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17713), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 24 });
                     break;
             }
 
@@ -11187,23 +11328,23 @@ static void bolliger_mabillard_track_flat_to_60_deg_up_long_base(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18030, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18030), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18034, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18034), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18038, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18038), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18042, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18042), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -11223,23 +11364,23 @@ static void bolliger_mabillard_track_flat_to_60_deg_up_long_base(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18031, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18031), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18035, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18035), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18039, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18039), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18043, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18043), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -11255,23 +11396,23 @@ static void bolliger_mabillard_track_flat_to_60_deg_up_long_base(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18032, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18032), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18036, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18036), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18040, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18040), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18044, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18044), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -11287,23 +11428,23 @@ static void bolliger_mabillard_track_flat_to_60_deg_up_long_base(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18033, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18033), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18037, { 0, 0, height }, { 32, 1, 98 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18037), { 0, 0, height },
+                        { 32, 1, 98 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18041, { 0, 0, height }, { 32, 1, 98 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18041), { 0, 0, height },
+                        { 32, 1, 98 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18045, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18045), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -11339,23 +11480,23 @@ static void bolliger_mabillard_track_60_deg_up_to_flat_long_base(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18046, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18046), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18050, { 0, 0, height }, { 32, 1, 98 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18050), { 0, 0, height },
+                        { 32, 1, 98 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18054, { 0, 0, height }, { 32, 1, 98 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18054), { 0, 0, height },
+                        { 32, 1, 98 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18058, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18058), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -11375,23 +11516,23 @@ static void bolliger_mabillard_track_60_deg_up_to_flat_long_base(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18047, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18047), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18051, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18051), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18055, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18055), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18059, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18059), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -11407,23 +11548,23 @@ static void bolliger_mabillard_track_60_deg_up_to_flat_long_base(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18048, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18048), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18052, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18052), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18056, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18056), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18060, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18060), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -11439,23 +11580,23 @@ static void bolliger_mabillard_track_60_deg_up_to_flat_long_base(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18049, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18049), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18053, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18053), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18057, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18057), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18061, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18061), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -11508,38 +11649,38 @@ static void bolliger_mabillard_track_left_barrel_roll_up_to_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17642, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17642), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17666, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17666), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     metal_a_supports_paint_setup(session, supportType, 2, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17645, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17645), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17669, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17669), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     metal_a_supports_paint_setup(session, supportType, 3, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17648, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17648), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17672, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17672), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     metal_a_supports_paint_setup(session, supportType, 1, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17651, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17651), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17675, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17675), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     metal_a_supports_paint_setup(session, supportType, 0, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -11557,35 +11698,35 @@ static void bolliger_mabillard_track_left_barrel_roll_up_to_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17643, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17643), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17667, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17667), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17646, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17646), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17670, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17670), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17649, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17649), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17673, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17673), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17652, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17652), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17676, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17676), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -11600,35 +11741,35 @@ static void bolliger_mabillard_track_left_barrel_roll_up_to_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17644, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17644), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17668, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 44 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17668), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 44 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17647, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17647), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17671, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 44 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17671), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 44 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17650, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17650), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17674, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 44 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17674), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 44 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17653, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17653), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17677, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 44 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17677), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 44 });
                     break;
             }
             switch (direction)
@@ -11660,38 +11801,38 @@ static void bolliger_mabillard_track_right_barrel_roll_up_to_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17654, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17654), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17678, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17678), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     metal_a_supports_paint_setup(session, supportType, 0, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17657, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17657), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17681, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17681), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     metal_a_supports_paint_setup(session, supportType, 2, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17660, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17660), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17684, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17684), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     metal_a_supports_paint_setup(session, supportType, 3, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17663, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17663), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17687, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17687), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     metal_a_supports_paint_setup(session, supportType, 1, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -11709,35 +11850,35 @@ static void bolliger_mabillard_track_right_barrel_roll_up_to_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17655, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17655), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17679, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17679), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17658, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17658), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17682, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17682), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17661, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17661), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17685, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17685), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17664, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17664), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17688, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17688), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -11752,35 +11893,35 @@ static void bolliger_mabillard_track_right_barrel_roll_up_to_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17656, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17656), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17680, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 44 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17680), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 44 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17659, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17659), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17683, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 44 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17683), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 44 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17662, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17662), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17686, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 44 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17686), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 44 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17665, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17665), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17689, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 44 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17689), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 44 });
                     break;
             }
             switch (direction)
@@ -11827,22 +11968,22 @@ static void bolliger_mabillard_track_powered_lift(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17476, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17476), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17477, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17477), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17478, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17478), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17479, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17479), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -11872,23 +12013,23 @@ static void bolliger_mabillard_track_left_large_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17732, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17732), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17739, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17739), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17746, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17746), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17753, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17753), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11905,23 +12046,23 @@ static void bolliger_mabillard_track_left_large_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17733, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17733), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17740, { 0, 0, height }, { 32, 20, 9 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17740), { 0, 0, height },
+                        { 32, 20, 9 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17747, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17747), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17754, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17754), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11934,23 +12075,23 @@ static void bolliger_mabillard_track_left_large_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17734, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17734), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17741, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 70 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17741), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height + 70 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17748, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 70 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17748), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height + 70 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17755, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17755), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -11965,26 +12106,26 @@ static void bolliger_mabillard_track_left_large_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17735, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17735), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     metal_a_supports_paint_setup(session, supportType, 5, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17742, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 200 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17742), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height + 200 });
                     metal_a_supports_paint_setup(session, supportType, 6, 22, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17749, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 200 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17749), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height + 200 });
                     metal_a_supports_paint_setup(session, supportType, 8, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17756, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17756), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     metal_a_supports_paint_setup(session, supportType, 7, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -12000,23 +12141,23 @@ static void bolliger_mabillard_track_left_large_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17736, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17736), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17743, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 16, height + 110 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17743), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 16, height + 110 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17750, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 100 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17750), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 0, height + 100 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17757, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17757), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -12028,23 +12169,23 @@ static void bolliger_mabillard_track_left_large_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17737, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17737), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17744, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 200 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17744), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height + 200 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17751, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 200 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17751), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height + 200 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17758, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17758), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -12059,23 +12200,23 @@ static void bolliger_mabillard_track_left_large_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17738, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17738), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height + 32 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17745, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17745), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height + 32 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17752, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17752), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height + 32 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17759, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17759), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height + 32 });
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -12104,23 +12245,23 @@ static void bolliger_mabillard_track_right_large_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17781, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17781), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17774, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17774), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17767, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17767), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17760, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17760), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -12137,23 +12278,23 @@ static void bolliger_mabillard_track_right_large_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17782, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17782), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17775, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17775), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17768, { 0, 0, height }, { 32, 20, 9 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17768), { 0, 0, height },
+                        { 32, 20, 9 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17761, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17761), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -12166,23 +12307,23 @@ static void bolliger_mabillard_track_right_large_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17783, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17783), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17776, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 70 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17776), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height + 70 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17769, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 70 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17769), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height + 70 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17762, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17762), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -12197,26 +12338,26 @@ static void bolliger_mabillard_track_right_large_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17784, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17784), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     metal_a_supports_paint_setup(session, supportType, 8, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17777, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 200 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17777), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height + 200 });
                     metal_a_supports_paint_setup(session, supportType, 7, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17770, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 200 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17770), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height + 200 });
                     metal_a_supports_paint_setup(session, supportType, 5, 22, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17763, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17763), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     metal_a_supports_paint_setup(session, supportType, 6, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -12232,23 +12373,23 @@ static void bolliger_mabillard_track_right_large_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17785, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17785), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17778, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 100 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17778), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 0, height + 100 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17771, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 16, height + 110 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17771), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 16, height + 110 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17764, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17764), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -12260,23 +12401,23 @@ static void bolliger_mabillard_track_right_large_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17786, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17786), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17779, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 200 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17779), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height + 200 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17772, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 200 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17772), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height + 200 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17765, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17765), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -12291,23 +12432,23 @@ static void bolliger_mabillard_track_right_large_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17787, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17787), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height + 32 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17780, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17780), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height + 32 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17773, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17773), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height + 32 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17766, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17766), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height + 32 });
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -12354,23 +12495,23 @@ static void bolliger_mabillard_track_90_deg_to_inverted_flat_quarter_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18062, { 0, 0, height }, { 2, 20, 31 },
-                        { 4, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18062), { 0, 0, height },
+                        { 2, 20, 31 }, { 4, 6, height + 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18065, { 0, 0, height }, { 2, 20, 31 },
-                        { 24, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18065), { 0, 0, height },
+                        { 2, 20, 31 }, { 24, 6, height + 8 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18068, { 0, 0, height }, { 2, 20, 31 },
-                        { 24, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18068), { 0, 0, height },
+                        { 2, 20, 31 }, { 24, 6, height + 8 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18071, { 0, 0, height }, { 2, 20, 31 },
-                        { 4, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18071), { 0, 0, height },
+                        { 2, 20, 31 }, { 4, 6, height + 8 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -12382,23 +12523,23 @@ static void bolliger_mabillard_track_90_deg_to_inverted_flat_quarter_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18063, { 0, 0, height }, { 2, 20, 31 },
-                        { -8, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18063), { 0, 0, height },
+                        { 2, 20, 31 }, { -8, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18066, { 0, 0, height }, { 2, 20, 63 },
-                        { 24, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18066), { 0, 0, height },
+                        { 2, 20, 63 }, { 24, 6, height + 8 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18069, { 0, 0, height }, { 2, 20, 63 },
-                        { 24, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18069), { 0, 0, height },
+                        { 2, 20, 63 }, { 24, 6, height + 8 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18072, { 0, 0, height }, { 2, 20, 31 },
-                        { -8, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18072), { 0, 0, height },
+                        { 2, 20, 31 }, { -8, 6, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -12410,23 +12551,23 @@ static void bolliger_mabillard_track_90_deg_to_inverted_flat_quarter_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18064, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18064), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 24 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18067, { 0, 0, height }, { 2, 20, 31 },
-                        { 24, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18067), { 0, 0, height },
+                        { 2, 20, 31 }, { 24, 6, height + 8 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18070, { 0, 0, height }, { 2, 20, 31 },
-                        { 24, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18070), { 0, 0, height },
+                        { 2, 20, 31 }, { 24, 6, height + 8 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18073, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18073), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 24 });
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -12465,13 +12606,13 @@ void bolliger_mabillard_track_booster(
         case 0:
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | SPR_G2_BM_BOOSTER_NE_SW,
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(SPR_G2_BM_BOOSTER_NE_SW),
                 { ne_sw_offsetX, ne_sw_offsetY, height }, { 32, 20, 3 }, { 0, 6, height });
             break;
         case 1:
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | SPR_G2_BM_BOOSTER_NW_SE,
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(SPR_G2_BM_BOOSTER_NW_SE),
                 { nw_se_offsetX, nw_se_offsetY, height }, { 32, 20, 3 }, { 0, 6, height });
             break;
     }
@@ -12497,23 +12638,23 @@ static void bolliger_mabillard_track_left_twist_down_to_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27430, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 0, height + 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27430), { 0, 6, height - 5 },
+                        { 32, 20, 3 }, { 0, 0, height + 6 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27436, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 0, height + 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27436), { 0, 6, height - 5 },
+                        { 32, 20, 3 }, { 0, 0, height + 6 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27429, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 0, height + 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27429), { 0, 6, height - 5 },
+                        { 32, 20, 3 }, { 0, 0, height + 6 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27435, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 0, height + 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27435), { 0, 6, height - 5 },
+                        { 32, 20, 3 }, { 0, 0, height + 6 });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 0, height - 5, session.TrackColours[SCHEME_SUPPORTS]);
@@ -12533,19 +12674,23 @@ static void bolliger_mabillard_track_left_twist_down_to_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27431, { 0, 6, height + 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27431), { 0, 6, height + 8 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27437, { 0, 6, height + 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27437), { 0, 6, height + 8 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27428, { 0, 6, height + 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27428), { 0, 6, height + 8 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27434, { 0, 6, height + 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27434), { 0, 6, height + 8 },
+                        { 32, 20, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -12560,19 +12705,23 @@ static void bolliger_mabillard_track_left_twist_down_to_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27432, { 0, 6, height - 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27432), { 0, 6, height - 8 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27438, { 0, 6, height - 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27438), { 0, 6, height - 8 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27427, { 0, 6, height - 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27427), { 0, 6, height - 8 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27433, { 0, 6, height - 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27433), { 0, 6, height - 8 },
+                        { 32, 20, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -12608,23 +12757,23 @@ static void bolliger_mabillard_track_right_twist_down_to_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27442, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 0, height + 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27442), { 0, 6, height - 5 },
+                        { 32, 20, 3 }, { 0, 0, height + 6 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27448, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 0, height + 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27448), { 0, 6, height - 5 },
+                        { 32, 20, 3 }, { 0, 0, height + 6 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27441, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 0, height + 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27441), { 0, 6, height - 5 },
+                        { 32, 20, 3 }, { 0, 0, height + 6 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27447, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 0, height + 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27447), { 0, 6, height - 5 },
+                        { 32, 20, 3 }, { 0, 0, height + 6 });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 0, height - 5, session.TrackColours[SCHEME_SUPPORTS]);
@@ -12644,19 +12793,23 @@ static void bolliger_mabillard_track_right_twist_down_to_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27443, { 0, 6, height + 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27443), { 0, 6, height + 8 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27449, { 0, 6, height + 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27449), { 0, 6, height + 8 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27440, { 0, 6, height + 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27440), { 0, 6, height + 8 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27446, { 0, 6, height + 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27446), { 0, 6, height + 8 },
+                        { 32, 20, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -12671,19 +12824,23 @@ static void bolliger_mabillard_track_right_twist_down_to_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27444, { 0, 6, height - 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27444), { 0, 6, height - 8 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27450, { 0, 6, height - 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27450), { 0, 6, height - 8 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27439, { 0, 6, height - 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27439), { 0, 6, height - 8 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27445, { 0, 6, height - 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27445), { 0, 6, height - 8 },
+                        { 32, 20, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -12719,19 +12876,23 @@ static void bolliger_mabillard_track_left_twist_up_to_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27427, { 0, 6, height - 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27427), { 0, 6, height - 8 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27433, { 0, 6, height - 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27433), { 0, 6, height - 8 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27432, { 0, 6, height - 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27432), { 0, 6, height - 8 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27438, { 0, 6, height - 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27438), { 0, 6, height - 8 },
+                        { 32, 20, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -12752,19 +12913,23 @@ static void bolliger_mabillard_track_left_twist_up_to_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27428, { 0, 6, height + 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27428), { 0, 6, height + 8 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27434, { 0, 6, height + 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27434), { 0, 6, height + 8 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27431, { 0, 6, height + 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27431), { 0, 6, height + 8 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27437, { 0, 6, height + 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27437), { 0, 6, height + 8 },
+                        { 32, 20, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -12779,23 +12944,23 @@ static void bolliger_mabillard_track_left_twist_up_to_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27429, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 0, height + 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27429), { 0, 6, height - 5 },
+                        { 32, 20, 3 }, { 0, 0, height + 6 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27435, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 0, height + 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27435), { 0, 6, height - 5 },
+                        { 32, 20, 3 }, { 0, 0, height + 6 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27430, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 0, height + 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27430), { 0, 6, height - 5 },
+                        { 32, 20, 3 }, { 0, 0, height + 6 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27436, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 0, height + 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27436), { 0, 6, height - 5 },
+                        { 32, 20, 3 }, { 0, 0, height + 6 });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 0, height - 5, session.TrackColours[SCHEME_SUPPORTS]);
@@ -12830,19 +12995,23 @@ static void bolliger_mabillard_track_right_twist_up_to_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27439, { 0, 6, height - 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27439), { 0, 6, height - 8 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27445, { 0, 6, height - 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27445), { 0, 6, height - 8 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27444, { 0, 6, height - 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27444), { 0, 6, height - 8 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27450, { 0, 6, height - 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27450), { 0, 6, height - 8 },
+                        { 32, 20, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -12863,19 +13032,23 @@ static void bolliger_mabillard_track_right_twist_up_to_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27440, { 0, 6, height + 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27440), { 0, 6, height + 8 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27446, { 0, 6, height + 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27446), { 0, 6, height + 8 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27443, { 0, 6, height + 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27443), { 0, 6, height + 8 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27449, { 0, 6, height + 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27449), { 0, 6, height + 8 },
+                        { 32, 20, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -12890,23 +13063,23 @@ static void bolliger_mabillard_track_right_twist_up_to_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27441, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 0, height + 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27441), { 0, 6, height - 5 },
+                        { 32, 20, 3 }, { 0, 0, height + 6 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27447, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 0, height + 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27447), { 0, 6, height - 5 },
+                        { 32, 20, 3 }, { 0, 0, height + 6 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27442, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 0, height + 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27442), { 0, 6, height - 5 },
+                        { 32, 20, 3 }, { 0, 0, height + 6 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27448, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 0, height + 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27448), { 0, 6, height - 5 },
+                        { 32, 20, 3 }, { 0, 0, height + 6 });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 0, height - 5, session.TrackColours[SCHEME_SUPPORTS]);

--- a/src/openrct2/ride/coaster/CompactInvertedCoaster.cpp
+++ b/src/openrct2/ride/coaster/CompactInvertedCoaster.cpp
@@ -30,14 +30,14 @@ static void compact_inverted_rc_track_flat(
             case 0:
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26557, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 29 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26557), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 29 });
                 break;
             case 1:
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26558, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 29 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26558), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 29 });
                 break;
         }
     }
@@ -48,14 +48,14 @@ static void compact_inverted_rc_track_flat(
             case 0:
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26555, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 29 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26555), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 29 });
                 break;
             case 1:
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26556, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 29 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26556), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 29 });
                 break;
         }
     }
@@ -85,13 +85,13 @@ static void compact_inverted_rc_track_station(
     };
 
     PaintAddImageAsParentRotated(
-        session, direction, imageIds[direction][0] | session.TrackColours[SCHEME_MISC], { 0, 0, height }, { 32, 28, 1 },
-        { 0, 2, height });
+        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][0]), { 0, 0, height },
+        { 32, 28, 1 }, { 0, 2, height });
     PaintAddImageAsParentRotated(
-        session, direction, imageIds[direction][1] | session.TrackColours[SCHEME_TRACK], { 0, 0, height + 29 }, { 32, 20, 3 },
-        { 0, 6, height + 29 });
+        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][1]), { 0, 0, height + 29 },
+        { 32, 20, 3 }, { 0, 6, height + 29 });
     PaintAddImageAsChildRotated(
-        session, direction, imageIds[direction][2] | session.TrackColours[SCHEME_SUPPORTS], { 0, 6, height + 29 },
+        session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(imageIds[direction][2]), { 0, 6, height + 29 },
         { 32, 20, 3 }, { 0, 6, height + 29 });
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], 11);
     track_paint_util_draw_station_inverted(session, ride, direction, height, trackElement, STATION_VARIANT_TALL);
@@ -111,23 +111,23 @@ static void compact_inverted_rc_track_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26621, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 45 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26621), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 45 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26622, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 45 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26622), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 45 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26623, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 45 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26623), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 45 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26624, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 45 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26624), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 45 });
                 break;
         }
     }
@@ -137,23 +137,23 @@ static void compact_inverted_rc_track_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26569, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 45 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26569), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 45 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26570, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 45 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26570), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 45 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26571, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 45 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26571), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 45 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26572, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 45 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26572), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 45 });
                 break;
         }
     }
@@ -205,23 +205,23 @@ static void compact_inverted_rc_track_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26637, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 93 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26637), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 93 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26638, { 0, 0, height + 29 }, { 32, 2, 81 },
-                    { 0, 4, height + 11 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26638), { 0, 0, height + 29 },
+                    { 32, 2, 81 }, { 0, 4, height + 11 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26639, { 0, 0, height + 29 }, { 32, 2, 81 },
-                    { 0, 4, height + 11 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26639), { 0, 0, height + 29 },
+                    { 32, 2, 81 }, { 0, 4, height + 11 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26640, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 93 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26640), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 93 });
                 break;
         }
     }
@@ -231,23 +231,23 @@ static void compact_inverted_rc_track_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26585, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 93 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26585), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 93 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26586, { 0, 0, height + 29 }, { 32, 2, 81 },
-                    { 0, 4, height + 11 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26586), { 0, 0, height + 29 },
+                    { 32, 2, 81 }, { 0, 4, height + 11 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26587, { 0, 0, height + 29 }, { 32, 2, 81 },
-                    { 0, 4, height + 11 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26587), { 0, 0, height + 29 },
+                    { 32, 2, 81 }, { 0, 4, height + 11 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26588, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 93 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26588), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 93 });
                 break;
         }
     }
@@ -275,23 +275,23 @@ static void compact_inverted_rc_track_flat_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26613, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26613), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26614, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26614), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26615, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26615), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26616, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26616), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
         }
     }
@@ -301,23 +301,23 @@ static void compact_inverted_rc_track_flat_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26561, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26561), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26562, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26562), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26563, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26563), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26564, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26564), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
         }
     }
@@ -369,29 +369,29 @@ static void compact_inverted_rc_track_25_deg_up_to_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26625, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 61 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26625), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 61 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26629, { 0, 0, height + 29 }, { 32, 10, 49 },
-                    { 0, 10, height + 11 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26629), { 0, 0, height + 29 },
+                    { 32, 10, 49 }, { 0, 10, height + 11 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26626, { 0, 0, height + 29 }, { 32, 2, 49 },
-                    { 0, 4, height + 11 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26626), { 0, 0, height + 29 },
+                    { 32, 2, 49 }, { 0, 4, height + 11 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26630, { 0, 0, height + 29 }, { 32, 10, 49 },
-                    { 0, 10, height + 11 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26630), { 0, 0, height + 29 },
+                    { 32, 10, 49 }, { 0, 10, height + 11 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26627, { 0, 0, height + 29 }, { 32, 2, 49 },
-                    { 0, 4, height + 11 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26627), { 0, 0, height + 29 },
+                    { 32, 2, 49 }, { 0, 4, height + 11 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26628, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 61 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26628), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 61 });
                 break;
         }
     }
@@ -401,29 +401,29 @@ static void compact_inverted_rc_track_25_deg_up_to_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26573, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 61 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26573), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 61 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26577, { 0, 0, height + 29 }, { 32, 10, 49 },
-                    { 0, 10, height + 11 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26577), { 0, 0, height + 29 },
+                    { 32, 10, 49 }, { 0, 10, height + 11 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26574, { 0, 0, height + 29 }, { 32, 2, 49 },
-                    { 0, 4, height + 11 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26574), { 0, 0, height + 29 },
+                    { 32, 2, 49 }, { 0, 4, height + 11 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26578, { 0, 0, height + 29 }, { 32, 10, 49 },
-                    { 0, 10, height + 11 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26578), { 0, 0, height + 29 },
+                    { 32, 10, 49 }, { 0, 10, height + 11 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26575, { 0, 0, height + 29 }, { 32, 2, 49 },
-                    { 0, 4, height + 11 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26575), { 0, 0, height + 29 },
+                    { 32, 2, 49 }, { 0, 4, height + 11 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26576, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 61 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26576), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 61 });
                 break;
         }
     }
@@ -451,29 +451,29 @@ static void compact_inverted_rc_track_60_deg_up_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26631, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 61 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26631), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 61 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26635, { 0, 0, height + 29 }, { 32, 10, 49 },
-                    { 0, 10, height + 11 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26635), { 0, 0, height + 29 },
+                    { 32, 10, 49 }, { 0, 10, height + 11 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26632, { 0, 0, height + 29 }, { 32, 2, 49 },
-                    { 0, 4, height + 11 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26632), { 0, 0, height + 29 },
+                    { 32, 2, 49 }, { 0, 4, height + 11 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26636, { 0, 0, height + 29 }, { 32, 10, 49 },
-                    { 0, 10, height + 11 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26636), { 0, 0, height + 29 },
+                    { 32, 10, 49 }, { 0, 10, height + 11 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26633, { 0, 0, height + 29 }, { 32, 2, 49 },
-                    { 0, 4, height + 11 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26633), { 0, 0, height + 29 },
+                    { 32, 2, 49 }, { 0, 4, height + 11 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26634, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 61 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26634), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 61 });
                 break;
         }
     }
@@ -483,29 +483,29 @@ static void compact_inverted_rc_track_60_deg_up_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26579, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 61 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26579), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 61 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26583, { 0, 0, height + 29 }, { 32, 10, 49 },
-                    { 0, 10, height + 11 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26583), { 0, 0, height + 29 },
+                    { 32, 10, 49 }, { 0, 10, height + 11 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26580, { 0, 0, height + 29 }, { 32, 2, 49 },
-                    { 0, 4, height + 11 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26580), { 0, 0, height + 29 },
+                    { 32, 2, 49 }, { 0, 4, height + 11 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26584, { 0, 0, height + 29 }, { 32, 10, 49 },
-                    { 0, 10, height + 11 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26584), { 0, 0, height + 29 },
+                    { 32, 10, 49 }, { 0, 10, height + 11 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26581, { 0, 0, height + 29 }, { 32, 2, 49 },
-                    { 0, 4, height + 11 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26581), { 0, 0, height + 29 },
+                    { 32, 2, 49 }, { 0, 4, height + 11 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26582, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 61 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26582), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 61 });
                 break;
         }
     }
@@ -557,23 +557,23 @@ static void compact_inverted_rc_track_25_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26617, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26617), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26618, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26618), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26619, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26619), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26620, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26620), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
         }
     }
@@ -583,23 +583,23 @@ static void compact_inverted_rc_track_25_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26565, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26565), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26566, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26566), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26567, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26567), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26568, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26568), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
         }
     }
@@ -700,23 +700,23 @@ static void compact_inverted_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26694, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26694), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26699, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26699), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26704, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26704), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26689, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26689), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
             }
 
@@ -740,21 +740,23 @@ static void compact_inverted_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26693, { 0, 0, height + 29 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26693), { 0, 0, height + 29 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26698, { 0, 0, height + 29 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26698), { 0, 0, height + 29 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26703, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26703), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26688, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26688), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -769,22 +771,23 @@ static void compact_inverted_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26692, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26692), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 16, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26697, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26697), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 16, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26702, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26702), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 0, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26687, { 0, 0, height + 29 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26687), { 0, 0, height + 29 },
+                        { 16, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -799,21 +802,23 @@ static void compact_inverted_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26691, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 16, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26691), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 16, 0, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26696, { 0, 0, height + 29 }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26696), { 0, 0, height + 29 },
+                        { 16, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26701, { 0, 0, height + 29 }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26701), { 0, 0, height + 29 },
+                        { 16, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26686, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 16, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26686), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 16, 0, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -828,23 +833,23 @@ static void compact_inverted_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26690, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26690), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26695, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26695), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26700, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26700), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26685, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26685), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 29 });
                     break;
             }
 
@@ -886,22 +891,22 @@ static void compact_inverted_rc_track_flat_to_left_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26657, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26657), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26658, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26658), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26659, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26659), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26660, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26660), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
     }
@@ -929,22 +934,22 @@ static void compact_inverted_rc_track_flat_to_right_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26661, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26661), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26662, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26662), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26663, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26663), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26664, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26664), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
     }
@@ -972,22 +977,22 @@ static void compact_inverted_rc_track_left_bank_to_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26663, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26663), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26664, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26664), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26661, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26661), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26662, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26662), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
     }
@@ -1015,22 +1020,22 @@ static void compact_inverted_rc_track_right_bank_to_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26659, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26659), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26660, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26660), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26657, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26657), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26658, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26658), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
     }
@@ -1061,23 +1066,23 @@ static void compact_inverted_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26738, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26738), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26743, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26743), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26748, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26748), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26733, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26733), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
             }
 
@@ -1101,21 +1106,23 @@ static void compact_inverted_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26737, { 0, 0, height + 29 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26737), { 0, 0, height + 29 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26742, { 0, 0, height + 29 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26742), { 0, 0, height + 29 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26747, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26747), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26732, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26732), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1130,22 +1137,23 @@ static void compact_inverted_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26736, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26736), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 16, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26741, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26741), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 16, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26746, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26746), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 0, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26731, { 0, 0, height + 29 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26731), { 0, 0, height + 29 },
+                        { 16, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1160,21 +1168,23 @@ static void compact_inverted_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26735, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 16, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26735), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 16, 0, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26740, { 0, 0, height + 29 }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26740), { 0, 0, height + 29 },
+                        { 16, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26745, { 0, 0, height + 29 }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26745), { 0, 0, height + 29 },
+                        { 16, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26730, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 16, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26730), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 16, 0, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1189,23 +1199,23 @@ static void compact_inverted_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26734, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26734), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26739, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26739), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26744, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26744), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26729, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26729), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 29 });
                     break;
             }
 
@@ -1248,22 +1258,22 @@ static void compact_inverted_rc_track_left_bank_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26665, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26665), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26666, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26666), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26667, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26667), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26668, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26668), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
     }
@@ -1315,22 +1325,22 @@ static void compact_inverted_rc_track_right_bank_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26669, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26669), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26670, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26670), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26671, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26671), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26672, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26672), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
     }
@@ -1382,22 +1392,22 @@ static void compact_inverted_rc_track_25_deg_up_to_left_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26673, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26673), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26674, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26674), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26675, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26675), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26676, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26676), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
     }
@@ -1449,22 +1459,22 @@ static void compact_inverted_rc_track_25_deg_up_to_right_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26677, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26677), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26678, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26678), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26679, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26679), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26680, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26680), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
     }
@@ -1548,22 +1558,22 @@ static void compact_inverted_rc_track_left_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26681, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26681), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26682, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26682), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26683, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26683), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26684, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26684), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
     }
@@ -1602,19 +1612,23 @@ static void compact_inverted_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26949, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26949), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26954, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26954), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26959, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26959), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26964, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26964), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
             }
 
@@ -1638,19 +1652,23 @@ static void compact_inverted_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26950, { 0, 0, height + 29 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26950), { 0, 0, height + 29 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26955, { 0, 0, height + 29 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26955), { 0, 0, height + 29 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26960, { 0, 16, height + 29 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26960), { 0, 16, height + 29 },
+                        { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26965, { 0, 16, height + 29 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26965), { 0, 16, height + 29 },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1665,19 +1683,23 @@ static void compact_inverted_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26951, { 0, 16, height + 29 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26951), { 0, 16, height + 29 },
+                        { 16, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26956, { 16, 16, height + 29 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26956), { 16, 16, height + 29 },
+                        { 16, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26961, { 16, 0, height + 29 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26961), { 16, 0, height + 29 },
+                        { 16, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26966, { 0, 0, height + 29 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26966), { 0, 0, height + 29 },
+                        { 16, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1692,19 +1714,23 @@ static void compact_inverted_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26952, { 16, 0, height + 29 }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26952), { 16, 0, height + 29 },
+                        { 16, 32, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26957, { 0, 0, height + 29 }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26957), { 0, 0, height + 29 },
+                        { 16, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26962, { 0, 0, height + 29 }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26962), { 0, 0, height + 29 },
+                        { 16, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26967, { 16, 0, height + 29 }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26967), { 16, 0, height + 29 },
+                        { 16, 32, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1719,19 +1745,23 @@ static void compact_inverted_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26953, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26953), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26958, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26958), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26963, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26963), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26968, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26968), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
             }
 
@@ -1767,19 +1797,23 @@ static void compact_inverted_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26929, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26929), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26934, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26934), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26939, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26939), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26944, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26944), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
             }
 
@@ -1803,19 +1837,23 @@ static void compact_inverted_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26930, { 0, 16, height + 29 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26930), { 0, 16, height + 29 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26935, { 0, 16, height + 29 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26935), { 0, 16, height + 29 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26940, { 0, 0, height + 29 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26940), { 0, 0, height + 29 },
+                        { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26945, { 0, 0, height + 29 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26945), { 0, 0, height + 29 },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1830,19 +1868,23 @@ static void compact_inverted_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26931, { 0, 0, height + 29 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26931), { 0, 0, height + 29 },
+                        { 16, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26936, { 16, 0, height + 29 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26936), { 16, 0, height + 29 },
+                        { 16, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26941, { 16, 16, height + 29 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26941), { 16, 16, height + 29 },
+                        { 16, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26946, { 0, 16, height + 29 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26946), { 0, 16, height + 29 },
+                        { 16, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1857,19 +1899,23 @@ static void compact_inverted_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26932, { 16, 0, height + 29 }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26932), { 16, 0, height + 29 },
+                        { 16, 32, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26937, { 0, 0, height + 29 }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26937), { 0, 0, height + 29 },
+                        { 16, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26942, { 0, 0, height + 29 }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26942), { 0, 0, height + 29 },
+                        { 16, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26947, { 16, 0, height + 29 }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26947), { 16, 0, height + 29 },
+                        { 16, 32, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1884,19 +1930,23 @@ static void compact_inverted_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26933, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26933), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26938, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26938), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26943, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26943), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26948, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26948), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
             }
 
@@ -1952,23 +2002,23 @@ static void compact_inverted_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26641, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26641), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26645, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26645), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26644, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26644), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26648, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26648), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
             }
 
@@ -1988,21 +2038,23 @@ static void compact_inverted_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26642, { 0, 0, height + 29 }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26642), { 0, 0, height + 29 },
+                        { 32, 26, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26646, { 0, 0, height + 29 }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26646), { 0, 0, height + 29 },
+                        { 32, 26, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26643, { 0, 0, height + 29 }, { 32, 26, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26643), { 0, 0, height + 29 },
+                        { 32, 26, 3 }, { 0, 6, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26647, { 0, 0, height + 29 }, { 32, 26, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26647), { 0, 0, height + 29 },
+                        { 32, 26, 3 }, { 0, 6, height + 29 });
                     break;
             }
 
@@ -2030,21 +2082,23 @@ static void compact_inverted_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26643, { 0, 0, height + 29 }, { 32, 26, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26643), { 0, 0, height + 29 },
+                        { 32, 26, 3 }, { 0, 6, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26647, { 0, 0, height + 29 }, { 32, 26, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26647), { 0, 0, height + 29 },
+                        { 32, 26, 3 }, { 0, 6, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26642, { 0, 0, height + 29 }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26642), { 0, 0, height + 29 },
+                        { 32, 26, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26646, { 0, 0, height + 29 }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26646), { 0, 0, height + 29 },
+                        { 32, 26, 3 });
                     break;
             }
 
@@ -2072,23 +2126,23 @@ static void compact_inverted_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26644, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26644), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26648, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26648), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26641, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26641), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26645, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26645), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
             }
 
@@ -2123,23 +2177,23 @@ static void compact_inverted_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26649, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26649), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26653, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26653), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26652, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26652), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26656, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26656), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
             }
 
@@ -2159,21 +2213,23 @@ static void compact_inverted_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26650, { 0, 0, height + 29 }, { 32, 26, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26650), { 0, 0, height + 29 },
+                        { 32, 26, 3 }, { 0, 6, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26654, { 0, 0, height + 29 }, { 32, 26, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26654), { 0, 0, height + 29 },
+                        { 32, 26, 3 }, { 0, 6, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26651, { 0, 0, height + 29 }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26651), { 0, 0, height + 29 },
+                        { 32, 26, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26655, { 0, 0, height + 29 }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26655), { 0, 0, height + 29 },
+                        { 32, 26, 3 });
                     break;
             }
 
@@ -2201,21 +2257,23 @@ static void compact_inverted_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26651, { 0, 0, height + 29 }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26651), { 0, 0, height + 29 },
+                        { 32, 26, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26655, { 0, 0, height + 29 }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26655), { 0, 0, height + 29 },
+                        { 32, 26, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26650, { 0, 0, height + 29 }, { 32, 26, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26650), { 0, 0, height + 29 },
+                        { 32, 26, 3 }, { 0, 6, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26654, { 0, 0, height + 29 }, { 32, 26, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26654), { 0, 0, height + 29 },
+                        { 32, 26, 3 }, { 0, 6, height + 29 });
                     break;
             }
 
@@ -2243,23 +2301,23 @@ static void compact_inverted_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26652, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26652), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26656, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26656), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26649, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26649), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26653, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26653), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
             }
 
@@ -2294,23 +2352,23 @@ static void compact_inverted_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27017, { 0, 6, height + 29 }, { 32, 2, 3 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27017), { 0, 6, height + 29 },
+                        { 32, 2, 3 }, { 0, 29, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27025, { 0, 6, height + 29 }, { 32, 2, 3 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27025), { 0, 6, height + 29 },
+                        { 32, 2, 3 }, { 0, 29, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27024, { 0, 6, height + 29 }, { 32, 2, 3 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27024), { 0, 6, height + 29 },
+                        { 32, 2, 3 }, { 0, 29, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27032, { 0, 6, height + 29 }, { 32, 10, 7 },
-                        { 0, 6, height + 45 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27032), { 0, 6, height + 29 },
+                        { 32, 10, 7 }, { 0, 6, height + 45 });
                     break;
             }
 
@@ -2351,23 +2409,23 @@ static void compact_inverted_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27018, { 0, 0, height + 29 }, { 32, 2, 3 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27018), { 0, 0, height + 29 },
+                        { 32, 2, 3 }, { 0, 29, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27026, { 0, 14, height + 29 }, { 32, 2, 63 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27026), { 0, 14, height + 29 },
+                        { 32, 2, 63 }, { 0, 29, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27023, { 0, 6, height + 29 }, { 32, 2, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27023), { 0, 6, height + 29 },
+                        { 32, 2, 3 }, { 0, 0, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27031, { 0, 6, height + 29 }, { 2, 2, 3 },
-                        { 29, 20, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27031), { 0, 6, height + 29 },
+                        { 2, 2, 3 }, { 29, 20, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -2378,23 +2436,23 @@ static void compact_inverted_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27019, { 16, 0, height + 2 }, { 5, 2, 119 },
-                        { 16, 29, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27019), { 16, 0, height + 2 },
+                        { 5, 2, 119 }, { 16, 29, height + 2 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27027, { 12, 0, height + 2 }, { 32, 2, 119 },
-                        { 0, -6, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27027), { 12, 0, height + 2 },
+                        { 32, 2, 119 }, { 0, -6, height + 2 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27022, { 10, 16, height + 2 }, { 4, 2, 119 },
-                        { 10, 0, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27022), { 10, 16, height + 2 },
+                        { 4, 2, 119 }, { 10, 0, height + 2 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27030, { 16, 16, height + 2 }, { 2, 2, 119 },
-                        { 29, 29, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27030), { 16, 16, height + 2 },
+                        { 2, 2, 119 }, { 29, 29, height + 2 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2406,23 +2464,23 @@ static void compact_inverted_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27020, { 0, 0, height + 34 }, { 32, 2, 3 },
-                        { 0, 0, height - 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27020), { 0, 0, height + 34 },
+                        { 32, 2, 3 }, { 0, 0, height - 6 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27028, { 0, 0, height + 34 }, { 2, 2, 3 },
-                        { 0, 0, height - 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27028), { 0, 0, height + 34 },
+                        { 2, 2, 3 }, { 0, 0, height - 6 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27021, { 0, 16, height + 34 }, { 32, 2, 3 },
-                        { 0, 0, height - 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27021), { 0, 16, height + 34 },
+                        { 32, 2, 3 }, { 0, 0, height - 6 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27029, { 0, 16, height + 34 }, { 2, 2, 3 },
-                        { 0, 0, height - 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27029), { 0, 16, height + 34 },
+                        { 2, 2, 3 }, { 0, 0, height - 6 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2443,23 +2501,23 @@ static void compact_inverted_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27021, { 0, 16, height + 34 }, { 32, 2, 3 },
-                        { 0, 0, height - 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27021), { 0, 16, height + 34 },
+                        { 32, 2, 3 }, { 0, 0, height - 6 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27029, { 0, 16, height + 34 }, { 2, 2, 3 },
-                        { 0, 0, height - 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27029), { 0, 16, height + 34 },
+                        { 2, 2, 3 }, { 0, 0, height - 6 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27020, { 0, 0, height + 34 }, { 32, 2, 3 },
-                        { 0, 0, height - 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27020), { 0, 0, height + 34 },
+                        { 32, 2, 3 }, { 0, 0, height - 6 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27028, { 0, 0, height + 34 }, { 2, 2, 3 },
-                        { 0, 0, height - 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27028), { 0, 0, height + 34 },
+                        { 2, 2, 3 }, { 0, 0, height - 6 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2474,23 +2532,23 @@ static void compact_inverted_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27022, { 10, 16, height + 2 }, { 4, 2, 119 },
-                        { 10, 0, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27022), { 10, 16, height + 2 },
+                        { 4, 2, 119 }, { 10, 0, height + 2 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27030, { 16, 16, height + 2 }, { 2, 2, 119 },
-                        { 29, 29, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27030), { 16, 16, height + 2 },
+                        { 2, 2, 119 }, { 29, 29, height + 2 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27019, { 16, 0, height + 2 }, { 5, 2, 119 },
-                        { 16, 29, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27019), { 16, 0, height + 2 },
+                        { 5, 2, 119 }, { 16, 29, height + 2 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27027, { 12, 0, height + 2 }, { 32, 2, 119 },
-                        { 0, -6, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27027), { 12, 0, height + 2 },
+                        { 32, 2, 119 }, { 0, -6, height + 2 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2502,23 +2560,23 @@ static void compact_inverted_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27023, { 0, 6, height + 29 }, { 32, 2, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27023), { 0, 6, height + 29 },
+                        { 32, 2, 3 }, { 0, 0, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27031, { 0, 6, height + 29 }, { 2, 2, 3 },
-                        { 29, 20, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27031), { 0, 6, height + 29 },
+                        { 2, 2, 3 }, { 29, 20, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27018, { 0, 0, height + 29 }, { 32, 2, 3 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27018), { 0, 0, height + 29 },
+                        { 32, 2, 3 }, { 0, 29, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27026, { 0, 14, height + 29 }, { 32, 2, 63 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27026), { 0, 14, height + 29 },
+                        { 32, 2, 63 }, { 0, 29, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -2529,23 +2587,23 @@ static void compact_inverted_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27024, { 0, 6, height + 29 }, { 32, 2, 3 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27024), { 0, 6, height + 29 },
+                        { 32, 2, 3 }, { 0, 29, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27032, { 0, 6, height + 29 }, { 32, 10, 7 },
-                        { 0, 6, height + 45 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27032), { 0, 6, height + 29 },
+                        { 32, 10, 7 }, { 0, 6, height + 45 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27017, { 0, 6, height + 29 }, { 32, 2, 3 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27017), { 0, 6, height + 29 },
+                        { 32, 2, 3 }, { 0, 29, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27025, { 0, 6, height + 29 }, { 32, 2, 3 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27025), { 0, 6, height + 29 },
+                        { 32, 2, 3 }, { 0, 29, height + 29 });
                     break;
             }
 
@@ -2601,23 +2659,23 @@ static void compact_inverted_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27048, { 0, 6, height + 29 }, { 32, 10, 7 },
-                        { 0, 6, height + 45 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27048), { 0, 6, height + 29 },
+                        { 32, 10, 7 }, { 0, 6, height + 45 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27040, { 0, 6, height + 29 }, { 32, 2, 3 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27040), { 0, 6, height + 29 },
+                        { 32, 2, 3 }, { 0, 29, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27041, { 0, 6, height + 29 }, { 32, 2, 3 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27041), { 0, 6, height + 29 },
+                        { 32, 2, 3 }, { 0, 29, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27033, { 0, 6, height + 29 }, { 32, 2, 3 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27033), { 0, 6, height + 29 },
+                        { 32, 2, 3 }, { 0, 29, height + 29 });
                     break;
             }
 
@@ -2658,23 +2716,23 @@ static void compact_inverted_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27047, { 0, 6, height + 29 }, { 2, 2, 3 },
-                        { 29, 20, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27047), { 0, 6, height + 29 },
+                        { 2, 2, 3 }, { 29, 20, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27039, { 0, 6, height + 29 }, { 32, 2, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27039), { 0, 6, height + 29 },
+                        { 32, 2, 3 }, { 0, 0, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27042, { 0, 14, height + 29 }, { 32, 2, 63 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27042), { 0, 14, height + 29 },
+                        { 32, 2, 63 }, { 0, 29, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27034, { 0, 0, height + 29 }, { 32, 2, 3 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27034), { 0, 0, height + 29 },
+                        { 32, 2, 3 }, { 0, 29, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -2685,23 +2743,23 @@ static void compact_inverted_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27046, { 16, 16, height + 2 }, { 2, 2, 119 },
-                        { 29, 29, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27046), { 16, 16, height + 2 },
+                        { 2, 2, 119 }, { 29, 29, height + 2 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27038, { 10, 16, height + 2 }, { 4, 2, 119 },
-                        { 10, 0, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27038), { 10, 16, height + 2 },
+                        { 4, 2, 119 }, { 10, 0, height + 2 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27043, { 12, 0, height + 2 }, { 32, 2, 119 },
-                        { 0, -6, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27043), { 12, 0, height + 2 },
+                        { 32, 2, 119 }, { 0, -6, height + 2 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27035, { 16, 0, height + 2 }, { 5, 2, 119 },
-                        { 16, 29, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27035), { 16, 0, height + 2 },
+                        { 5, 2, 119 }, { 16, 29, height + 2 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2713,23 +2771,23 @@ static void compact_inverted_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27045, { 0, 16, height + 34 }, { 2, 2, 3 },
-                        { 0, 0, height - 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27045), { 0, 16, height + 34 },
+                        { 2, 2, 3 }, { 0, 0, height - 6 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27037, { 0, 16, height + 34 }, { 32, 2, 3 },
-                        { 0, 0, height - 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27037), { 0, 16, height + 34 },
+                        { 32, 2, 3 }, { 0, 0, height - 6 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27044, { 0, 0, height + 34 }, { 2, 2, 3 },
-                        { 0, 0, height - 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27044), { 0, 0, height + 34 },
+                        { 2, 2, 3 }, { 0, 0, height - 6 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27036, { 0, 0, height + 34 }, { 32, 2, 3 },
-                        { 0, 0, height - 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27036), { 0, 0, height + 34 },
+                        { 32, 2, 3 }, { 0, 0, height - 6 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2750,23 +2808,23 @@ static void compact_inverted_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27044, { 0, 0, height + 34 }, { 2, 2, 3 },
-                        { 0, 0, height - 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27044), { 0, 0, height + 34 },
+                        { 2, 2, 3 }, { 0, 0, height - 6 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27036, { 0, 0, height + 34 }, { 32, 2, 3 },
-                        { 0, 0, height - 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27036), { 0, 0, height + 34 },
+                        { 32, 2, 3 }, { 0, 0, height - 6 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27045, { 0, 16, height + 34 }, { 2, 2, 3 },
-                        { 0, 0, height - 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27045), { 0, 16, height + 34 },
+                        { 2, 2, 3 }, { 0, 0, height - 6 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27037, { 0, 16, height + 34 }, { 32, 2, 3 },
-                        { 0, 0, height - 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27037), { 0, 16, height + 34 },
+                        { 32, 2, 3 }, { 0, 0, height - 6 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2781,23 +2839,23 @@ static void compact_inverted_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27043, { 12, 0, height + 2 }, { 32, 2, 119 },
-                        { 0, -6, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27043), { 12, 0, height + 2 },
+                        { 32, 2, 119 }, { 0, -6, height + 2 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27035, { 16, 0, height + 2 }, { 5, 2, 119 },
-                        { 16, 29, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27035), { 16, 0, height + 2 },
+                        { 5, 2, 119 }, { 16, 29, height + 2 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27046, { 16, 16, height + 2 }, { 2, 2, 119 },
-                        { 29, 29, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27046), { 16, 16, height + 2 },
+                        { 2, 2, 119 }, { 29, 29, height + 2 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27038, { 10, 16, height + 2 }, { 4, 2, 119 },
-                        { 10, 0, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27038), { 10, 16, height + 2 },
+                        { 4, 2, 119 }, { 10, 0, height + 2 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2809,23 +2867,23 @@ static void compact_inverted_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27042, { 0, 14, height + 29 }, { 32, 2, 63 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27042), { 0, 14, height + 29 },
+                        { 32, 2, 63 }, { 0, 29, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27034, { 0, 0, height + 29 }, { 32, 2, 3 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27034), { 0, 0, height + 29 },
+                        { 32, 2, 3 }, { 0, 29, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27047, { 0, 6, height + 29 }, { 2, 2, 3 },
-                        { 29, 20, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27047), { 0, 6, height + 29 },
+                        { 2, 2, 3 }, { 29, 20, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27039, { 0, 6, height + 29 }, { 32, 2, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27039), { 0, 6, height + 29 },
+                        { 32, 2, 3 }, { 0, 0, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -2836,23 +2894,23 @@ static void compact_inverted_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27041, { 0, 6, height + 29 }, { 32, 2, 3 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27041), { 0, 6, height + 29 },
+                        { 32, 2, 3 }, { 0, 29, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27033, { 0, 6, height + 29 }, { 32, 2, 3 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27033), { 0, 6, height + 29 },
+                        { 32, 2, 3 }, { 0, 29, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27048, { 0, 6, height + 29 }, { 32, 10, 7 },
-                        { 0, 6, height + 45 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27048), { 0, 6, height + 29 },
+                        { 32, 10, 7 }, { 0, 6, height + 45 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27040, { 0, 6, height + 29 }, { 32, 2, 3 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27040), { 0, 6, height + 29 },
+                        { 32, 2, 3 }, { 0, 29, height + 29 });
                     break;
             }
 
@@ -2908,23 +2966,23 @@ static void compact_inverted_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26710, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26710), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26713, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26713), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26716, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26716), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26707, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26707), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
             }
 
@@ -2948,22 +3006,23 @@ static void compact_inverted_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26709, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26709), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 0, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26712, { 0, 0, height + 29 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26712), { 0, 0, height + 29 },
+                        { 16, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26715, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26715), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 16, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26706, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26706), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 16, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2975,23 +3034,23 @@ static void compact_inverted_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26708, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26708), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26711, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26711), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26714, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26714), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26705, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26705), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 29 });
                     break;
             }
 
@@ -3036,23 +3095,23 @@ static void compact_inverted_rc_track_left_quarter_turn_3_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26722, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26722), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26725, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26725), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26728, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26728), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26719, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26719), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
             }
 
@@ -3076,23 +3135,23 @@ static void compact_inverted_rc_track_left_quarter_turn_3_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26721, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26721), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 0, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26724, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26724), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 0, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26727, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26727), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 16, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26718, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26718), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 16, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3104,23 +3163,23 @@ static void compact_inverted_rc_track_left_quarter_turn_3_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26720, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26720), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26723, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26723), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26726, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26726), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26717, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26717), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 29 });
                     break;
             }
 
@@ -3165,19 +3224,23 @@ static void compact_inverted_rc_track_left_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26924, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26924), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26926, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26926), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26928, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26928), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26922, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26922), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
             }
 
@@ -3204,19 +3267,23 @@ static void compact_inverted_rc_track_left_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26923, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26923), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26925, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26925), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26927, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26927), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26921, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26921), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
             }
 
@@ -3252,19 +3319,23 @@ static void compact_inverted_rc_track_right_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26913, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26913), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26915, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26915), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26917, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26917), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26919, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26919), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
             }
 
@@ -3291,19 +3362,23 @@ static void compact_inverted_rc_track_right_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26914, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26914), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26916, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26916), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26918, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26918), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26920, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26920), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
             }
 
@@ -3359,19 +3434,23 @@ static void compact_inverted_rc_track_left_twist_down_to_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26993, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26993), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26999, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26999), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26998, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26998), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27004, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27004), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
             }
 
@@ -3394,19 +3473,23 @@ static void compact_inverted_rc_track_left_twist_down_to_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26994, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26994), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27000, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27000), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26997, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26997), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27003, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27003), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3421,19 +3504,23 @@ static void compact_inverted_rc_track_left_twist_down_to_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26995, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26995), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27001, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27001), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26996, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26996), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27002, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27002), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -3469,19 +3556,23 @@ static void compact_inverted_rc_track_right_twist_down_to_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27005, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27005), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27011, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27011), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27010, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27010), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27016, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27016), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
             }
 
@@ -3504,19 +3595,23 @@ static void compact_inverted_rc_track_right_twist_down_to_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27006, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27006), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27012, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27012), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27009, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27009), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27015, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27015), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3531,19 +3626,23 @@ static void compact_inverted_rc_track_right_twist_down_to_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27007, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27007), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27013, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27013), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27008, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27008), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27014, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27014), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -3579,19 +3678,23 @@ static void compact_inverted_rc_track_left_twist_up_to_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26996, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26996), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27002, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27002), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26995, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26995), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27001, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27001), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -3612,19 +3715,23 @@ static void compact_inverted_rc_track_left_twist_up_to_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26997, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26997), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27003, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27003), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26994, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26994), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27000, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27000), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3639,19 +3746,23 @@ static void compact_inverted_rc_track_left_twist_up_to_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26998, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26998), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27004, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27004), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26993, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26993), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26999, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26999), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
             }
 
@@ -3689,19 +3800,23 @@ static void compact_inverted_rc_track_right_twist_up_to_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27008, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27008), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27014, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27014), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27007, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27007), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27013, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27013), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -3722,19 +3837,23 @@ static void compact_inverted_rc_track_right_twist_up_to_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27009, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27009), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27015, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27015), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27006, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27006), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27012, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27012), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3749,19 +3868,23 @@ static void compact_inverted_rc_track_right_twist_up_to_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27010, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27010), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27016, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27016), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27005, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27005), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27011, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27011), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
             }
 
@@ -3799,23 +3922,23 @@ static void compact_inverted_rc_track_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27073, { 0, 6, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 45 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27073), { 0, 6, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 45 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27081, { 0, 6, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 45 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27081), { 0, 6, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 45 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27080, { 0, 6, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 45 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27080), { 0, 6, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 45 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27088, { 0, 6, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 45 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27088), { 0, 6, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 45 });
                     break;
             }
 
@@ -3852,23 +3975,23 @@ static void compact_inverted_rc_track_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27074, { 0, 0, height + 29 }, { 32, 2, 3 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27074), { 0, 0, height + 29 },
+                        { 32, 2, 3 }, { 0, 29, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27082, { 0, 14, height + 29 }, { 32, 2, 63 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27082), { 0, 14, height + 29 },
+                        { 32, 2, 63 }, { 0, 29, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27079, { 0, 6, height + 29 }, { 32, 2, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27079), { 0, 6, height + 29 },
+                        { 32, 2, 3 }, { 0, 0, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27087, { 0, 6, height + 29 }, { 2, 2, 3 },
-                        { 29, 20, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27087), { 0, 6, height + 29 },
+                        { 2, 2, 3 }, { 29, 20, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -3879,23 +4002,23 @@ static void compact_inverted_rc_track_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27075, { 16, 0, height + 2 }, { 5, 2, 119 },
-                        { 16, 29, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27075), { 16, 0, height + 2 },
+                        { 5, 2, 119 }, { 16, 29, height + 2 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27083, { 12, 0, height + 2 }, { 32, 2, 119 },
-                        { 0, -6, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27083), { 12, 0, height + 2 },
+                        { 32, 2, 119 }, { 0, -6, height + 2 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27078, { 10, 16, height + 2 }, { 4, 2, 119 },
-                        { 10, 0, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27078), { 10, 16, height + 2 },
+                        { 4, 2, 119 }, { 10, 0, height + 2 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27086, { 16, 16, height + 2 }, { 2, 2, 119 },
-                        { 29, 29, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27086), { 16, 16, height + 2 },
+                        { 2, 2, 119 }, { 29, 29, height + 2 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3910,23 +4033,23 @@ static void compact_inverted_rc_track_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27076, { 0, 0, height + 34 }, { 32, 20, 3 },
-                        { 0, 6, height + 34 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27076), { 0, 0, height + 34 },
+                        { 32, 20, 3 }, { 0, 6, height + 34 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27084, { 0, 0, height + 34 }, { 2, 2, 3 },
-                        { 0, 0, height - 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27084), { 0, 0, height + 34 },
+                        { 2, 2, 3 }, { 0, 0, height - 6 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27077, { 0, 16, height + 34 }, { 32, 2, 3 },
-                        { 0, 0, height - 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27077), { 0, 16, height + 34 },
+                        { 32, 2, 3 }, { 0, 0, height - 6 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27085, { 0, 16, height + 34 }, { 32, 20, 3 },
-                        { 0, 6, height + 34 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27085), { 0, 16, height + 34 },
+                        { 32, 20, 3 }, { 0, 6, height + 34 });
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -3960,23 +4083,23 @@ static void compact_inverted_rc_track_left_corkscrew_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27049, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 33 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27049), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 33 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27052, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 33 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27052), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 33 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27055, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 33 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27055), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 33 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27058, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 33 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27058), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 33 });
                     break;
             }
 
@@ -3999,23 +4122,23 @@ static void compact_inverted_rc_track_left_corkscrew_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27050, { 0, 0, height + 14 }, { 20, 20, 3 },
-                        { 6, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27050), { 0, 0, height + 14 },
+                        { 20, 20, 3 }, { 6, 6, height + 24 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27053, { 0, 0, height + 14 }, { 20, 20, 3 },
-                        { 6, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27053), { 0, 0, height + 14 },
+                        { 20, 20, 3 }, { 6, 6, height + 24 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27056, { 0, 0, height + 14 }, { 20, 20, 3 },
-                        { 6, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27056), { 0, 0, height + 14 },
+                        { 20, 20, 3 }, { 6, 6, height + 24 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27059, { 0, 0, height + 14 }, { 20, 20, 3 },
-                        { 6, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27059), { 0, 0, height + 14 },
+                        { 20, 20, 3 }, { 6, 6, height + 24 });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -4026,23 +4149,23 @@ static void compact_inverted_rc_track_left_corkscrew_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27051, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 39 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27051), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 39 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27054, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 39 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27054), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 39 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27057, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 39 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27057), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 39 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27060, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 39 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27060), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 39 });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -4078,23 +4201,23 @@ static void compact_inverted_rc_track_right_corkscrew_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27061, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 33 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27061), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 33 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27064, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 33 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27064), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 33 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27067, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 33 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27067), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 33 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27070, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 33 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27070), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 33 });
                     break;
             }
 
@@ -4117,23 +4240,23 @@ static void compact_inverted_rc_track_right_corkscrew_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27062, { 0, 0, height + 14 }, { 20, 20, 3 },
-                        { 6, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27062), { 0, 0, height + 14 },
+                        { 20, 20, 3 }, { 6, 6, height + 24 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27065, { 0, 0, height + 14 }, { 20, 20, 3 },
-                        { 6, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27065), { 0, 0, height + 14 },
+                        { 20, 20, 3 }, { 6, 6, height + 24 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27068, { 0, 0, height + 14 }, { 20, 20, 3 },
-                        { 6, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27068), { 0, 0, height + 14 },
+                        { 20, 20, 3 }, { 6, 6, height + 24 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27071, { 0, 0, height + 14 }, { 20, 20, 3 },
-                        { 6, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27071), { 0, 0, height + 14 },
+                        { 20, 20, 3 }, { 6, 6, height + 24 });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -4144,23 +4267,23 @@ static void compact_inverted_rc_track_right_corkscrew_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27063, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 39 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27063), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 39 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27066, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 39 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27066), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 39 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27069, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 39 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27069), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 39 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27072, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 39 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27072), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 39 });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -4209,34 +4332,34 @@ static void compact_inverted_rc_track_left_quarter_turn_1_60_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26910, { 0, 0, height + 5 }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26910), { 0, 0, height + 5 }, { 28, 28, 3 },
                 { 2, 2, height + 5 });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26906, { 0, 0, height + 5 }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26906), { 0, 0, height + 5 }, { 28, 28, 1 },
                 { 2, 2, height + 104 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26911, { 0, 0, height + 5 }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26911), { 0, 0, height + 5 }, { 28, 28, 3 },
                 { 2, 2, height + 5 });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26907, { 0, 0, height + 5 }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26907), { 0, 0, height + 5 }, { 28, 28, 1 },
                 { 2, 2, height + 104 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26912, { 0, 0, height + 5 }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26912), { 0, 0, height + 5 }, { 28, 28, 3 },
                 { 2, 2, height + 5 });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26908, { 0, 0, height + 5 }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26908), { 0, 0, height + 5 }, { 28, 28, 1 },
                 { 2, 2, height + 104 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26909, { 0, 0, height + 5 }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26909), { 0, 0, height + 5 }, { 28, 28, 3 },
                 { 2, 2, height + 5 });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26905, { 0, 0, height + 5 }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26905), { 0, 0, height + 5 }, { 28, 28, 1 },
                 { 2, 2, height + 104 });
             break;
     }
@@ -4254,34 +4377,34 @@ static void compact_inverted_rc_track_right_quarter_turn_1_60_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26901, { 0, 0, height + 5 }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26901), { 0, 0, height + 5 }, { 28, 28, 3 },
                 { 2, 2, height + 5 });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26897, { 0, 0, height + 5 }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26897), { 0, 0, height + 5 }, { 28, 28, 1 },
                 { 2, 2, height + 104 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26902, { 0, 0, height + 5 }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26902), { 0, 0, height + 5 }, { 28, 28, 3 },
                 { 2, 2, height + 5 });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26898, { 0, 0, height + 5 }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26898), { 0, 0, height + 5 }, { 28, 28, 1 },
                 { 2, 2, height + 104 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26903, { 0, 0, height + 5 }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26903), { 0, 0, height + 5 }, { 28, 28, 3 },
                 { 2, 2, height + 5 });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26899, { 0, 0, height + 5 }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26899), { 0, 0, height + 5 }, { 28, 28, 1 },
                 { 2, 2, height + 104 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26904, { 0, 0, height + 5 }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26904), { 0, 0, height + 5 }, { 28, 28, 3 },
                 { 2, 2, height + 5 });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26900, { 0, 0, height + 5 }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26900), { 0, 0, height + 5 }, { 28, 28, 1 },
                 { 2, 2, height + 104 });
             break;
     }
@@ -4319,13 +4442,13 @@ static void compact_inverted_rc_track_brakes(
         case 0:
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26559, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26559), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
         case 1:
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26560, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26560), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
     }
@@ -4354,23 +4477,23 @@ static void compact_inverted_rc_track_left_quarter_banked_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27118, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27118), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 35 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27123, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27123), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 35 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27128, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27128), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 35 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27113, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27113), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 35 });
                     break;
             }
 
@@ -4394,23 +4517,23 @@ static void compact_inverted_rc_track_left_quarter_banked_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27117, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27117), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 0, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27122, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27122), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 0, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27127, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27127), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27112, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27112), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 43 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4425,23 +4548,23 @@ static void compact_inverted_rc_track_left_quarter_banked_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27116, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27116), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 16, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27121, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27121), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 16, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27126, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27126), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 0, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27111, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27111), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 0, height + 43 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4456,23 +4579,23 @@ static void compact_inverted_rc_track_left_quarter_banked_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27115, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 16, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27115), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 16, 0, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27120, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27120), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 0, 0, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27125, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27125), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 0, 0, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27110, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 16, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27110), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 16, 0, height + 43 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4487,23 +4610,23 @@ static void compact_inverted_rc_track_left_quarter_banked_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27114, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27114), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27119, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27119), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27124, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27124), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27109, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27109), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 43 });
                     break;
             }
 
@@ -4539,23 +4662,23 @@ static void compact_inverted_rc_track_right_quarter_banked_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27089, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27089), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 35 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27094, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27094), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 35 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27099, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27099), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 35 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27104, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27104), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 35 });
                     break;
             }
 
@@ -4579,23 +4702,23 @@ static void compact_inverted_rc_track_right_quarter_banked_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27090, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27090), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27095, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27095), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27100, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27100), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 0, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27105, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27105), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 0, height + 43 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4610,23 +4733,23 @@ static void compact_inverted_rc_track_right_quarter_banked_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27091, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27091), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 0, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27096, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27096), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 0, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27101, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27101), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 16, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27106, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27106), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 16, height + 43 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4641,23 +4764,23 @@ static void compact_inverted_rc_track_right_quarter_banked_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27092, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 16, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27092), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 16, 0, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27097, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27097), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 0, 0, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27102, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27102), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 0, 0, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27107, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 16, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27107), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 16, 0, height + 43 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4672,23 +4795,23 @@ static void compact_inverted_rc_track_right_quarter_banked_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27093, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27093), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27098, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27098), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27103, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27103), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27108, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27108), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 43 });
                     break;
             }
 
@@ -4724,23 +4847,23 @@ static void compact_inverted_rc_track_left_quarter_banked_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27098, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27098), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27103, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27103), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27108, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27108), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27093, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27093), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 43 });
                     break;
             }
 
@@ -4764,23 +4887,23 @@ static void compact_inverted_rc_track_left_quarter_banked_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27097, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27097), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 0, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27102, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27102), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 0, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27107, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27107), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27092, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27092), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 43 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4795,23 +4918,23 @@ static void compact_inverted_rc_track_left_quarter_banked_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27096, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27096), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 16, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27101, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27101), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 16, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27106, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27106), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 0, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27091, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27091), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 0, height + 43 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4826,23 +4949,23 @@ static void compact_inverted_rc_track_left_quarter_banked_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27095, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 16, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27095), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 16, 0, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27100, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27100), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 0, 0, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27105, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27105), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 0, 0, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27090, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 16, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27090), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 16, 0, height + 43 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4857,23 +4980,23 @@ static void compact_inverted_rc_track_left_quarter_banked_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27094, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27094), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 35 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27099, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27099), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 35 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27104, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27104), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 35 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27089, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27089), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 35 });
                     break;
             }
 
@@ -4909,23 +5032,23 @@ static void compact_inverted_rc_track_right_quarter_banked_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27109, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27109), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27114, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27114), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27119, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27119), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27124, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27124), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 43 });
                     break;
             }
 
@@ -4949,23 +5072,23 @@ static void compact_inverted_rc_track_right_quarter_banked_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27110, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27110), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27115, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27115), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27120, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27120), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 0, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27125, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27125), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 0, height + 43 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4980,23 +5103,23 @@ static void compact_inverted_rc_track_right_quarter_banked_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27111, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27111), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 0, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27116, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27116), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 0, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27121, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27121), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 16, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27126, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27126), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 16, height + 43 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5011,23 +5134,23 @@ static void compact_inverted_rc_track_right_quarter_banked_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27112, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 16, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27112), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 16, 0, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27117, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27117), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 0, 0, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27122, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27122), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 0, 0, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27127, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 16, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27127), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 16, 0, height + 43 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5042,23 +5165,23 @@ static void compact_inverted_rc_track_right_quarter_banked_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27113, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27113), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 35 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27118, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27118), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 35 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27123, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27123), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 35 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27128, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27128), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 35 });
                     break;
             }
 
@@ -5091,46 +5214,46 @@ static void compact_inverted_rc_track_on_ride_photo(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
             metal_a_supports_paint_setup(
                 session, METAL_SUPPORTS_TUBES_INVERTED, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(
                 session, METAL_SUPPORTS_TUBES_INVERTED, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26555, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26555), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
             metal_a_supports_paint_setup(
                 session, METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(
                 session, METAL_SUPPORTS_TUBES_INVERTED, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26556, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26556), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
             metal_a_supports_paint_setup(
                 session, METAL_SUPPORTS_TUBES_INVERTED, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(
                 session, METAL_SUPPORTS_TUBES_INVERTED, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26555, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26555), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
             metal_a_supports_paint_setup(
                 session, METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(
                 session, METAL_SUPPORTS_TUBES_INVERTED, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26556, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26556), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
     }
@@ -5154,22 +5277,22 @@ static void compact_inverted_rc_track_90_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26609, { 0, 0, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26609), { 0, 0, height + 29 },
                             { 32, 20, 3 }, { 0, 6, height + 61 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26610, { 0, 0, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26610), { 0, 0, height + 29 },
                             { 32, 2, 31 }, { 0, 4, height + 11 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26611, { 0, 0, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26611), { 0, 0, height + 29 },
                             { 32, 2, 31 }, { 0, 4, height + 11 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26612, { 0, 0, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26612), { 0, 0, height + 29 },
                             { 32, 20, 3 }, { 0, 6, height + 61 });
                         break;
                 }
@@ -5180,22 +5303,22 @@ static void compact_inverted_rc_track_90_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26605, { 0, 0, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26605), { 0, 0, height + 29 },
                             { 32, 20, 3 }, { 0, 6, height + 61 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26606, { 0, 0, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26606), { 0, 0, height + 29 },
                             { 32, 2, 31 }, { 0, 4, height + 11 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26607, { 0, 0, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26607), { 0, 0, height + 29 },
                             { 32, 2, 31 }, { 0, 4, height + 11 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26608, { 0, 0, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26608), { 0, 0, height + 29 },
                             { 32, 20, 3 }, { 0, 6, height + 61 });
                         break;
                 }
@@ -5232,22 +5355,22 @@ static void compact_inverted_rc_track_60_deg_up_to_90_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26597, { 0, 0, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26597), { 0, 0, height + 29 },
                             { 32, 20, 3 }, { 0, 6, height + 85 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26598, { 0, 0, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26598), { 0, 0, height + 29 },
                             { 32, 2, 55 }, { 0, 4, height + 11 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26599, { 0, 0, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26599), { 0, 0, height + 29 },
                             { 32, 2, 55 }, { 0, 4, height + 11 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26600, { 0, 0, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26600), { 0, 0, height + 29 },
                             { 32, 20, 3 }, { 0, 6, height + 85 });
                         break;
                 }
@@ -5258,22 +5381,22 @@ static void compact_inverted_rc_track_60_deg_up_to_90_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26589, { 0, 0, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26589), { 0, 0, height + 29 },
                             { 32, 20, 3 }, { 0, 6, height + 85 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26590, { 0, 0, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26590), { 0, 0, height + 29 },
                             { 32, 2, 55 }, { 0, 4, height + 11 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26591, { 0, 0, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26591), { 0, 0, height + 29 },
                             { 32, 2, 55 }, { 0, 4, height + 11 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26592, { 0, 0, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26592), { 0, 0, height + 29 },
                             { 32, 20, 3 }, { 0, 6, height + 85 });
                         break;
                 }
@@ -5311,23 +5434,23 @@ static void compact_inverted_rc_track_90_deg_up_to_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26601, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 85 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26601), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 85 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26602, { 0, 0, height + 29 }, { 32, 2, 55 },
-                    { 0, 4, height + 11 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26602), { 0, 0, height + 29 },
+                    { 32, 2, 55 }, { 0, 4, height + 11 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26603, { 0, 0, height + 29 }, { 32, 2, 55 },
-                    { 0, 4, height + 11 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26603), { 0, 0, height + 29 },
+                    { 32, 2, 55 }, { 0, 4, height + 11 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26604, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 85 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26604), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 85 });
                 break;
         }
     }
@@ -5337,23 +5460,23 @@ static void compact_inverted_rc_track_90_deg_up_to_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26593, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 85 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26593), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 85 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26594, { 0, 0, height + 29 }, { 32, 2, 55 },
-                    { 0, 4, height + 11 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26594), { 0, 0, height + 29 },
+                    { 32, 2, 55 }, { 0, 4, height + 11 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26595, { 0, 0, height + 29 }, { 32, 2, 55 },
-                    { 0, 4, height + 11 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26595), { 0, 0, height + 29 },
+                    { 32, 2, 55 }, { 0, 4, height + 11 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26596, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 85 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26596), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 85 });
                 break;
         }
     }
@@ -5385,22 +5508,22 @@ static void compact_inverted_rc_track_60_deg_down_to_90_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26603, { 0, 0, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26603), { 0, 0, height + 29 },
                             { 32, 2, 55 }, { 0, 4, height + 11 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26604, { 0, 0, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26604), { 0, 0, height + 29 },
                             { 32, 20, 3 }, { 0, 6, height + 85 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26601, { 0, 0, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26601), { 0, 0, height + 29 },
                             { 32, 20, 3 }, { 0, 6, height + 85 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26602, { 0, 0, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26602), { 0, 0, height + 29 },
                             { 32, 2, 55 }, { 0, 4, height + 11 });
                         break;
                 }
@@ -5411,22 +5534,22 @@ static void compact_inverted_rc_track_60_deg_down_to_90_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26595, { 0, 0, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26595), { 0, 0, height + 29 },
                             { 32, 2, 55 }, { 0, 4, height + 11 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26596, { 0, 0, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26596), { 0, 0, height + 29 },
                             { 32, 20, 3 }, { 0, 6, height + 85 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26593, { 0, 0, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26593), { 0, 0, height + 29 },
                             { 32, 20, 3 }, { 0, 6, height + 85 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26594, { 0, 0, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26594), { 0, 0, height + 29 },
                             { 32, 2, 55 }, { 0, 4, height + 11 });
                         break;
                 }
@@ -5456,23 +5579,23 @@ static void compact_inverted_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26765, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26765), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26769, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26769), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26773, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26773), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26777, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26777), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
             }
 
@@ -5492,23 +5615,23 @@ static void compact_inverted_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26766, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26766), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 0, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26770, { 0, 0, height + 29 }, { 34, 16, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26770), { 0, 0, height + 29 },
+                        { 34, 16, 3 }, { 0, 0, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26774, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26774), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26778, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26778), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5523,23 +5646,23 @@ static void compact_inverted_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26767, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26767), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 16, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26771, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26771), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 16, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26775, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26775), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 0, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26779, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26779), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 0, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5557,23 +5680,23 @@ static void compact_inverted_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26768, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26768), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 16, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26772, { 0, 0, height + 29 }, { 16, 18, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26772), { 0, 0, height + 29 },
+                        { 16, 18, 3 }, { 0, 16, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26776, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26776), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 0, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26780, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26780), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 0, height + 29 });
                     break;
             }
 
@@ -5619,23 +5742,23 @@ static void compact_inverted_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26749, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26749), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26753, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26753), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26757, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26757), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26761, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26761), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
             }
 
@@ -5655,23 +5778,23 @@ static void compact_inverted_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26750, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26750), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26754, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26754), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26758, { 0, 0, height + 29 }, { 34, 16, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26758), { 0, 0, height + 29 },
+                        { 34, 16, 3 }, { 0, 0, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26762, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26762), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 0, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5686,23 +5809,23 @@ static void compact_inverted_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26751, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26751), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 0, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26755, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26755), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 0, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26759, { 0, 0, height + 29 }, { 28, 28, 3 },
-                        { 4, 4, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26759), { 0, 0, height + 29 },
+                        { 28, 28, 3 }, { 4, 4, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26763, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26763), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 16, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5720,23 +5843,23 @@ static void compact_inverted_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26752, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26752), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 0, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26756, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26756), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 0, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26760, { 0, 0, height + 29 }, { 16, 18, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26760), { 0, 0, height + 29 },
+                        { 16, 18, 3 }, { 0, 16, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26764, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26764), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 16, height + 29 });
                     break;
             }
 
@@ -5800,23 +5923,23 @@ static void compact_inverted_rc_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26853, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26853), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26857, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26857), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26861, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26861), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26865, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26865), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
             }
 
@@ -5836,23 +5959,23 @@ static void compact_inverted_rc_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26854, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26854), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 0, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26858, { 0, 0, height + 29 }, { 34, 16, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26858), { 0, 0, height + 29 },
+                        { 34, 16, 3 }, { 0, 0, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26862, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26862), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26866, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26866), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5867,23 +5990,23 @@ static void compact_inverted_rc_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26855, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26855), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 16, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26859, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26859), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 16, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26863, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26863), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 0, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26867, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26867), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 0, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5901,23 +6024,23 @@ static void compact_inverted_rc_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26856, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26856), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 16, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26860, { 0, 0, height + 29 }, { 16, 18, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26860), { 0, 0, height + 29 },
+                        { 16, 18, 3 }, { 0, 16, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26864, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26864), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 0, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26868, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26868), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 0, height + 29 });
                     break;
             }
 
@@ -5963,23 +6086,23 @@ static void compact_inverted_rc_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26837, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26837), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26841, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26841), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26845, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26845), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26849, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26849), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
             }
 
@@ -5999,23 +6122,23 @@ static void compact_inverted_rc_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26838, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26838), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26842, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26842), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26846, { 0, 0, height + 29 }, { 34, 16, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26846), { 0, 0, height + 29 },
+                        { 34, 16, 3 }, { 0, 0, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26850, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26850), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 0, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6030,23 +6153,23 @@ static void compact_inverted_rc_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26839, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26839), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 0, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26843, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26843), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 0, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26847, { 0, 0, height + 29 }, { 28, 28, 3 },
-                        { 4, 4, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26847), { 0, 0, height + 29 },
+                        { 28, 28, 3 }, { 4, 4, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26851, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26851), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 16, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6064,23 +6187,23 @@ static void compact_inverted_rc_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26840, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26840), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 0, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26844, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26844), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 0, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26848, { 0, 0, height + 29 }, { 16, 18, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26848), { 0, 0, height + 29 },
+                        { 16, 18, 3 }, { 0, 16, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26852, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26852), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 16, height + 29 });
                     break;
             }
 
@@ -6147,7 +6270,7 @@ static void compact_inverted_rc_track_diag_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26812, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26812), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 29 });
                         break;
                 }
@@ -6158,7 +6281,7 @@ static void compact_inverted_rc_track_diag_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26784, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26784), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 29 });
                         break;
                 }
@@ -6174,7 +6297,7 @@ static void compact_inverted_rc_track_diag_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26809, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26809), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 29 });
                         break;
                 }
@@ -6185,7 +6308,7 @@ static void compact_inverted_rc_track_diag_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26781, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26781), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 29 });
                         break;
                 }
@@ -6201,7 +6324,7 @@ static void compact_inverted_rc_track_diag_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26811, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26811), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 29 });
                         break;
                 }
@@ -6212,7 +6335,7 @@ static void compact_inverted_rc_track_diag_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26783, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26783), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 29 });
                         break;
                 }
@@ -6228,7 +6351,7 @@ static void compact_inverted_rc_track_diag_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26810, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26810), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 29 });
                         break;
                 }
@@ -6239,7 +6362,7 @@ static void compact_inverted_rc_track_diag_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26782, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26782), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 29 });
                         break;
                 }
@@ -6286,7 +6409,7 @@ static void compact_inverted_rc_track_diag_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26824, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26824), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -6297,7 +6420,7 @@ static void compact_inverted_rc_track_diag_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26796, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26796), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -6313,7 +6436,7 @@ static void compact_inverted_rc_track_diag_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26821, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26821), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -6324,7 +6447,7 @@ static void compact_inverted_rc_track_diag_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26793, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26793), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -6340,7 +6463,7 @@ static void compact_inverted_rc_track_diag_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26823, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26823), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -6351,7 +6474,7 @@ static void compact_inverted_rc_track_diag_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26795, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26795), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -6367,7 +6490,7 @@ static void compact_inverted_rc_track_diag_25_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26822, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26822), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -6378,7 +6501,7 @@ static void compact_inverted_rc_track_diag_25_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26794, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26794), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -6423,7 +6546,7 @@ static void compact_inverted_rc_track_diag_60_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26808, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26808), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 93 });
                     break;
             }
@@ -6436,7 +6559,7 @@ static void compact_inverted_rc_track_diag_60_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26805, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26805), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 93 });
                     break;
             }
@@ -6449,7 +6572,7 @@ static void compact_inverted_rc_track_diag_60_deg_up(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26807, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26807), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 93 });
                     break;
             }
@@ -6462,7 +6585,7 @@ static void compact_inverted_rc_track_diag_60_deg_up(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26806, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26806), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -6508,7 +6631,7 @@ static void compact_inverted_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26816, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26816), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -6519,7 +6642,7 @@ static void compact_inverted_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26788, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26788), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -6535,7 +6658,7 @@ static void compact_inverted_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26813, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26813), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -6546,7 +6669,7 @@ static void compact_inverted_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26785, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26785), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -6562,7 +6685,7 @@ static void compact_inverted_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26815, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26815), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -6573,7 +6696,7 @@ static void compact_inverted_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26787, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26787), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -6589,7 +6712,7 @@ static void compact_inverted_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26814, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26814), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -6600,7 +6723,7 @@ static void compact_inverted_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26786, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26786), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -6645,7 +6768,7 @@ static void compact_inverted_rc_track_diag_25_deg_up_to_60_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26800, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26800), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 61 });
                     break;
             }
@@ -6658,7 +6781,7 @@ static void compact_inverted_rc_track_diag_25_deg_up_to_60_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26797, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26797), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 61 });
                     break;
             }
@@ -6671,7 +6794,7 @@ static void compact_inverted_rc_track_diag_25_deg_up_to_60_deg_up(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26799, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26799), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 61 });
                     break;
             }
@@ -6684,7 +6807,7 @@ static void compact_inverted_rc_track_diag_25_deg_up_to_60_deg_up(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26798, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26798), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 61 });
                     break;
             }
@@ -6728,7 +6851,7 @@ static void compact_inverted_rc_track_diag_60_deg_up_to_25_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26804, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26804), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 61 });
                     break;
             }
@@ -6741,7 +6864,7 @@ static void compact_inverted_rc_track_diag_60_deg_up_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26801, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26801), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 61 });
                     break;
             }
@@ -6754,7 +6877,7 @@ static void compact_inverted_rc_track_diag_60_deg_up_to_25_deg_up(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26803, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26803), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 61 });
                     break;
             }
@@ -6767,7 +6890,7 @@ static void compact_inverted_rc_track_diag_60_deg_up_to_25_deg_up(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26802, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26802), { -16, -16, height + 29 },
                         { 16, 16, 3 }, { 0, 0, height + 61 });
                     break;
             }
@@ -6813,7 +6936,7 @@ static void compact_inverted_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26820, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26820), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -6824,7 +6947,7 @@ static void compact_inverted_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26792, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26792), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -6840,7 +6963,7 @@ static void compact_inverted_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26817, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26817), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -6851,7 +6974,7 @@ static void compact_inverted_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26789, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26789), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -6867,7 +6990,7 @@ static void compact_inverted_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26819, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26819), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -6878,7 +7001,7 @@ static void compact_inverted_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26791, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26791), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -6894,7 +7017,7 @@ static void compact_inverted_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26818, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26818), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -6905,7 +7028,7 @@ static void compact_inverted_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26790, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26790), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -6952,7 +7075,7 @@ static void compact_inverted_rc_track_diag_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26822, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26822), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -6963,7 +7086,7 @@ static void compact_inverted_rc_track_diag_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26794, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26794), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -6979,7 +7102,7 @@ static void compact_inverted_rc_track_diag_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26823, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26823), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -6990,7 +7113,7 @@ static void compact_inverted_rc_track_diag_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26795, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26795), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -7006,7 +7129,7 @@ static void compact_inverted_rc_track_diag_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26821, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26821), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -7017,7 +7140,7 @@ static void compact_inverted_rc_track_diag_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26793, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26793), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -7033,7 +7156,7 @@ static void compact_inverted_rc_track_diag_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26824, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26824), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -7044,7 +7167,7 @@ static void compact_inverted_rc_track_diag_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26796, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26796), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -7089,7 +7212,7 @@ static void compact_inverted_rc_track_diag_60_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26806, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26806), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -7102,7 +7225,7 @@ static void compact_inverted_rc_track_diag_60_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26807, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26807), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 93 });
                     break;
             }
@@ -7115,7 +7238,7 @@ static void compact_inverted_rc_track_diag_60_deg_down(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26805, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26805), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 93 });
                     break;
             }
@@ -7128,7 +7251,7 @@ static void compact_inverted_rc_track_diag_60_deg_down(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26808, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26808), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 93 });
                     break;
             }
@@ -7174,7 +7297,7 @@ static void compact_inverted_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26818, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26818), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -7185,7 +7308,7 @@ static void compact_inverted_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26790, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26790), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -7200,7 +7323,7 @@ static void compact_inverted_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26819, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26819), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -7211,7 +7334,7 @@ static void compact_inverted_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26791, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26791), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -7226,7 +7349,7 @@ static void compact_inverted_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26817, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26817), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -7237,7 +7360,7 @@ static void compact_inverted_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26789, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26789), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -7252,7 +7375,7 @@ static void compact_inverted_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26820, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26820), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -7263,7 +7386,7 @@ static void compact_inverted_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26792, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26792), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -7308,7 +7431,7 @@ static void compact_inverted_rc_track_diag_25_deg_down_to_60_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26802, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26802), { -16, -16, height + 29 },
                         { 16, 16, 3 }, { 0, 0, height + 61 });
                     break;
             }
@@ -7321,7 +7444,7 @@ static void compact_inverted_rc_track_diag_25_deg_down_to_60_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26803, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26803), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 61 });
                     break;
             }
@@ -7334,7 +7457,7 @@ static void compact_inverted_rc_track_diag_25_deg_down_to_60_deg_down(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26801, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26801), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 61 });
                     break;
             }
@@ -7347,7 +7470,7 @@ static void compact_inverted_rc_track_diag_25_deg_down_to_60_deg_down(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26804, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26804), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 61 });
                     break;
             }
@@ -7391,7 +7514,7 @@ static void compact_inverted_rc_track_diag_60_deg_down_to_25_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26798, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26798), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 61 });
                     break;
             }
@@ -7404,7 +7527,7 @@ static void compact_inverted_rc_track_diag_60_deg_down_to_25_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26799, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26799), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 61 });
                     break;
             }
@@ -7417,7 +7540,7 @@ static void compact_inverted_rc_track_diag_60_deg_down_to_25_deg_down(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26797, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26797), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 61 });
                     break;
             }
@@ -7430,7 +7553,7 @@ static void compact_inverted_rc_track_diag_60_deg_down_to_25_deg_down(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26800, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26800), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 61 });
                     break;
             }
@@ -7476,7 +7599,7 @@ static void compact_inverted_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26814, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26814), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -7487,7 +7610,7 @@ static void compact_inverted_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26786, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26786), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -7503,7 +7626,7 @@ static void compact_inverted_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26815, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26815), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -7514,7 +7637,7 @@ static void compact_inverted_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26787, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26787), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -7530,7 +7653,7 @@ static void compact_inverted_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26813, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26813), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -7541,7 +7664,7 @@ static void compact_inverted_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26785, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26785), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -7557,7 +7680,7 @@ static void compact_inverted_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26816, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26816), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -7568,7 +7691,7 @@ static void compact_inverted_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26788, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26788), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -7613,7 +7736,7 @@ static void compact_inverted_rc_track_diag_flat_to_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26876, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26876), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -7626,7 +7749,7 @@ static void compact_inverted_rc_track_diag_flat_to_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26873, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26873), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -7639,7 +7762,7 @@ static void compact_inverted_rc_track_diag_flat_to_left_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26875, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26875), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -7652,7 +7775,7 @@ static void compact_inverted_rc_track_diag_flat_to_left_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26874, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26874), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -7697,7 +7820,7 @@ static void compact_inverted_rc_track_diag_flat_to_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26880, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26880), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -7710,7 +7833,7 @@ static void compact_inverted_rc_track_diag_flat_to_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26877, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26877), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -7723,7 +7846,7 @@ static void compact_inverted_rc_track_diag_flat_to_right_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26879, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26879), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -7736,7 +7859,7 @@ static void compact_inverted_rc_track_diag_flat_to_right_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26878, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26878), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -7781,7 +7904,7 @@ static void compact_inverted_rc_track_diag_left_bank_to_flat(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26878, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26878), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -7794,7 +7917,7 @@ static void compact_inverted_rc_track_diag_left_bank_to_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26879, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26879), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -7807,7 +7930,7 @@ static void compact_inverted_rc_track_diag_left_bank_to_flat(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26877, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26877), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -7820,7 +7943,7 @@ static void compact_inverted_rc_track_diag_left_bank_to_flat(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26880, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26880), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -7865,7 +7988,7 @@ static void compact_inverted_rc_track_diag_right_bank_to_flat(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26874, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26874), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -7878,7 +8001,7 @@ static void compact_inverted_rc_track_diag_right_bank_to_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26875, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26875), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -7891,7 +8014,7 @@ static void compact_inverted_rc_track_diag_right_bank_to_flat(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26873, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26873), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -7904,7 +8027,7 @@ static void compact_inverted_rc_track_diag_right_bank_to_flat(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26876, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26876), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -7949,7 +8072,7 @@ static void compact_inverted_rc_track_diag_left_bank_to_25_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26892, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26892), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -7962,7 +8085,7 @@ static void compact_inverted_rc_track_diag_left_bank_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26889, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26889), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -7975,7 +8098,7 @@ static void compact_inverted_rc_track_diag_left_bank_to_25_deg_up(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26891, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26891), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -7988,7 +8111,7 @@ static void compact_inverted_rc_track_diag_left_bank_to_25_deg_up(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26890, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26890), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8032,7 +8155,7 @@ static void compact_inverted_rc_track_diag_right_bank_to_25_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26896, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26896), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8045,7 +8168,7 @@ static void compact_inverted_rc_track_diag_right_bank_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26893, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26893), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8058,7 +8181,7 @@ static void compact_inverted_rc_track_diag_right_bank_to_25_deg_up(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26895, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26895), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8071,7 +8194,7 @@ static void compact_inverted_rc_track_diag_right_bank_to_25_deg_up(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26894, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26894), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8115,7 +8238,7 @@ static void compact_inverted_rc_track_diag_25_deg_up_to_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26884, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26884), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8128,7 +8251,7 @@ static void compact_inverted_rc_track_diag_25_deg_up_to_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26881, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26881), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8141,7 +8264,7 @@ static void compact_inverted_rc_track_diag_25_deg_up_to_left_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26883, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26883), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8154,7 +8277,7 @@ static void compact_inverted_rc_track_diag_25_deg_up_to_left_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26882, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26882), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8198,7 +8321,7 @@ static void compact_inverted_rc_track_diag_25_deg_up_to_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26888, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26888), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8211,7 +8334,7 @@ static void compact_inverted_rc_track_diag_25_deg_up_to_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26885, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26885), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8224,7 +8347,7 @@ static void compact_inverted_rc_track_diag_25_deg_up_to_right_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26887, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26887), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8237,7 +8360,7 @@ static void compact_inverted_rc_track_diag_25_deg_up_to_right_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26886, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26886), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8281,7 +8404,7 @@ static void compact_inverted_rc_track_diag_left_bank_to_25_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26886, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26886), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8293,7 +8416,7 @@ static void compact_inverted_rc_track_diag_left_bank_to_25_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26887, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26887), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8305,7 +8428,7 @@ static void compact_inverted_rc_track_diag_left_bank_to_25_deg_down(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26885, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26885), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8317,7 +8440,7 @@ static void compact_inverted_rc_track_diag_left_bank_to_25_deg_down(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26888, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26888), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8361,7 +8484,7 @@ static void compact_inverted_rc_track_diag_right_bank_to_25_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26882, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26882), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8373,7 +8496,7 @@ static void compact_inverted_rc_track_diag_right_bank_to_25_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26883, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26883), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8385,7 +8508,7 @@ static void compact_inverted_rc_track_diag_right_bank_to_25_deg_down(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26881, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26881), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8397,7 +8520,7 @@ static void compact_inverted_rc_track_diag_right_bank_to_25_deg_down(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26884, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26884), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8441,7 +8564,7 @@ static void compact_inverted_rc_track_diag_25_deg_down_to_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26894, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26894), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8454,7 +8577,7 @@ static void compact_inverted_rc_track_diag_25_deg_down_to_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26895, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26895), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8467,7 +8590,7 @@ static void compact_inverted_rc_track_diag_25_deg_down_to_left_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26893, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26893), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8480,7 +8603,7 @@ static void compact_inverted_rc_track_diag_25_deg_down_to_left_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26896, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26896), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8524,7 +8647,7 @@ static void compact_inverted_rc_track_diag_25_deg_down_to_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26890, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26890), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8537,7 +8660,7 @@ static void compact_inverted_rc_track_diag_25_deg_down_to_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26891, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26891), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8550,7 +8673,7 @@ static void compact_inverted_rc_track_diag_25_deg_down_to_right_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26889, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26889), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8563,7 +8686,7 @@ static void compact_inverted_rc_track_diag_25_deg_down_to_right_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26892, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26892), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8607,7 +8730,7 @@ static void compact_inverted_rc_track_diag_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26872, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26872), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -8620,7 +8743,7 @@ static void compact_inverted_rc_track_diag_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26869, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26869), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -8633,7 +8756,7 @@ static void compact_inverted_rc_track_diag_left_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26871, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26871), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -8646,7 +8769,7 @@ static void compact_inverted_rc_track_diag_left_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26870, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26870), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -8691,7 +8814,7 @@ static void compact_inverted_rc_track_diag_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26870, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26870), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -8704,7 +8827,7 @@ static void compact_inverted_rc_track_diag_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26871, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26871), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -8717,7 +8840,7 @@ static void compact_inverted_rc_track_diag_right_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26869, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26869), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -8730,7 +8853,7 @@ static void compact_inverted_rc_track_diag_right_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26872, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26872), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -8773,13 +8896,13 @@ static void compact_inverted_rc_track_block_brakes(
         case 0:
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26559, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26559), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
         case 1:
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26560, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26560), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
     }

--- a/src/openrct2/ride/coaster/CorkscrewRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/CorkscrewRollerCoaster.cpp
@@ -41,22 +41,22 @@ static void corkscrew_rc_track_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16226, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16226), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16227, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16227), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16228, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16228), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16229, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16229), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -72,13 +72,13 @@ static void corkscrew_rc_track_flat(
             case 0:
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16224, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16224), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16225, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16225), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -109,17 +109,18 @@ static void corkscrew_rc_track_station(
     {
         bool isClosed = trackElement.BlockBrakeClosed();
         PaintAddImageAsParentRotated(
-            session, direction, _CorkscrewRCBlockBrakeImages[direction][isClosed] | session.TrackColours[SCHEME_TRACK],
+            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(_CorkscrewRCBlockBrakeImages[direction][isClosed]),
             { 0, 0, height }, { 32, 20, 1 }, { 0, 6, height + 3 });
     }
     else
     {
         PaintAddImageAsParentRotated(
-            session, direction, imageIds[direction][0] | session.TrackColours[SCHEME_TRACK], { 0, 0, height }, { 32, 20, 1 },
-            { 0, 6, height + 3 });
+            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]), { 0, 0, height },
+            { 32, 20, 1 }, { 0, 6, height + 3 });
     }
     PaintAddImageAsParentRotated(
-        session, direction, imageIds[direction][1] | session.TrackColours[SCHEME_MISC], { 0, 0, height }, { 32, 32, 1 });
+        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][1]), { 0, 0, height },
+        { 32, 32, 1 });
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], 0);
     track_paint_util_draw_station_2(session, ride, direction, height, trackElement, 9, 11);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -138,22 +139,22 @@ static void corkscrew_rc_track_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16314, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16314), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16315, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16315), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16316, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16316), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16317, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16317), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -168,22 +169,22 @@ static void corkscrew_rc_track_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16286, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16286), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16287, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16287), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16288, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16288), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16289, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16289), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -216,22 +217,22 @@ static void corkscrew_rc_track_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16330, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16330), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16331, { 0, 0, height }, { 32, 1, 98 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16331), { 0, 0, height }, { 32, 1, 98 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16332, { 0, 0, height }, { 32, 1, 98 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16332), { 0, 0, height }, { 32, 1, 98 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16333, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16333), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -246,22 +247,22 @@ static void corkscrew_rc_track_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16302, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16302), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16303, { 0, 0, height }, { 32, 1, 98 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16303), { 0, 0, height }, { 32, 1, 98 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16304, { 0, 0, height }, { 32, 1, 98 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16304), { 0, 0, height }, { 32, 1, 98 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16305, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16305), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -294,22 +295,22 @@ static void corkscrew_rc_track_flat_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16306, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16306), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16307, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16307), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16308, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16308), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16309, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16309), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -324,22 +325,22 @@ static void corkscrew_rc_track_flat_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16278, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16278), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16279, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16279), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16280, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16280), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16281, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16281), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -372,28 +373,28 @@ static void corkscrew_rc_track_25_deg_up_to_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16318, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16318), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16319, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16319), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16322, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16322), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16320, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16320), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16323, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16323), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16321, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16321), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -408,28 +409,28 @@ static void corkscrew_rc_track_25_deg_up_to_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16290, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16290), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16291, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16291), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16294, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16294), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16292, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16292), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16295, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16295), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16293, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16293), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -462,28 +463,28 @@ static void corkscrew_rc_track_60_deg_up_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16324, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16324), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16325, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16325), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16328, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16328), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16326, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16326), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16329, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16329), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16327, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16327), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -498,28 +499,28 @@ static void corkscrew_rc_track_60_deg_up_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16296, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16296), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16297, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16297), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16300, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16300), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16298, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16298), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16301, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16301), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16299, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16299), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -552,22 +553,22 @@ static void corkscrew_rc_track_25_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16310, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16310), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16311, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16311), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16312, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16312), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16313, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16313), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -582,22 +583,22 @@ static void corkscrew_rc_track_25_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16282, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16282), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16283, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16283), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16284, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16284), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16285, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16285), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -679,23 +680,23 @@ static void corkscrew_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16343, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16343), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16348, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16348), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16353, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16353), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16338, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16338), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -715,23 +716,23 @@ static void corkscrew_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16342, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16342), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16347, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16347), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16352, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16352), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16337, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16337), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -746,23 +747,23 @@ static void corkscrew_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16341, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16341), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16346, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16346), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16351, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16351), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16336, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16336), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -777,23 +778,23 @@ static void corkscrew_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16340, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16340), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16345, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16345), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16350, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16350), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16335, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16335), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -808,23 +809,23 @@ static void corkscrew_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16339, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16339), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16344, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16344), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16349, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16349), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16334, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16334), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -862,28 +863,28 @@ static void corkscrew_rc_track_flat_to_left_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16238, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16238), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16246, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16246), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16239, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16239), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16247, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16247), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16240, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16240), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16241, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16241), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -906,28 +907,28 @@ static void corkscrew_rc_track_flat_to_right_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16242, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16242), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16243, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16243), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16244, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16244), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16248, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16248), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16245, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16245), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16249, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16249), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
     }
@@ -950,28 +951,28 @@ static void corkscrew_rc_track_left_bank_to_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16244, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16244), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16248, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16248), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16245, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16245), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16249, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16249), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16242, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16242), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16243, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16243), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -994,28 +995,28 @@ static void corkscrew_rc_track_right_bank_to_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16240, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16240), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16241, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16241), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16238, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16238), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16246, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16246), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16239, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16239), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16247, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16247), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
     }
@@ -1041,26 +1042,26 @@ static void corkscrew_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16363, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16363), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16374, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16374), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16368, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16368), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16373, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16373), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16358, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16358), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1080,23 +1081,23 @@ static void corkscrew_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16362, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16362), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16367, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16367), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16372, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16372), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16357, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16357), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1111,23 +1112,23 @@ static void corkscrew_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16361, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16361), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16366, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16366), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16371, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16371), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16356, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16356), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1142,23 +1143,23 @@ static void corkscrew_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16360, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16360), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16365, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16365), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16370, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16370), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16355, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16355), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1173,26 +1174,26 @@ static void corkscrew_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16359, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16359), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16364, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16364), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16369, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16369), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16375, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16375), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16354, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16354), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1230,28 +1231,28 @@ static void corkscrew_rc_track_left_bank_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16250, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16250), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16254, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16254), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16251, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16251), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16255, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16255), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16252, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16252), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16253, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16253), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -1281,28 +1282,28 @@ static void corkscrew_rc_track_right_bank_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16256, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16256), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16257, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16257), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16258, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16258), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16260, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16260), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16259, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16259), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16261, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16261), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
     }
@@ -1332,28 +1333,28 @@ static void corkscrew_rc_track_25_deg_up_to_left_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16262, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16262), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16266, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16266), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16263, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16263), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16267, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16267), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16264, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16264), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16265, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16265), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -1383,28 +1384,28 @@ static void corkscrew_rc_track_25_deg_up_to_right_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16268, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16268), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16269, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16269), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16270, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16270), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16272, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16272), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16271, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16271), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16273, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16273), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
     }
@@ -1466,22 +1467,22 @@ static void corkscrew_rc_track_left_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16274, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16274), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16275, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16275), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16276, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16276), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16277, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16277), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -1515,23 +1516,23 @@ static void corkscrew_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16510, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16510), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16515, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16515), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16520, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16520), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16525, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16525), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1551,21 +1552,23 @@ static void corkscrew_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16511, { 0, 0, height }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16511), { 0, 0, height },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16516, { 0, 0, height }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16516), { 0, 0, height },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16521, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16521), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16526, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16526), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1580,22 +1583,23 @@ static void corkscrew_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16512, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16512), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16517, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16517), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16522, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16522), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16527, { 0, 0, height }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16527), { 0, 0, height },
+                        { 16, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1610,21 +1614,23 @@ static void corkscrew_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16513, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16513), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16518, { 0, 0, height }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16518), { 0, 0, height },
+                        { 16, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16523, { 0, 0, height }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16523), { 0, 0, height },
+                        { 16, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16528, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16528), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1639,23 +1645,23 @@ static void corkscrew_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16514, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16514), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16519, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16519), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16524, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16524), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16529, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16529), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1687,23 +1693,23 @@ static void corkscrew_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16490, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16490), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16495, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16495), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16500, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16500), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16505, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16505), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1723,21 +1729,23 @@ static void corkscrew_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16491, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16491), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16496, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16496), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16501, { 0, 0, height }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16501), { 0, 0, height },
+                        { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16506, { 0, 0, height }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16506), { 0, 0, height },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1752,22 +1760,23 @@ static void corkscrew_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16492, { 0, 0, height }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16492), { 0, 0, height },
+                        { 16, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16497, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16497), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16502, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16502), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16507, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16507), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1782,21 +1791,23 @@ static void corkscrew_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16493, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16493), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16498, { 0, 0, height }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16498), { 0, 0, height },
+                        { 16, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16503, { 0, 0, height }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16503), { 0, 0, height },
+                        { 16, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16508, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16508), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1811,23 +1822,23 @@ static void corkscrew_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16494, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16494), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16499, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16499), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16504, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16504), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16509, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16509), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1877,23 +1888,23 @@ static void corkscrew_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16402, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16402), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16406, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16406), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16405, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16405), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16409, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16409), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1910,25 +1921,27 @@ static void corkscrew_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16403, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16403), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16407, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16407), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 6, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16404, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16404), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16408, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16408), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1943,23 +1956,25 @@ static void corkscrew_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16404, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16404), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16408, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16408), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16403, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16403), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16407, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16407), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 6, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -1976,23 +1991,23 @@ static void corkscrew_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16405, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16405), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16409, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16409), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16402, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16402), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16406, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16406), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2024,23 +2039,23 @@ static void corkscrew_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16410, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16410), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16414, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16414), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16413, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16413), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16417, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16417), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2057,25 +2072,27 @@ static void corkscrew_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16411, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16411), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16415, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16415), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16412, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16412), { 0, 0, height },
+                        { 32, 26, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16416, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16416), { 0, 0, height },
+                        { 32, 26, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2090,23 +2107,25 @@ static void corkscrew_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16412, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16412), { 0, 0, height },
+                        { 32, 26, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16416, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16416), { 0, 0, height },
+                        { 32, 26, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16411, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16411), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16415, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16415), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2123,23 +2142,23 @@ static void corkscrew_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16413, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16413), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16417, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16417), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16410, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16410), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16414, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16414), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2171,25 +2190,29 @@ static void corkscrew_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16562, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16562), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16570, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16570), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16569, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16569), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16577, { 0, 6, height }, { 32, 20, 7 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16577), { 0, 6, height },
+                        { 32, 20, 7 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2210,25 +2233,29 @@ static void corkscrew_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16563, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16563), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16571, { 0, 14, height }, { 32, 2, 63 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16571), { 0, 14, height },
+                        { 32, 2, 63 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 15, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16568, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16568), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16576, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16576), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2245,23 +2272,23 @@ static void corkscrew_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16564, { 16, 0, height }, { 3, 16, 119 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16564), { 16, 0, height },
+                        { 3, 16, 119 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16572, { 12, 0, height }, { 3, 16, 119 },
-                        { 12, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16572), { 12, 0, height },
+                        { 3, 16, 119 }, { 12, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16567, { 10, 16, height }, { 4, 16, 119 },
-                        { 10, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16567), { 10, 16, height },
+                        { 4, 16, 119 }, { 10, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16575, { 16, 16, height }, { 2, 16, 119 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16575), { 16, 16, height },
+                        { 2, 16, 119 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2273,19 +2300,23 @@ static void corkscrew_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16565, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16565), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16573, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16573), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16566, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16566), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16574, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16574), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2306,19 +2337,23 @@ static void corkscrew_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16566, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16566), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16574, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16574), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16565, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16565), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16573, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16573), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2333,23 +2368,23 @@ static void corkscrew_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16567, { 10, 16, height }, { 4, 16, 119 },
-                        { 10, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16567), { 10, 16, height },
+                        { 4, 16, 119 }, { 10, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16575, { 16, 16, height }, { 2, 16, 119 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16575), { 16, 16, height },
+                        { 2, 16, 119 }, { 16, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16564, { 16, 0, height }, { 3, 16, 119 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16564), { 16, 0, height },
+                        { 3, 16, 119 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16572, { 12, 0, height }, { 3, 16, 119 },
-                        { 12, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16572), { 12, 0, height },
+                        { 3, 16, 119 }, { 12, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2361,25 +2396,29 @@ static void corkscrew_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16568, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16568), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16576, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16576), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16563, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16563), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16571, { 0, 14, height }, { 32, 2, 63 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16571), { 0, 14, height },
+                        { 32, 2, 63 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 15, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2396,25 +2435,29 @@ static void corkscrew_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16569, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16569), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16577, { 0, 6, height }, { 32, 20, 7 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16577), { 0, 6, height },
+                        { 32, 20, 7 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16562, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16562), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16570, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16570), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2450,19 +2493,23 @@ static void corkscrew_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16593, { 0, 6, height }, { 32, 20, 7 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16593), { 0, 6, height },
+                        { 32, 20, 7 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16585, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16585), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16586, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16586), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16578, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16578), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2477,25 +2524,29 @@ static void corkscrew_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16592, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16592), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16584, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16584), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16587, { 0, 14, height }, { 32, 2, 63 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16587), { 0, 14, height },
+                        { 32, 2, 63 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16579, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16579), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2507,23 +2558,23 @@ static void corkscrew_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16591, { 16, 16, height }, { 2, 16, 119 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16591), { 16, 16, height },
+                        { 2, 16, 119 }, { 16, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16583, { 10, 16, height }, { 4, 16, 119 },
-                        { 10, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16583), { 10, 16, height },
+                        { 4, 16, 119 }, { 10, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16588, { 12, 0, height }, { 3, 16, 119 },
-                        { 12, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16588), { 12, 0, height },
+                        { 3, 16, 119 }, { 12, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16580, { 16, 0, height }, { 2, 16, 119 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16580), { 16, 0, height },
+                        { 2, 16, 119 }, { 16, 0, height });
                     break;
             }
             paint_util_set_general_support_height(session, height + 168, 0x20);
@@ -2533,19 +2584,23 @@ static void corkscrew_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16590, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16590), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16582, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16582), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16589, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16589), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16581, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16581), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_general_support_height(session, height + 48, 0x20);
@@ -2561,19 +2616,23 @@ static void corkscrew_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16589, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16589), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16581, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16581), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16590, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16590), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16582, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16582), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_general_support_height(session, height + 48, 0x20);
@@ -2583,23 +2642,23 @@ static void corkscrew_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16588, { 12, 0, height }, { 3, 16, 119 },
-                        { 12, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16588), { 12, 0, height },
+                        { 3, 16, 119 }, { 12, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16580, { 16, 0, height }, { 2, 16, 119 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16580), { 16, 0, height },
+                        { 2, 16, 119 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16591, { 16, 16, height }, { 2, 16, 119 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16591), { 16, 16, height },
+                        { 2, 16, 119 }, { 16, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16583, { 10, 16, height }, { 4, 16, 119 },
-                        { 10, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16583), { 10, 16, height },
+                        { 4, 16, 119 }, { 10, 16, height });
                     break;
             }
             paint_util_set_general_support_height(session, height + 168, 0x20);
@@ -2609,25 +2668,29 @@ static void corkscrew_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16587, { 0, 14, height }, { 32, 2, 63 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16587), { 0, 14, height },
+                        { 32, 2, 63 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16579, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16579), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16592, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16592), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16584, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16584), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2639,19 +2702,23 @@ static void corkscrew_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16586, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16586), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16578, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16578), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16593, { 0, 6, height }, { 32, 20, 7 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16593), { 0, 6, height },
+                        { 32, 20, 7 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16585, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16585), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2683,23 +2750,23 @@ static void corkscrew_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16381, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16381), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16384, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16384), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16387, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16387), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16378, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16378), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2719,23 +2786,23 @@ static void corkscrew_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16380, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16380), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16383, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16383), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16386, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16386), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16377, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16377), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2747,23 +2814,23 @@ static void corkscrew_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16379, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16379), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16382, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16382), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16385, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16385), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16376, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16376), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2804,26 +2871,26 @@ static void corkscrew_rc_track_left_quarter_turn_3_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16393, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16393), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16400, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16400), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16396, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16396), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16399, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16399), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16390, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16390), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2843,23 +2910,23 @@ static void corkscrew_rc_track_left_quarter_turn_3_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16392, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16392), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16395, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16395), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16398, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16398), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16389, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16389), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2871,26 +2938,26 @@ static void corkscrew_rc_track_left_quarter_turn_3_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16391, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16391), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16394, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16394), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16397, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16397), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16401, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16401), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16388, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16388), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2931,19 +2998,23 @@ static void corkscrew_rc_track_left_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16541, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16541), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16543, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16543), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16545, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16545), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16539, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16539), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2966,19 +3037,23 @@ static void corkscrew_rc_track_left_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16540, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16540), { 6, 0, height },
+                        { 20, 32, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16542, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16542), { 6, 0, height },
+                        { 20, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16544, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16544), { 6, 0, height },
+                        { 20, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16538, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16538), { 6, 0, height },
+                        { 20, 32, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3010,19 +3085,23 @@ static void corkscrew_rc_track_right_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16530, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16530), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16532, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16532), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16534, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16534), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16536, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16536), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3045,25 +3124,29 @@ static void corkscrew_rc_track_right_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16531, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16531), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16533, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16533), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16535, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16535), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16537, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16537), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3114,19 +3197,23 @@ static void corkscrew_rc_track_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16594, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16594), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16602, { 0, 6, height }, { 32, 20, 11 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16602), { 0, 6, height },
+                        { 32, 20, 11 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16601, { 0, 6, height }, { 32, 20, 9 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16601), { 0, 6, height },
+                        { 32, 20, 9 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16609, { 0, 6, height }, { 32, 20, 7 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16609), { 0, 6, height },
+                        { 32, 20, 7 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3143,28 +3230,29 @@ static void corkscrew_rc_track_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16595, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16595), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16603, { 0, 14, height }, { 3, 20, 63 },
-                        { 28, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16603), { 0, 14, height },
+                        { 3, 20, 63 }, { 28, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 15, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16600, { 0, 6, height }, { 3, 20, 63 },
-                        { 28, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16600), { 0, 6, height },
+                        { 3, 20, 63 }, { 28, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16608, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16608), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3177,21 +3265,23 @@ static void corkscrew_rc_track_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16596, { 16, 0, height }, { 2, 16, 119 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16596), { 16, 0, height },
+                        { 2, 16, 119 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16604, { 12, 0, height }, { 3, 16, 119 },
-                        { 12, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16604), { 12, 0, height },
+                        { 3, 16, 119 }, { 12, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16599, { 10, 16, height }, { 4, 12, 119 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16599), { 10, 16, height },
+                        { 4, 12, 119 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16607, { 16, 16, height }, { 2, 16, 119 },
-                        { 15, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16607), { 16, 16, height },
+                        { 2, 16, 119 }, { 15, 6, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3206,19 +3296,23 @@ static void corkscrew_rc_track_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16597, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16597), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16605, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16605), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16598, { 0, 16, height + 32 }, { 32, 12, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16598), { 0, 16, height + 32 },
+                        { 32, 12, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16606, { 0, 16, height + 32 }, { 32, 12, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16606), { 0, 16, height + 32 },
+                        { 32, 12, 3 });
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -3252,23 +3346,23 @@ static void corkscrew_rc_track_left_corkscrew_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16610, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16610), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 4 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16613, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16613), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 4 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16616, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16616), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 4 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16619, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16619), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 4 });
                     break;
             }
 
@@ -3285,23 +3379,23 @@ static void corkscrew_rc_track_left_corkscrew_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16611, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16611), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16614, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16614), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16617, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16617), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16620, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16620), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -3312,23 +3406,23 @@ static void corkscrew_rc_track_left_corkscrew_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16612, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16612), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 24 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16615, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16615), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 24 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16618, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16618), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 24 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16621, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16621), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 24 });
                     break;
             }
 
@@ -3364,23 +3458,23 @@ static void corkscrew_rc_track_right_corkscrew_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16622, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16622), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 4 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16625, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16625), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 4 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16628, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16628), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 4 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16631, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16631), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 4 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3398,23 +3492,23 @@ static void corkscrew_rc_track_right_corkscrew_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16623, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16623), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16626, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16626), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16629, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16629), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16632, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16632), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -3425,23 +3519,23 @@ static void corkscrew_rc_track_right_corkscrew_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16624, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16624), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 24 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16627, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16627), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 24 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16630, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16630), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 24 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16633, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16633), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 24 });
                     break;
             }
 
@@ -3493,26 +3587,26 @@ static void corkscrew_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16481, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16481), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16488, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16488), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16484, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16484), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16487, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16487), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16478, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16478), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3533,23 +3627,23 @@ static void corkscrew_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16480, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16480), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16483, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16483), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16486, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16486), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16477, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16477), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3561,26 +3655,26 @@ static void corkscrew_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16479, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16479), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16482, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16482), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16485, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16485), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16489, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16489), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16476, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16476), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 8 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3603,26 +3697,26 @@ static void corkscrew_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16478, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16478), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16481, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16481), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16488, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16488), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16484, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16484), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16487, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16487), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3648,23 +3742,23 @@ static void corkscrew_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16477, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16477), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16480, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16480), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16483, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16483), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16486, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16486), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3676,26 +3770,26 @@ static void corkscrew_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16476, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16476), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16479, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16479), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16482, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16482), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16485, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16485), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16489, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16489), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3723,26 +3817,26 @@ static void corkscrew_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16462, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16462), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16465, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16465), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16468, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16468), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16471, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16471), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16475, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16475), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3763,23 +3857,23 @@ static void corkscrew_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16463, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16463), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16466, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16466), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16469, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16469), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16472, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16472), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3791,26 +3885,26 @@ static void corkscrew_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16464, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16464), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16467, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16467), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16474, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16474), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16470, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16470), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16473, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16473), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3833,26 +3927,26 @@ static void corkscrew_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16465, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16465), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16468, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16468), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16471, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16471), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16475, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16475), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16462, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16462), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3878,23 +3972,23 @@ static void corkscrew_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16466, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16466), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16469, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16469), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16472, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16472), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16463, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16463), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3906,26 +4000,26 @@ static void corkscrew_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16467, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16467), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16474, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16474), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16470, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16470), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16473, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16473), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16464, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16464), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3982,26 +4076,26 @@ static void corkscrew_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16449, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16449), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16460, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16460), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16454, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16454), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16459, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16459), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16444, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16444), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4022,23 +4116,23 @@ static void corkscrew_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16448, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16448), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16453, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16453), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16458, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16458), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16443, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16443), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4053,23 +4147,23 @@ static void corkscrew_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16447, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16447), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16452, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16452), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16457, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16457), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16442, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16442), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4084,23 +4178,23 @@ static void corkscrew_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16446, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16446), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16451, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16451), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16456, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16456), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16441, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16441), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4115,26 +4209,26 @@ static void corkscrew_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16445, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16445), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16450, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16450), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16455, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16455), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16461, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16461), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16440, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16440), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 8 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4157,26 +4251,26 @@ static void corkscrew_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16444, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16444), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16449, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16449), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16460, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16460), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16454, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16454), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16459, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16459), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4202,23 +4296,23 @@ static void corkscrew_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16443, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16443), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16448, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16448), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16453, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16453), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16458, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16458), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4233,23 +4327,23 @@ static void corkscrew_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16442, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16442), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16447, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16447), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16452, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16452), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16457, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16457), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4264,23 +4358,23 @@ static void corkscrew_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16441, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16441), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16446, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16446), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16451, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16451), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16456, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16456), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4295,26 +4389,26 @@ static void corkscrew_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16440, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16440), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16445, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16445), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16450, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16450), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16455, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16455), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16461, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16461), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4342,26 +4436,26 @@ static void corkscrew_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16418, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16418), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16423, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16423), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16428, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16428), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16433, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16433), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16439, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16439), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4382,23 +4476,23 @@ static void corkscrew_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16419, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16419), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16424, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16424), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16429, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16429), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16434, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16434), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4413,23 +4507,23 @@ static void corkscrew_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16420, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16420), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16425, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16425), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16430, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16430), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16435, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16435), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4444,23 +4538,23 @@ static void corkscrew_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16421, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16421), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16426, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16426), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16431, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16431), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16436, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16436), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4475,26 +4569,26 @@ static void corkscrew_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16422, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16422), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16427, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16427), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16438, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16438), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16432, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16432), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16437, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16437), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4517,26 +4611,26 @@ static void corkscrew_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16423, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16423), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16428, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16428), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16433, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16433), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16439, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16439), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16418, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16418), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4562,23 +4656,23 @@ static void corkscrew_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16424, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16424), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16429, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16429), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16434, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16434), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16419, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16419), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4593,23 +4687,23 @@ static void corkscrew_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16425, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16425), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16430, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16430), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16435, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16435), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16420, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16420), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4624,23 +4718,23 @@ static void corkscrew_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16426, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16426), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16431, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16431), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16436, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16436), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16421, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16421), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4655,26 +4749,26 @@ static void corkscrew_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16427, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16427), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16438, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16438), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16432, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16432), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16437, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16437), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16422, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16422), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4728,34 +4822,34 @@ static void corkscrew_rc_track_left_quarter_turn_1_60_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16555, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16555), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16559, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16559), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16556, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16556), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16560, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16560), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16557, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16557), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16561, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16561), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16554, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16554), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16558, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16558), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
     }
@@ -4773,34 +4867,34 @@ static void corkscrew_rc_track_right_quarter_turn_1_60_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16546, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16546), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16550, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16550), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16547, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16547), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16551, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16551), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16548, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16548), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16552, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16552), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16549, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16549), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16553, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16553), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
     }
@@ -4835,13 +4929,13 @@ static void corkscrew_rc_track_brakes(
         case 0:
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16230, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16230), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16231, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16231), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -4864,38 +4958,38 @@ static void corkscrew_rc_track_on_ride_photo(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16224, { 0, 0, height }, { 32, 20, 0 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16224), { 0, 0, height }, { 32, 20, 0 },
                 { 0, 6, height + 3 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16225, { 0, 0, height }, { 32, 20, 0 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16225), { 0, 0, height }, { 32, 20, 0 },
                 { 0, 6, height + 3 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16224, { 0, 0, height }, { 32, 20, 0 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16224), { 0, 0, height }, { 32, 20, 0 },
                 { 0, 6, height + 3 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 16225, { 0, 0, height }, { 32, 20, 0 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16225), { 0, 0, height }, { 32, 20, 0 },
                 { 0, 6, height + 3 });
             break;
     }
@@ -4917,23 +5011,23 @@ static void corkscrew_rc_track_flat_to_60_deg_up_long_base(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16788, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16788), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16792, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16792), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16796, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16796), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16800, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16800), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -4954,23 +5048,23 @@ static void corkscrew_rc_track_flat_to_60_deg_up_long_base(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16789, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16789), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16793, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16793), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16797, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16797), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16801, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16801), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -4987,23 +5081,23 @@ static void corkscrew_rc_track_flat_to_60_deg_up_long_base(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16790, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16790), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16794, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16794), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16798, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16798), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16802, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16802), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -5020,23 +5114,23 @@ static void corkscrew_rc_track_flat_to_60_deg_up_long_base(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16791, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16791), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16795, { 0, 0, height }, { 32, 1, 98 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16795), { 0, 0, height },
+                        { 32, 1, 98 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16799, { 0, 0, height }, { 32, 1, 98 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16799), { 0, 0, height },
+                        { 32, 1, 98 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16803, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16803), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -5072,23 +5166,23 @@ static void corkscrew_rc_track_60_deg_up_to_flat_long_base(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16804, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16804), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16808, { 0, 0, height }, { 32, 1, 98 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16808), { 0, 0, height },
+                        { 32, 1, 98 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16812, { 0, 0, height }, { 32, 1, 98 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16812), { 0, 0, height },
+                        { 32, 1, 98 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16816, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16816), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -5109,23 +5203,23 @@ static void corkscrew_rc_track_60_deg_up_to_flat_long_base(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16805, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16805), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16809, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16809), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16813, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16813), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16817, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16817), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -5142,23 +5236,23 @@ static void corkscrew_rc_track_60_deg_up_to_flat_long_base(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16806, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16806), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16810, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16810), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16814, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16814), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16818, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16818), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -5175,23 +5269,23 @@ static void corkscrew_rc_track_60_deg_up_to_flat_long_base(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16807, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16807), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16811, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16811), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16815, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16815), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16819, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16819), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -5243,23 +5337,23 @@ static void corkscrew_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16740, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16740), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16744, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16744), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16748, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16748), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16752, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16752), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -5276,23 +5370,23 @@ static void corkscrew_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16741, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16741), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16745, { 0, 0, height }, { 34, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16745), { 0, 0, height },
+                        { 34, 16, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16749, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16749), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16753, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16753), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5307,23 +5401,23 @@ static void corkscrew_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16742, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16742), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16746, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16746), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16750, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16750), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16754, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16754), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5341,29 +5435,29 @@ static void corkscrew_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16743, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16743), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16747, { 0, 0, height }, { 16, 18, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16747), { 0, 0, height },
+                        { 16, 18, 3 }, { 0, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16751, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16751), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16755, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16755), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -5390,23 +5484,23 @@ static void corkscrew_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16724, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16724), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16728, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16728), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16732, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16732), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16736, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16736), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -5423,23 +5517,23 @@ static void corkscrew_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16725, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16725), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16729, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16729), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16733, { 0, 0, height }, { 34, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16733), { 0, 0, height },
+                        { 34, 16, 3 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16737, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16737), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5454,23 +5548,23 @@ static void corkscrew_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16726, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16726), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16730, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16730), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16734, { 0, 0, height }, { 28, 28, 3 },
-                        { 4, 4, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16734), { 0, 0, height },
+                        { 28, 28, 3 }, { 4, 4, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16738, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16738), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5488,29 +5582,29 @@ static void corkscrew_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16727, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16727), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16731, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16731), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16735, { 0, 0, height }, { 16, 18, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16735), { 0, 0, height },
+                        { 16, 18, 3 }, { 0, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16739, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16739), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -5555,23 +5649,23 @@ static void corkscrew_rc_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16772, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16772), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16776, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16776), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16780, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16780), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16784, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16784), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -5588,23 +5682,23 @@ static void corkscrew_rc_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16773, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16773), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16777, { 0, 0, height }, { 34, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16777), { 0, 0, height },
+                        { 34, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16781, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16781), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16785, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16785), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5619,23 +5713,23 @@ static void corkscrew_rc_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16774, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16774), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16778, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16778), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16782, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16782), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16786, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16786), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5653,29 +5747,29 @@ static void corkscrew_rc_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16775, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16775), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16779, { 0, 0, height }, { 16, 18, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16779), { 0, 0, height },
+                        { 16, 18, 0 }, { 0, 16, height + 27 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16783, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16783), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16787, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16787), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -5702,23 +5796,23 @@ static void corkscrew_rc_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16756, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16756), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16760, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16760), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16764, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16764), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16768, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16768), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -5735,23 +5829,23 @@ static void corkscrew_rc_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16757, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16757), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16761, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16761), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16765, { 0, 0, height }, { 34, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16765), { 0, 0, height },
+                        { 34, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16769, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16769), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5766,23 +5860,23 @@ static void corkscrew_rc_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16758, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16758), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16762, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16762), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16766, { 0, 0, height }, { 28, 28, 0 },
-                        { 4, 4, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16766), { 0, 0, height },
+                        { 28, 28, 0 }, { 4, 4, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16770, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16770), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5800,29 +5894,29 @@ static void corkscrew_rc_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16759, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16759), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16763, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16763), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16767, { 0, 0, height }, { 16, 18, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16767), { 0, 0, height },
+                        { 16, 18, 0 }, { 0, 16, height + 27 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16771, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16771), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -5869,8 +5963,8 @@ static void corkscrew_rc_track_diag_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16699, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16699), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5880,8 +5974,8 @@ static void corkscrew_rc_track_diag_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16637, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16637), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5896,8 +5990,8 @@ static void corkscrew_rc_track_diag_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16696, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16696), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5907,8 +6001,8 @@ static void corkscrew_rc_track_diag_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16634, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16634), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5923,8 +6017,8 @@ static void corkscrew_rc_track_diag_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16698, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16698), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5934,8 +6028,8 @@ static void corkscrew_rc_track_diag_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16636, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16636), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5954,8 +6048,8 @@ static void corkscrew_rc_track_diag_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16697, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16697), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5979,8 +6073,8 @@ static void corkscrew_rc_track_diag_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16635, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16635), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6015,8 +6109,8 @@ static void corkscrew_rc_track_diag_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16711, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16711), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6026,8 +6120,8 @@ static void corkscrew_rc_track_diag_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16649, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16649), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6042,8 +6136,8 @@ static void corkscrew_rc_track_diag_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16708, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16708), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6053,8 +6147,8 @@ static void corkscrew_rc_track_diag_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16646, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16646), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6069,8 +6163,8 @@ static void corkscrew_rc_track_diag_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16710, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16710), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6080,8 +6174,8 @@ static void corkscrew_rc_track_diag_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16648, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16648), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6100,8 +6194,8 @@ static void corkscrew_rc_track_diag_25_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16709, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16709), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6125,8 +6219,8 @@ static void corkscrew_rc_track_diag_25_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16647, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16647), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6161,8 +6255,8 @@ static void corkscrew_rc_track_diag_60_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16723, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16723), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6172,8 +6266,8 @@ static void corkscrew_rc_track_diag_60_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16661, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16661), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6188,8 +6282,8 @@ static void corkscrew_rc_track_diag_60_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16720, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16720), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6199,8 +6293,8 @@ static void corkscrew_rc_track_diag_60_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16658, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16658), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6215,8 +6309,8 @@ static void corkscrew_rc_track_diag_60_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16722, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16722), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6226,8 +6320,8 @@ static void corkscrew_rc_track_diag_60_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16660, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16660), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6246,8 +6340,8 @@ static void corkscrew_rc_track_diag_60_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16721, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16721), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 36, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6271,8 +6365,8 @@ static void corkscrew_rc_track_diag_60_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16659, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16659), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 36, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6307,8 +6401,8 @@ static void corkscrew_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16703, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16703), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6318,8 +6412,8 @@ static void corkscrew_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16641, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16641), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6334,8 +6428,8 @@ static void corkscrew_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16700, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16700), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6345,8 +6439,8 @@ static void corkscrew_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16638, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16638), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6361,8 +6455,8 @@ static void corkscrew_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16702, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16702), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6372,8 +6466,8 @@ static void corkscrew_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16640, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16640), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6392,8 +6486,8 @@ static void corkscrew_rc_track_diag_flat_to_25_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16701, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16701), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6417,8 +6511,8 @@ static void corkscrew_rc_track_diag_flat_to_25_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16639, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16639), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6453,8 +6547,8 @@ static void corkscrew_rc_track_diag_25_deg_up_to_60_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16715, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16715), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6464,8 +6558,8 @@ static void corkscrew_rc_track_diag_25_deg_up_to_60_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16653, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16653), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6480,8 +6574,8 @@ static void corkscrew_rc_track_diag_25_deg_up_to_60_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16712, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16712), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6491,8 +6585,8 @@ static void corkscrew_rc_track_diag_25_deg_up_to_60_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16650, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16650), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6507,8 +6601,8 @@ static void corkscrew_rc_track_diag_25_deg_up_to_60_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16714, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16714), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6518,8 +6612,8 @@ static void corkscrew_rc_track_diag_25_deg_up_to_60_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16652, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16652), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6538,8 +6632,8 @@ static void corkscrew_rc_track_diag_25_deg_up_to_60_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16713, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16713), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6563,8 +6657,8 @@ static void corkscrew_rc_track_diag_25_deg_up_to_60_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16651, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16651), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6599,8 +6693,8 @@ static void corkscrew_rc_track_diag_60_deg_up_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16719, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16719), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6610,8 +6704,8 @@ static void corkscrew_rc_track_diag_60_deg_up_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16657, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16657), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6626,8 +6720,8 @@ static void corkscrew_rc_track_diag_60_deg_up_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16716, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16716), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6637,8 +6731,8 @@ static void corkscrew_rc_track_diag_60_deg_up_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16654, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16654), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6653,8 +6747,8 @@ static void corkscrew_rc_track_diag_60_deg_up_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16718, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16718), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6664,8 +6758,8 @@ static void corkscrew_rc_track_diag_60_deg_up_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16656, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16656), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6684,8 +6778,8 @@ static void corkscrew_rc_track_diag_60_deg_up_to_25_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16717, { -16, -16, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16717), { -16, -16, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 21, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6709,8 +6803,8 @@ static void corkscrew_rc_track_diag_60_deg_up_to_25_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16655, { -16, -16, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16655), { -16, -16, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 21, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6745,8 +6839,8 @@ static void corkscrew_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16707, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16707), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6756,8 +6850,8 @@ static void corkscrew_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16645, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16645), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6772,8 +6866,8 @@ static void corkscrew_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16704, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16704), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6783,8 +6877,8 @@ static void corkscrew_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16642, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16642), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6799,8 +6893,8 @@ static void corkscrew_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16706, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16706), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6810,8 +6904,8 @@ static void corkscrew_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16644, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16644), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6830,8 +6924,8 @@ static void corkscrew_rc_track_diag_25_deg_up_to_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16705, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16705), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6855,8 +6949,8 @@ static void corkscrew_rc_track_diag_25_deg_up_to_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16643, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16643), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6891,8 +6985,8 @@ static void corkscrew_rc_track_diag_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16709, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16709), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6902,8 +6996,8 @@ static void corkscrew_rc_track_diag_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16647, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16647), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6918,8 +7012,8 @@ static void corkscrew_rc_track_diag_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16710, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16710), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6929,8 +7023,8 @@ static void corkscrew_rc_track_diag_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16648, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16648), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6945,8 +7039,8 @@ static void corkscrew_rc_track_diag_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16708, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16708), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6956,8 +7050,8 @@ static void corkscrew_rc_track_diag_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16646, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16646), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6976,8 +7070,8 @@ static void corkscrew_rc_track_diag_25_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16711, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16711), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7001,8 +7095,8 @@ static void corkscrew_rc_track_diag_25_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16649, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16649), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7037,8 +7131,8 @@ static void corkscrew_rc_track_diag_60_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16721, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16721), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7048,8 +7142,8 @@ static void corkscrew_rc_track_diag_60_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16659, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16659), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7064,8 +7158,8 @@ static void corkscrew_rc_track_diag_60_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16722, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16722), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7075,8 +7169,8 @@ static void corkscrew_rc_track_diag_60_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16660, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16660), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7091,8 +7185,8 @@ static void corkscrew_rc_track_diag_60_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16720, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16720), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7102,8 +7196,8 @@ static void corkscrew_rc_track_diag_60_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16658, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16658), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7122,8 +7216,8 @@ static void corkscrew_rc_track_diag_60_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16723, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16723), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 28, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7147,8 +7241,8 @@ static void corkscrew_rc_track_diag_60_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16661, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16661), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 28, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7183,8 +7277,8 @@ static void corkscrew_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16705, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16705), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7194,8 +7288,8 @@ static void corkscrew_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16643, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16643), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7209,8 +7303,8 @@ static void corkscrew_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16706, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16706), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7220,8 +7314,8 @@ static void corkscrew_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16644, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16644), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7235,8 +7329,8 @@ static void corkscrew_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16704, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16704), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7246,8 +7340,8 @@ static void corkscrew_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16642, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16642), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7265,8 +7359,8 @@ static void corkscrew_rc_track_diag_flat_to_25_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16707, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16707), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7290,8 +7384,8 @@ static void corkscrew_rc_track_diag_flat_to_25_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16645, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16645), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7327,8 +7421,8 @@ static void corkscrew_rc_track_diag_25_deg_down_to_60_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16717, { -16, -16, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16717), { -16, -16, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         break;
                 }
             }
@@ -7338,8 +7432,8 @@ static void corkscrew_rc_track_diag_25_deg_down_to_60_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16655, { -16, -16, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16655), { -16, -16, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         break;
                 }
             }
@@ -7354,8 +7448,8 @@ static void corkscrew_rc_track_diag_25_deg_down_to_60_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16718, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16718), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7365,8 +7459,8 @@ static void corkscrew_rc_track_diag_25_deg_down_to_60_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16656, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16656), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7381,8 +7475,8 @@ static void corkscrew_rc_track_diag_25_deg_down_to_60_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16716, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16716), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7392,8 +7486,8 @@ static void corkscrew_rc_track_diag_25_deg_down_to_60_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16654, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16654), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7412,8 +7506,8 @@ static void corkscrew_rc_track_diag_25_deg_down_to_60_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16719, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16719), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 17, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7437,8 +7531,8 @@ static void corkscrew_rc_track_diag_25_deg_down_to_60_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16657, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16657), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 17, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7473,8 +7567,8 @@ static void corkscrew_rc_track_diag_60_deg_down_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16713, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16713), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7484,8 +7578,8 @@ static void corkscrew_rc_track_diag_60_deg_down_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16651, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16651), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7500,8 +7594,8 @@ static void corkscrew_rc_track_diag_60_deg_down_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16714, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16714), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7511,8 +7605,8 @@ static void corkscrew_rc_track_diag_60_deg_down_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16652, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16652), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7527,8 +7621,8 @@ static void corkscrew_rc_track_diag_60_deg_down_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16712, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16712), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7538,8 +7632,8 @@ static void corkscrew_rc_track_diag_60_deg_down_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16650, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16650), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7558,8 +7652,8 @@ static void corkscrew_rc_track_diag_60_deg_down_to_25_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16715, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16715), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7583,8 +7677,8 @@ static void corkscrew_rc_track_diag_60_deg_down_to_25_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16653, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16653), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7619,8 +7713,8 @@ static void corkscrew_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16701, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16701), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7630,8 +7724,8 @@ static void corkscrew_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16639, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16639), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7646,8 +7740,8 @@ static void corkscrew_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16702, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16702), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7657,8 +7751,8 @@ static void corkscrew_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16640, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16640), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7673,8 +7767,8 @@ static void corkscrew_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16700, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16700), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7684,8 +7778,8 @@ static void corkscrew_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16638, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16638), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7704,8 +7798,8 @@ static void corkscrew_rc_track_diag_25_deg_down_to_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16703, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16703), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7729,8 +7823,8 @@ static void corkscrew_rc_track_diag_25_deg_down_to_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16641, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16641), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7763,8 +7857,8 @@ static void corkscrew_rc_track_diag_flat_to_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16669, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16669), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7776,11 +7870,11 @@ static void corkscrew_rc_track_diag_flat_to_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16666, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16666), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16670, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16670), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7792,8 +7886,8 @@ static void corkscrew_rc_track_diag_flat_to_left_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16668, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16668), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7809,8 +7903,8 @@ static void corkscrew_rc_track_diag_flat_to_left_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16667, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16667), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7842,8 +7936,8 @@ static void corkscrew_rc_track_diag_flat_to_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16674, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16674), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7855,8 +7949,8 @@ static void corkscrew_rc_track_diag_flat_to_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16671, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16671), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7868,11 +7962,11 @@ static void corkscrew_rc_track_diag_flat_to_right_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16673, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16673), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16675, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16675), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7888,8 +7982,8 @@ static void corkscrew_rc_track_diag_flat_to_right_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16672, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16672), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7921,8 +8015,8 @@ static void corkscrew_rc_track_diag_left_bank_to_flat(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16672, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16672), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7934,11 +8028,11 @@ static void corkscrew_rc_track_diag_left_bank_to_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16673, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16673), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16675, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16675), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7950,8 +8044,8 @@ static void corkscrew_rc_track_diag_left_bank_to_flat(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16671, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16671), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7967,8 +8061,8 @@ static void corkscrew_rc_track_diag_left_bank_to_flat(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16674, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16674), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8000,8 +8094,8 @@ static void corkscrew_rc_track_diag_right_bank_to_flat(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16667, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16667), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8013,8 +8107,8 @@ static void corkscrew_rc_track_diag_right_bank_to_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16668, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16668), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8026,11 +8120,11 @@ static void corkscrew_rc_track_diag_right_bank_to_flat(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16666, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16666), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16670, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16670), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8046,8 +8140,8 @@ static void corkscrew_rc_track_diag_right_bank_to_flat(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16669, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16669), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8079,8 +8173,8 @@ static void corkscrew_rc_track_diag_left_bank_to_25_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16689, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16689), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8092,11 +8186,11 @@ static void corkscrew_rc_track_diag_left_bank_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16686, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16686), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16690, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16690), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8108,8 +8202,8 @@ static void corkscrew_rc_track_diag_left_bank_to_25_deg_up(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16688, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16688), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8125,8 +8219,8 @@ static void corkscrew_rc_track_diag_left_bank_to_25_deg_up(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16687, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16687), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8158,8 +8252,8 @@ static void corkscrew_rc_track_diag_right_bank_to_25_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16694, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16694), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8171,8 +8265,8 @@ static void corkscrew_rc_track_diag_right_bank_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16691, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16691), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8184,11 +8278,11 @@ static void corkscrew_rc_track_diag_right_bank_to_25_deg_up(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16693, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16693), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16695, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16695), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8204,8 +8298,8 @@ static void corkscrew_rc_track_diag_right_bank_to_25_deg_up(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16692, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16692), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8237,8 +8331,8 @@ static void corkscrew_rc_track_diag_25_deg_up_to_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16679, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16679), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8250,11 +8344,11 @@ static void corkscrew_rc_track_diag_25_deg_up_to_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16676, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16676), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16680, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16680), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8266,8 +8360,8 @@ static void corkscrew_rc_track_diag_25_deg_up_to_left_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16678, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16678), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8283,8 +8377,8 @@ static void corkscrew_rc_track_diag_25_deg_up_to_left_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16677, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16677), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8316,8 +8410,8 @@ static void corkscrew_rc_track_diag_25_deg_up_to_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16684, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16684), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8329,8 +8423,8 @@ static void corkscrew_rc_track_diag_25_deg_up_to_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16681, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16681), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8342,11 +8436,11 @@ static void corkscrew_rc_track_diag_25_deg_up_to_right_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16683, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16683), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16685, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16685), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8362,8 +8456,8 @@ static void corkscrew_rc_track_diag_25_deg_up_to_right_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16682, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16682), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8395,8 +8489,8 @@ static void corkscrew_rc_track_diag_left_bank_to_25_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16682, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16682), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8407,11 +8501,11 @@ static void corkscrew_rc_track_diag_left_bank_to_25_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16683, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16683), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16685, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16685), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8422,8 +8516,8 @@ static void corkscrew_rc_track_diag_left_bank_to_25_deg_down(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16681, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16681), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8438,8 +8532,8 @@ static void corkscrew_rc_track_diag_left_bank_to_25_deg_down(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16684, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16684), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8472,8 +8566,8 @@ static void corkscrew_rc_track_diag_right_bank_to_25_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16677, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16677), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8484,8 +8578,8 @@ static void corkscrew_rc_track_diag_right_bank_to_25_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16678, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16678), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8496,11 +8590,11 @@ static void corkscrew_rc_track_diag_right_bank_to_25_deg_down(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16676, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16676), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16680, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16680), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8515,8 +8609,8 @@ static void corkscrew_rc_track_diag_right_bank_to_25_deg_down(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16679, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16679), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8549,8 +8643,8 @@ static void corkscrew_rc_track_diag_25_deg_down_to_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16692, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16692), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8562,11 +8656,11 @@ static void corkscrew_rc_track_diag_25_deg_down_to_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16693, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16693), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16695, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16695), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8578,8 +8672,8 @@ static void corkscrew_rc_track_diag_25_deg_down_to_left_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16691, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16691), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8595,8 +8689,8 @@ static void corkscrew_rc_track_diag_25_deg_down_to_left_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16694, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16694), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8628,8 +8722,8 @@ static void corkscrew_rc_track_diag_25_deg_down_to_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16687, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16687), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8641,8 +8735,8 @@ static void corkscrew_rc_track_diag_25_deg_down_to_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16688, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16688), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8654,11 +8748,11 @@ static void corkscrew_rc_track_diag_25_deg_down_to_right_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16686, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16686), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16690, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16690), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8674,8 +8768,8 @@ static void corkscrew_rc_track_diag_25_deg_down_to_right_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16689, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16689), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8707,8 +8801,8 @@ static void corkscrew_rc_track_diag_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16665, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16665), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8720,8 +8814,8 @@ static void corkscrew_rc_track_diag_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16662, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16662), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8733,8 +8827,8 @@ static void corkscrew_rc_track_diag_left_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16664, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16664), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8750,8 +8844,8 @@ static void corkscrew_rc_track_diag_left_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16663, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16663), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8783,8 +8877,8 @@ static void corkscrew_rc_track_diag_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16663, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16663), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8796,8 +8890,8 @@ static void corkscrew_rc_track_diag_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16664, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16664), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8809,8 +8903,8 @@ static void corkscrew_rc_track_diag_right_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16662, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16662), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8826,8 +8920,8 @@ static void corkscrew_rc_track_diag_right_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16665, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16665), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8854,7 +8948,7 @@ static void corkscrew_rc_track_block_brakes(
 {
     bool isClosed = trackElement.BlockBrakeClosed();
     PaintAddImageAsParentRotated(
-        session, direction, session.TrackColours[SCHEME_TRACK] | _CorkscrewRCBlockBrakeImages[direction][isClosed],
+        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(_CorkscrewRCBlockBrakeImages[direction][isClosed]),
         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
     metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
@@ -8883,20 +8977,20 @@ static void corkscrew_rc_track_booster(
         case 0:
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | sprite_ne_sw_behind, { 0, 0, height }, { 32, 20, 3 },
-                { 0, 6, height });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(sprite_ne_sw_behind), { 0, 0, height },
+                { 32, 20, 3 }, { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | sprite_ne_sw_after, { 0, 0, height }, { 32, 1, 26 },
-                { 0, 27, height });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(sprite_ne_sw_after), { 0, 0, height },
+                { 32, 1, 26 }, { 0, 27, height });
             break;
         case 1:
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | sprite_nw_se_behind, { 0, 0, height }, { 32, 20, 3 },
-                { 0, 6, height });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(sprite_nw_se_behind), { 0, 0, height },
+                { 32, 20, 3 }, { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | sprite_nw_se_after, { 0, 0, height }, { 32, 1, 26 },
-                { 0, 27, height });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(sprite_nw_se_after), { 0, 0, height },
+                { 32, 1, 26 }, { 0, 27, height });
             break;
     }
     if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -8920,19 +9014,23 @@ static void corkscrew_rc_track_left_twist_down_to_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26972, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26972), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26978, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26978), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26971, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26971), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26977, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26977), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -8953,19 +9051,23 @@ static void corkscrew_rc_track_left_twist_down_to_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26973, { 0, 6, height + 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26973), { 0, 6, height + 8 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26979, { 0, 6, height + 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26979), { 0, 6, height + 8 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26970, { 0, 6, height + 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26970), { 0, 6, height + 8 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26976, { 0, 6, height + 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26976), { 0, 6, height + 8 },
+                        { 32, 20, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8980,19 +9082,23 @@ static void corkscrew_rc_track_left_twist_down_to_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26974, { 0, 6, height - 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26974), { 0, 6, height - 8 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26980, { 0, 6, height - 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26980), { 0, 6, height - 8 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26969, { 0, 6, height - 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26969), { 0, 6, height - 8 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26975, { 0, 6, height - 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26975), { 0, 6, height - 8 },
+                        { 32, 20, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -9028,19 +9134,23 @@ static void corkscrew_rc_track_right_twist_down_to_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26984, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26984), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26990, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26990), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26983, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26983), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26989, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26989), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -9061,19 +9171,23 @@ static void corkscrew_rc_track_right_twist_down_to_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26985, { 0, 6, height + 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26985), { 0, 6, height + 8 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26991, { 0, 6, height + 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26991), { 0, 6, height + 8 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26982, { 0, 6, height + 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26982), { 0, 6, height + 8 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26988, { 0, 6, height + 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26988), { 0, 6, height + 8 },
+                        { 32, 20, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -9088,19 +9202,23 @@ static void corkscrew_rc_track_right_twist_down_to_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26986, { 0, 6, height - 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26986), { 0, 6, height - 8 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26992, { 0, 6, height - 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26992), { 0, 6, height - 8 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26981, { 0, 6, height - 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26981), { 0, 6, height - 8 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26987, { 0, 6, height - 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26987), { 0, 6, height - 8 },
+                        { 32, 20, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -9136,19 +9254,23 @@ static void corkscrew_rc_track_left_twist_up_to_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26969, { 0, 6, height - 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26969), { 0, 6, height - 8 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26975, { 0, 6, height - 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26975), { 0, 6, height - 8 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26974, { 0, 6, height - 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26974), { 0, 6, height - 8 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26980, { 0, 6, height - 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26980), { 0, 6, height - 8 },
+                        { 32, 20, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -9170,19 +9292,23 @@ static void corkscrew_rc_track_left_twist_up_to_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26970, { 0, 6, height + 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26970), { 0, 6, height + 8 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26976, { 0, 6, height + 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26976), { 0, 6, height + 8 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26973, { 0, 6, height + 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26973), { 0, 6, height + 8 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26979, { 0, 6, height + 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26979), { 0, 6, height + 8 },
+                        { 32, 20, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -9197,19 +9323,23 @@ static void corkscrew_rc_track_left_twist_up_to_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26971, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26971), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26977, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26977), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26972, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26972), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26978, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26978), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -9244,19 +9374,23 @@ static void corkscrew_rc_track_right_twist_up_to_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26981, { 0, 6, height - 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26981), { 0, 6, height - 8 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26987, { 0, 6, height - 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26987), { 0, 6, height - 8 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26986, { 0, 6, height - 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26986), { 0, 6, height - 8 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26992, { 0, 6, height - 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26992), { 0, 6, height - 8 },
+                        { 32, 20, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -9278,19 +9412,23 @@ static void corkscrew_rc_track_right_twist_up_to_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26982, { 0, 6, height + 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26982), { 0, 6, height + 8 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26988, { 0, 6, height + 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26988), { 0, 6, height + 8 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26985, { 0, 6, height + 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26985), { 0, 6, height + 8 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26991, { 0, 6, height + 8 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26991), { 0, 6, height + 8 },
+                        { 32, 20, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -9305,19 +9443,23 @@ static void corkscrew_rc_track_right_twist_up_to_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26983, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26983), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26989, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26989), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26984, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26984), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26990, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26990), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(

--- a/src/openrct2/ride/coaster/FlyingRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/FlyingRollerCoaster.cpp
@@ -32,23 +32,23 @@ static void flying_rc_track_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17486, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17486), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17487, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17487), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17488, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17488), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17489, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17489), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -64,14 +64,14 @@ static void flying_rc_track_flat(
                 case 0:
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17146, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17146), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17147, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17147), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -94,14 +94,14 @@ static void flying_rc_track_flat(
                 case 0:
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27131, { 0, 0, height + 24 }, { 32, 20, 1 },
-                        { 0, 6, height + 22 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27131), { 0, 0, height + 24 },
+                        { 32, 20, 1 }, { 0, 6, height + 22 });
                     break;
                 case 1:
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27132, { 0, 0, height + 24 }, { 32, 20, 1 },
-                        { 0, 6, height + 22 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27132), { 0, 0, height + 24 },
+                        { 32, 20, 1 }, { 0, 6, height + 22 });
                     break;
             }
         }
@@ -112,14 +112,14 @@ static void flying_rc_track_flat(
                 case 0:
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27129, { 0, 0, height + 24 }, { 32, 20, 1 },
-                        { 0, 6, height + 22 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27129), { 0, 0, height + 24 },
+                        { 32, 20, 1 }, { 0, 6, height + 22 });
                     break;
                 case 1:
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27130, { 0, 0, height + 24 }, { 32, 20, 1 },
-                        { 0, 6, height + 22 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27130), { 0, 0, height + 24 },
+                        { 32, 20, 1 }, { 0, 6, height + 22 });
                     break;
             }
         }
@@ -151,13 +151,13 @@ static void flying_rc_track_station(
             { SPR_STATION_BASE_C_NW_SE, 27132, SPR_STATION_INVERTED_BAR_C_NW_SE },
         };
         PaintAddImageAsParentRotated(
-            session, direction, imageIds[direction][0] | session.TrackColours[SCHEME_MISC], { 0, 0, height }, { 32, 28, 1 },
-            { 0, 2, height });
+            session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][0]), { 0, 0, height },
+            { 32, 28, 1 }, { 0, 2, height });
         PaintAddImageAsParentRotated(
-            session, direction, imageIds[direction][1] | session.TrackColours[SCHEME_TRACK], { 0, 0, height + 24 },
+            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][1]), { 0, 0, height + 24 },
             { 32, 20, 3 }, { 0, 6, height + 24 });
         PaintAddImageAsChildRotated(
-            session, direction, imageIds[direction][2] | session.TrackColours[SCHEME_SUPPORTS], { 0, 6, height + 24 },
+            session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(imageIds[direction][2]), { 0, 6, height + 24 },
             { 32, 20, 1 }, { 0, 6, height + 24 });
         track_paint_util_draw_station_metal_supports_2(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], 11);
         track_paint_util_draw_station_inverted(session, ride, direction, height, trackElement, STATION_VARIANT_1);
@@ -174,17 +174,18 @@ static void flying_rc_track_station(
         if (trackElement.GetTrackType() == TrackElemType::EndStation)
         {
             PaintAddImageAsParentRotated(
-                session, direction, imageIds[direction][1] | session.TrackColours[SCHEME_TRACK], { 0, 0, height },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][1]), { 0, 0, height },
                 { 32, 20, 1 }, { 0, 6, height + 3 });
         }
         else
         {
             PaintAddImageAsParentRotated(
-                session, direction, imageIds[direction][0] | session.TrackColours[SCHEME_TRACK], { 0, 0, height },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]), { 0, 0, height },
                 { 32, 20, 1 }, { 0, 6, height + 3 });
         }
         PaintAddImageAsParentRotated(
-            session, direction, imageIds[direction][2] | session.TrackColours[SCHEME_MISC], { 0, 0, height }, { 32, 32, 1 });
+            session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][2]), { 0, 0, height },
+            { 32, 32, 1 });
         track_paint_util_draw_station_metal_supports_2(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], 11);
         track_paint_util_draw_station_2(session, ride, direction, height, trackElement, 9, 11);
     }
@@ -207,23 +208,23 @@ static void flying_rc_track_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17498, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17498), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17499, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17499), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17500, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17500), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17501, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17501), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
         }
@@ -233,23 +234,23 @@ static void flying_rc_track_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17204, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17204), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17205, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17205), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17206, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17206), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17207, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17207), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
         }
@@ -278,23 +279,23 @@ static void flying_rc_track_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27249, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 40 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27249), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 40 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27250, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 40 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27250), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 40 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27251, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 40 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27251), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 40 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27252, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 40 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27252), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 40 });
                     break;
             }
         }
@@ -304,23 +305,23 @@ static void flying_rc_track_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27221, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 40 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27221), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 40 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27222, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 40 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27222), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 40 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27223, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 40 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27223), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 40 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27224, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 40 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27224), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 40 });
                     break;
             }
         }
@@ -373,22 +374,22 @@ static void flying_rc_track_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17220, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17220), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17221, { 0, 0, height }, { 32, 1, 98 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17221), { 0, 0, height }, { 32, 1, 98 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17222, { 0, 0, height }, { 32, 1, 98 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17222), { 0, 0, height }, { 32, 1, 98 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17223, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17223), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -415,23 +416,23 @@ static void flying_rc_track_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27237, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 88 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27237), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 88 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27238, { 0, 0, height + 24 }, { 32, 2, 81 },
-                    { 0, 4, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27238), { 0, 0, height + 24 },
+                    { 32, 2, 81 }, { 0, 4, height + 6 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27239, { 0, 0, height + 24 }, { 32, 2, 81 },
-                    { 0, 4, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27239), { 0, 0, height + 24 },
+                    { 32, 2, 81 }, { 0, 4, height + 6 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27240, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 88 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27240), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 88 });
                 break;
         }
         if (direction == 0 || direction == 3)
@@ -461,23 +462,23 @@ static void flying_rc_track_flat_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17490, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17490), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17491, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17491), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17492, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17492), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17493, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17493), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
         }
@@ -487,23 +488,23 @@ static void flying_rc_track_flat_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17196, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17196), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17197, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17197), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17198, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17198), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17199, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17199), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
         }
@@ -532,23 +533,23 @@ static void flying_rc_track_flat_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27241, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27241), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27242, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27242), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27243, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27243), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27244, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27244), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
             }
         }
@@ -558,23 +559,23 @@ static void flying_rc_track_flat_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27213, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27213), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27214, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27214), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27215, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27215), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27216, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27216), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
             }
         }
@@ -627,28 +628,28 @@ static void flying_rc_track_25_deg_up_to_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17208, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17208), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17209, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17209), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17212, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17212), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17210, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17210), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17213, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17213), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17211, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17211), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -675,29 +676,29 @@ static void flying_rc_track_25_deg_up_to_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27225, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 56 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27225), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 56 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27229, { 0, 0, height + 24 }, { 32, 10, 49 },
-                    { 0, 10, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27229), { 0, 0, height + 24 },
+                    { 32, 10, 49 }, { 0, 10, height + 6 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27226, { 0, 0, height + 24 }, { 32, 2, 49 },
-                    { 0, 4, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27226), { 0, 0, height + 24 },
+                    { 32, 2, 49 }, { 0, 4, height + 6 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27230, { 0, 0, height + 24 }, { 32, 10, 49 },
-                    { 0, 10, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27230), { 0, 0, height + 24 },
+                    { 32, 10, 49 }, { 0, 10, height + 6 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27227, { 0, 0, height + 24 }, { 32, 2, 49 },
-                    { 0, 4, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27227), { 0, 0, height + 24 },
+                    { 32, 2, 49 }, { 0, 4, height + 6 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27228, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 56 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27228), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 56 });
                 break;
         }
         if (direction == 0 || direction == 3)
@@ -725,28 +726,28 @@ static void flying_rc_track_60_deg_up_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17214, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17214), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17215, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17215), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17218, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17218), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17216, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17216), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17219, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17219), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17217, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17217), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -773,29 +774,29 @@ static void flying_rc_track_60_deg_up_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27231, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 56 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27231), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 56 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27235, { 0, 0, height + 24 }, { 32, 10, 49 },
-                    { 0, 10, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27235), { 0, 0, height + 24 },
+                    { 32, 10, 49 }, { 0, 10, height + 6 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27232, { 0, 0, height + 24 }, { 32, 2, 49 },
-                    { 0, 4, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27232), { 0, 0, height + 24 },
+                    { 32, 2, 49 }, { 0, 4, height + 6 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27236, { 0, 0, height + 24 }, { 32, 10, 49 },
-                    { 0, 10, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27236), { 0, 0, height + 24 },
+                    { 32, 10, 49 }, { 0, 10, height + 6 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27233, { 0, 0, height + 24 }, { 32, 2, 49 },
-                    { 0, 4, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27233), { 0, 0, height + 24 },
+                    { 32, 2, 49 }, { 0, 4, height + 6 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27234, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 56 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27234), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 56 });
                 break;
         }
 
@@ -849,23 +850,23 @@ static void flying_rc_track_25_deg_up_to_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17494, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17494), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17495, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17495), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17496, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17496), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17497, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17497), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
         }
@@ -875,23 +876,23 @@ static void flying_rc_track_25_deg_up_to_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17200, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17200), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17201, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17201), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17202, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17202), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17203, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17203), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
         }
@@ -920,23 +921,23 @@ static void flying_rc_track_25_deg_up_to_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27245, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27245), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27246, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27246), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27247, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27247), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27248, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27248), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
             }
         }
@@ -946,23 +947,23 @@ static void flying_rc_track_25_deg_up_to_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27217, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27217), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27218, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27218), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27219, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27219), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27220, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27220), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
             }
         }
@@ -1066,23 +1067,23 @@ static void flying_rc_track_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17259, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17259), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17264, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17264), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17269, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17269), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17254, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17254), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -1104,23 +1105,23 @@ static void flying_rc_track_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17258, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17258), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17263, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17263), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17268, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17268), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17253, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17253), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -1135,23 +1136,23 @@ static void flying_rc_track_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17257, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17257), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17262, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17262), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 16, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17267, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17267), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17252, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17252), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -1167,23 +1168,23 @@ static void flying_rc_track_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17256, { 0, 0, height }, { 16, 32, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17256), { 0, 0, height },
+                            { 16, 32, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17261, { 0, 0, height }, { 16, 32, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17261), { 0, 0, height },
+                            { 16, 32, 3 }, { 0, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17266, { 0, 0, height }, { 16, 32, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17266), { 0, 0, height },
+                            { 16, 32, 3 }, { 0, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17251, { 0, 0, height }, { 16, 32, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17251), { 0, 0, height },
+                            { 16, 32, 3 }, { 16, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -1198,23 +1199,23 @@ static void flying_rc_track_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17255, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17255), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17260, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17260), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17265, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17265), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17250, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17250), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -1244,22 +1245,22 @@ static void flying_rc_track_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27142, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27142), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27147, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27147), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27152, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27152), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27137, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27137), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                 }
@@ -1285,22 +1286,22 @@ static void flying_rc_track_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27141, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27141), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27146, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27146), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27151, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27151), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 16, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27136, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27136), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 16, height + 22 });
                         break;
                 }
@@ -1316,22 +1317,22 @@ static void flying_rc_track_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27140, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27140), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 16, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27145, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27145), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 16, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27150, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27150), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 0, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27135, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27135), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 0, height + 22 });
                         break;
                 }
@@ -1348,22 +1349,22 @@ static void flying_rc_track_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27139, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27139), { 0, 0, height + 24 },
                             { 16, 32, 3 }, { 16, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27144, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27144), { 0, 0, height + 24 },
                             { 16, 32, 3 }, { 0, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27149, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27149), { 0, 0, height + 24 },
                             { 16, 32, 3 }, { 0, 0, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27134, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27134), { 0, 0, height + 24 },
                             { 16, 32, 3 }, { 16, 0, height + 22 });
                         break;
                 }
@@ -1379,22 +1380,22 @@ static void flying_rc_track_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27138, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27138), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27143, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27143), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27148, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27148), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27133, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27133), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 22 });
                         break;
                 }
@@ -1441,28 +1442,28 @@ static void flying_rc_track_flat_to_left_bank(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17156, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17156), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17164, { 0, 0, height }, { 32, 1, 26 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17164), { 0, 0, height }, { 32, 1, 26 },
                     { 0, 27, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17157, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17157), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17165, { 0, 0, height }, { 32, 1, 26 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17165), { 0, 0, height }, { 32, 1, 26 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17158, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17158), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17159, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17159), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -1482,23 +1483,23 @@ static void flying_rc_track_flat_to_left_bank(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27269, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27269), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27270, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27270), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27271, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27271), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27272, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27272), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
         }
 
@@ -1528,28 +1529,28 @@ static void flying_rc_track_flat_to_right_bank(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17160, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17160), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17161, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17161), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17162, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17162), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17166, { 0, 0, height }, { 32, 1, 26 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17166), { 0, 0, height }, { 32, 1, 26 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17163, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17163), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17167, { 0, 0, height }, { 32, 1, 26 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17167), { 0, 0, height }, { 32, 1, 26 },
                     { 0, 27, height });
                 break;
         }
@@ -1569,23 +1570,23 @@ static void flying_rc_track_flat_to_right_bank(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27273, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27273), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27274, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27274), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27275, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27275), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27276, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27276), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
         }
 
@@ -1615,28 +1616,28 @@ static void flying_rc_track_left_bank_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17162, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17162), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17166, { 0, 0, height }, { 32, 1, 26 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17166), { 0, 0, height }, { 32, 1, 26 },
                     { 0, 27, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17163, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17163), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17167, { 0, 0, height }, { 32, 1, 26 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17167), { 0, 0, height }, { 32, 1, 26 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17160, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17160), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17161, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17161), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -1656,23 +1657,23 @@ static void flying_rc_track_left_bank_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27275, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27275), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27276, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27276), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27273, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27273), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27274, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27274), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
         }
 
@@ -1702,28 +1703,28 @@ static void flying_rc_track_right_bank_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17158, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17158), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17159, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17159), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17156, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17156), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17164, { 0, 0, height }, { 32, 1, 26 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17164), { 0, 0, height }, { 32, 1, 26 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17157, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17157), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17165, { 0, 0, height }, { 32, 1, 26 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17165), { 0, 0, height }, { 32, 1, 26 },
                     { 0, 27, height });
                 break;
         }
@@ -1743,23 +1744,23 @@ static void flying_rc_track_right_bank_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27271, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27271), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27272, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27272), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27269, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27269), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27270, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27270), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
         }
 
@@ -1792,26 +1793,26 @@ static void flying_rc_track_banked_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17279, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17279), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17290, { 0, 0, height }, { 32, 1, 26 },
-                            { 0, 27, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17290), { 0, 0, height },
+                            { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17284, { 0, 0, height }, { 32, 1, 26 },
-                            { 0, 27, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17284), { 0, 0, height },
+                            { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17289, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17289), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17274, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17274), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -1833,23 +1834,23 @@ static void flying_rc_track_banked_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17278, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17278), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17283, { 0, 0, height }, { 32, 16, 1 },
-                            { 0, 0, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17283), { 0, 0, height },
+                            { 32, 16, 1 }, { 0, 0, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17288, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17288), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17273, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17273), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -1864,23 +1865,23 @@ static void flying_rc_track_banked_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17277, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17277), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17282, { 0, 0, height }, { 16, 16, 1 },
-                            { 16, 16, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17282), { 0, 0, height },
+                            { 16, 16, 1 }, { 16, 16, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17287, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17287), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17272, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17272), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -1896,23 +1897,23 @@ static void flying_rc_track_banked_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17276, { 0, 0, height }, { 16, 32, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17276), { 0, 0, height },
+                            { 16, 32, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17281, { 0, 0, height }, { 16, 32, 1 },
-                            { 0, 0, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17281), { 0, 0, height },
+                            { 16, 32, 1 }, { 0, 0, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17286, { 0, 0, height }, { 16, 32, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17286), { 0, 0, height },
+                            { 16, 32, 3 }, { 0, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17271, { 0, 0, height }, { 16, 32, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17271), { 0, 0, height },
+                            { 16, 32, 3 }, { 16, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -1927,26 +1928,26 @@ static void flying_rc_track_banked_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17275, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17275), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17280, { 0, 0, height }, { 1, 32, 26 },
-                            { 27, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17280), { 0, 0, height },
+                            { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17285, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17285), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17291, { 0, 0, height }, { 1, 32, 26 },
-                            { 27, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17291), { 0, 0, height },
+                            { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17270, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17270), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -1976,22 +1977,22 @@ static void flying_rc_track_banked_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27162, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27162), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 24 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27167, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27167), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 24 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27172, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27172), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 24 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27157, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27157), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 24 });
                         break;
                 }
@@ -2017,22 +2018,22 @@ static void flying_rc_track_banked_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27161, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27161), { 0, 0, height + 24 },
                             { 32, 16, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27166, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27166), { 0, 0, height + 24 },
                             { 32, 16, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27171, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27171), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 16, height + 24 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27156, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27156), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 16, height + 24 });
                         break;
                 }
@@ -2048,22 +2049,22 @@ static void flying_rc_track_banked_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27160, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27160), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 16, height + 24 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27165, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27165), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 16, height + 24 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27170, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27170), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 0, height + 24 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27155, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27155), { 0, 0, height + 24 },
                             { 16, 16, 3 });
                         break;
                 }
@@ -2080,22 +2081,22 @@ static void flying_rc_track_banked_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27159, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27159), { 0, 0, height + 24 },
                             { 16, 32, 3 }, { 16, 0, height + 24 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27164, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27164), { 0, 0, height + 24 },
                             { 16, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27169, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27169), { 0, 0, height + 24 },
                             { 16, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27154, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27154), { 0, 0, height + 24 },
                             { 16, 32, 3 }, { 16, 0, height + 24 });
                         break;
                 }
@@ -2111,22 +2112,22 @@ static void flying_rc_track_banked_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27158, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27158), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 24 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27163, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27163), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 24 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27168, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27168), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 24 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27153, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27153), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 24 });
                         break;
                 }
@@ -2173,28 +2174,28 @@ static void flying_rc_track_left_bank_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17168, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17168), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17172, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17172), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17169, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17169), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17173, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17173), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17170, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17170), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17171, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17171), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -2221,23 +2222,23 @@ static void flying_rc_track_left_bank_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27277, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27277), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27278, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27278), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27279, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27279), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27280, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27280), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
         }
 
@@ -2291,28 +2292,28 @@ static void flying_rc_track_right_bank_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17174, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17174), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17175, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17175), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17176, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17176), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17178, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17178), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17177, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17177), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17179, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17179), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
         }
@@ -2339,23 +2340,23 @@ static void flying_rc_track_right_bank_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27281, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27281), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27282, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27282), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27283, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27283), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27284, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27284), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
         }
 
@@ -2409,28 +2410,28 @@ static void flying_rc_track_25_deg_up_to_left_bank(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17180, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17180), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17184, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17184), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17181, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17181), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17185, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17185), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17182, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17182), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17183, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17183), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -2457,23 +2458,23 @@ static void flying_rc_track_25_deg_up_to_left_bank(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27285, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27285), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27286, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27286), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27287, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27287), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27288, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27288), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
         }
 
@@ -2527,28 +2528,28 @@ static void flying_rc_track_25_deg_up_to_right_bank(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17186, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17186), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17187, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17187), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17188, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17188), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17190, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17190), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17189, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17189), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17191, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17191), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
         }
@@ -2575,23 +2576,23 @@ static void flying_rc_track_25_deg_up_to_right_bank(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27289, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27289), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27290, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27290), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27291, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27291), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27292, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27292), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
         }
 
@@ -2677,22 +2678,22 @@ static void flying_rc_track_left_bank(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17192, { 0, 0, height }, { 32, 1, 26 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17192), { 0, 0, height }, { 32, 1, 26 },
                     { 0, 27, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17193, { 0, 0, height }, { 32, 1, 26 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17193), { 0, 0, height }, { 32, 1, 26 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17194, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17194), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17195, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17195), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -2712,23 +2713,23 @@ static void flying_rc_track_left_bank(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27293, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27293), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27294, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27294), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27295, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27295), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27296, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27296), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
         }
 
@@ -2769,23 +2770,23 @@ static void flying_rc_track_left_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17344, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17344), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17349, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17349), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17354, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17354), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17359, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17359), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -2807,21 +2808,23 @@ static void flying_rc_track_left_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17345, { 0, 0, height }, { 32, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17345), { 0, 0, height },
+                            { 32, 16, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17350, { 0, 0, height }, { 32, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17350), { 0, 0, height },
+                            { 32, 16, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17355, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17355), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17360, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17360), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -2836,22 +2839,23 @@ static void flying_rc_track_left_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17346, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17346), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17351, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17351), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 16, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17356, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17356), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17361, { 0, 0, height }, { 16, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17361), { 0, 0, height },
+                            { 16, 16, 3 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -2867,21 +2871,23 @@ static void flying_rc_track_left_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17347, { 0, 0, height }, { 16, 32, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17347), { 0, 0, height },
+                            { 16, 32, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17352, { 0, 0, height }, { 16, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17352), { 0, 0, height },
+                            { 16, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17357, { 0, 0, height }, { 16, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17357), { 0, 0, height },
+                            { 16, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17362, { 0, 0, height }, { 16, 32, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17362), { 0, 0, height },
+                            { 16, 32, 3 }, { 16, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -2896,23 +2902,23 @@ static void flying_rc_track_left_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17348, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17348), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17353, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17353), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17358, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17358), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17363, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17363), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -2942,22 +2948,22 @@ static void flying_rc_track_left_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27317, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27317), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27322, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27322), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27327, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27327), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27332, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27332), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                 }
@@ -2983,22 +2989,22 @@ static void flying_rc_track_left_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27318, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27318), { 0, 0, height + 24 },
                             { 32, 16, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27323, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27323), { 0, 0, height + 24 },
                             { 32, 16, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27328, { 0, 16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27328), { 0, 16, height + 24 },
                             { 32, 16, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27333, { 0, 16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27333), { 0, 16, height + 24 },
                             { 32, 16, 3 });
                         break;
                 }
@@ -3014,22 +3020,22 @@ static void flying_rc_track_left_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27319, { 0, 16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27319), { 0, 16, height + 24 },
                             { 16, 16, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27324, { 16, 16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27324), { 16, 16, height + 24 },
                             { 16, 16, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27329, { 16, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27329), { 16, 0, height + 24 },
                             { 16, 16, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27334, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27334), { 0, 0, height + 24 },
                             { 16, 16, 3 });
                         break;
                 }
@@ -3046,22 +3052,22 @@ static void flying_rc_track_left_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27320, { 16, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27320), { 16, 0, height + 24 },
                             { 16, 32, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27325, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27325), { 0, 0, height + 24 },
                             { 16, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27330, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27330), { 0, 0, height + 24 },
                             { 16, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27335, { 16, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27335), { 16, 0, height + 24 },
                             { 16, 32, 3 });
                         break;
                 }
@@ -3077,22 +3083,22 @@ static void flying_rc_track_left_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27321, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27321), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27326, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27326), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27331, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27331), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27336, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27336), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                 }
@@ -3133,23 +3139,23 @@ static void flying_rc_track_right_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17324, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17324), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17329, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17329), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17334, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17334), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17339, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17339), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -3171,21 +3177,23 @@ static void flying_rc_track_right_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17325, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17325), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17330, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17330), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17335, { 0, 0, height }, { 32, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17335), { 0, 0, height },
+                            { 32, 16, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17340, { 0, 0, height }, { 32, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17340), { 0, 0, height },
+                            { 32, 16, 3 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -3200,22 +3208,23 @@ static void flying_rc_track_right_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17326, { 0, 0, height }, { 16, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17326), { 0, 0, height },
+                            { 16, 16, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17331, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17331), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17336, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17336), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17341, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17341), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -3231,21 +3240,23 @@ static void flying_rc_track_right_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17327, { 0, 0, height }, { 16, 32, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17327), { 0, 0, height },
+                            { 16, 32, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17332, { 0, 0, height }, { 16, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17332), { 0, 0, height },
+                            { 16, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17337, { 0, 0, height }, { 16, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17337), { 0, 0, height },
+                            { 16, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17342, { 0, 0, height }, { 16, 32, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17342), { 0, 0, height },
+                            { 16, 32, 3 }, { 16, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -3260,23 +3271,23 @@ static void flying_rc_track_right_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17328, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17328), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17333, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17333), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17338, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17338), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17343, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17343), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -3306,22 +3317,22 @@ static void flying_rc_track_right_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27297, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27297), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27302, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27302), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27307, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27307), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27312, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27312), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                 }
@@ -3347,22 +3358,22 @@ static void flying_rc_track_right_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27298, { 0, 16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27298), { 0, 16, height + 24 },
                             { 32, 16, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27303, { 0, 16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27303), { 0, 16, height + 24 },
                             { 32, 16, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27308, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27308), { 0, 0, height + 24 },
                             { 32, 16, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27313, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27313), { 0, 0, height + 24 },
                             { 32, 16, 3 });
                         break;
                 }
@@ -3378,22 +3389,22 @@ static void flying_rc_track_right_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27299, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27299), { 0, 0, height + 24 },
                             { 16, 16, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27304, { 16, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27304), { 16, 0, height + 24 },
                             { 16, 16, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27309, { 16, 16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27309), { 16, 16, height + 24 },
                             { 16, 16, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27314, { 0, 16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27314), { 0, 16, height + 24 },
                             { 16, 16, 3 });
                         break;
                 }
@@ -3410,22 +3421,22 @@ static void flying_rc_track_right_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27300, { 16, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27300), { 16, 0, height + 24 },
                             { 16, 32, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27305, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27305), { 0, 0, height + 24 },
                             { 16, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27310, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27310), { 0, 0, height + 24 },
                             { 16, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27315, { 16, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27315), { 16, 0, height + 24 },
                             { 16, 32, 3 });
                         break;
                 }
@@ -3441,22 +3452,22 @@ static void flying_rc_track_right_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27301, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27301), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27306, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27306), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27311, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27311), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27316, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27316), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                 }
@@ -3515,23 +3526,23 @@ static void flying_rc_track_s_bend_left(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17308, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17308), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17312, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17312), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17311, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17311), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17315, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17315), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -3550,25 +3561,27 @@ static void flying_rc_track_s_bend_left(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17309, { 0, 0, height }, { 32, 26, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17309), { 0, 0, height },
+                            { 32, 26, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17313, { 0, 0, height }, { 32, 26, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17313), { 0, 0, height },
+                            { 32, 26, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 6, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17310, { 0, 0, height }, { 32, 26, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17310), { 0, 0, height },
+                            { 32, 26, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17314, { 0, 0, height }, { 32, 26, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17314), { 0, 0, height },
+                            { 32, 26, 3 }, { 0, 6, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -3583,23 +3596,25 @@ static void flying_rc_track_s_bend_left(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17310, { 0, 0, height }, { 32, 26, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17310), { 0, 0, height },
+                            { 32, 26, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17314, { 0, 0, height }, { 32, 26, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17314), { 0, 0, height },
+                            { 32, 26, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17309, { 0, 0, height }, { 32, 26, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17309), { 0, 0, height },
+                            { 32, 26, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17313, { 0, 0, height }, { 32, 26, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17313), { 0, 0, height },
+                            { 32, 26, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 6, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -3616,23 +3631,23 @@ static void flying_rc_track_s_bend_left(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17311, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17311), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17315, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17315), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17308, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17308), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17312, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17312), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -3662,22 +3677,22 @@ static void flying_rc_track_s_bend_left(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27253, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27253), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27257, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27257), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27256, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27256), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27260, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27260), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                 }
@@ -3699,22 +3714,22 @@ static void flying_rc_track_s_bend_left(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27254, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27254), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27258, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27258), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27255, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27255), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 6, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27259, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27259), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 6, height + 22 });
                         break;
                 }
@@ -3743,22 +3758,22 @@ static void flying_rc_track_s_bend_left(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27255, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27255), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 6, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27259, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27259), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 6, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27254, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27254), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 0, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27258, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27258), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 0, height + 22 });
                         break;
                 }
@@ -3787,22 +3802,22 @@ static void flying_rc_track_s_bend_left(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27256, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27256), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27260, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27260), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27253, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27253), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27257, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27257), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                 }
@@ -3842,23 +3857,23 @@ static void flying_rc_track_s_bend_right(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17316, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17316), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17320, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17320), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17319, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17319), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17323, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17323), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -3877,25 +3892,27 @@ static void flying_rc_track_s_bend_right(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17317, { 0, 0, height }, { 32, 26, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17317), { 0, 0, height },
+                            { 32, 26, 3 }, { 0, 6, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17321, { 0, 0, height }, { 32, 26, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17321), { 0, 0, height },
+                            { 32, 26, 3 }, { 0, 6, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17318, { 0, 0, height }, { 32, 26, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17318), { 0, 0, height },
+                            { 32, 26, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17322, { 0, 0, height }, { 32, 26, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17322), { 0, 0, height },
+                            { 32, 26, 3 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -3910,23 +3927,25 @@ static void flying_rc_track_s_bend_right(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17318, { 0, 0, height }, { 32, 26, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17318), { 0, 0, height },
+                            { 32, 26, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17322, { 0, 0, height }, { 32, 26, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17322), { 0, 0, height },
+                            { 32, 26, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17317, { 0, 0, height }, { 32, 26, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17317), { 0, 0, height },
+                            { 32, 26, 3 }, { 0, 6, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17321, { 0, 0, height }, { 32, 26, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17321), { 0, 0, height },
+                            { 32, 26, 3 }, { 0, 6, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -3943,23 +3962,23 @@ static void flying_rc_track_s_bend_right(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17319, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17319), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17323, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17323), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17316, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17316), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17320, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17320), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -3989,22 +4008,22 @@ static void flying_rc_track_s_bend_right(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27261, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27261), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27265, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27265), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27264, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27264), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27268, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27268), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                 }
@@ -4026,22 +4045,22 @@ static void flying_rc_track_s_bend_right(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27262, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27262), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 6, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27266, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27266), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 6, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27263, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27263), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 0, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27267, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27267), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 0, height + 22 });
                         break;
                 }
@@ -4070,22 +4089,22 @@ static void flying_rc_track_s_bend_right(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27263, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27263), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27267, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27267), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27262, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27262), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 6, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27266, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27266), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 6, height + 22 });
                         break;
                 }
@@ -4114,22 +4133,22 @@ static void flying_rc_track_s_bend_right(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27264, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27264), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27268, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27268), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27261, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27261), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27265, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27265), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                 }
@@ -4169,23 +4188,23 @@ static void flying_rc_track_left_quarter_turn_3(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17229, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17229), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17232, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17232), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17235, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17235), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17226, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17226), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -4207,23 +4226,23 @@ static void flying_rc_track_left_quarter_turn_3(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17228, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17228), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17231, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17231), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17234, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17234), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17225, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17225), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -4236,23 +4255,23 @@ static void flying_rc_track_left_quarter_turn_3(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17227, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17227), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17230, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17230), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17233, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17233), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17224, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17224), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -4282,22 +4301,22 @@ static void flying_rc_track_left_quarter_turn_3(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27392, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27392), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27395, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27395), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27398, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27398), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27389, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27389), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                 }
@@ -4323,22 +4342,22 @@ static void flying_rc_track_left_quarter_turn_3(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27391, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27391), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27394, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27394), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27397, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27397), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 16, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27388, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27388), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 16, height + 22 });
                         break;
                 }
@@ -4352,22 +4371,22 @@ static void flying_rc_track_left_quarter_turn_3(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27390, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27390), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27393, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27393), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27396, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27396), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27387, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27387), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 22 });
                         break;
                 }
@@ -4417,26 +4436,26 @@ static void flying_rc_track_left_quarter_turn_3_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17241, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17241), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17248, { 0, 0, height }, { 32, 1, 26 },
-                            { 0, 27, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17248), { 0, 0, height },
+                            { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17244, { 0, 0, height }, { 32, 1, 26 },
-                            { 0, 27, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17244), { 0, 0, height },
+                            { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17247, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17247), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17238, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17238), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -4458,23 +4477,23 @@ static void flying_rc_track_left_quarter_turn_3_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17240, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17240), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17243, { 0, 0, height }, { 16, 16, 1 },
-                            { 0, 0, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17243), { 0, 0, height },
+                            { 16, 16, 1 }, { 0, 0, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17246, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17246), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17237, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17237), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -4487,26 +4506,26 @@ static void flying_rc_track_left_quarter_turn_3_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17239, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17239), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17242, { 0, 0, height }, { 1, 32, 26 },
-                            { 27, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17242), { 0, 0, height },
+                            { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17245, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17245), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17249, { 0, 0, height }, { 1, 32, 26 },
-                            { 27, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17249), { 0, 0, height },
+                            { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17236, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17236), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -4536,22 +4555,22 @@ static void flying_rc_track_left_quarter_turn_3_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27404, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27404), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27407, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27407), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27410, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27410), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27401, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27401), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                 }
@@ -4577,22 +4596,22 @@ static void flying_rc_track_left_quarter_turn_3_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27403, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27403), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27406, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27406), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27409, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27409), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 16, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27400, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27400), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 16, height + 22 });
                         break;
                 }
@@ -4606,22 +4625,22 @@ static void flying_rc_track_left_quarter_turn_3_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27402, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27402), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27405, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27405), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27408, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27408), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27399, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27399), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 22 });
                         break;
                 }
@@ -4671,19 +4690,23 @@ static void flying_rc_track_left_quarter_turn_3_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17375, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17375), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17377, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17377), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17379, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17379), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17373, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17373), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -4708,19 +4731,23 @@ static void flying_rc_track_left_quarter_turn_3_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17374, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17374), { 6, 0, height },
+                            { 20, 32, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17376, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17376), { 6, 0, height },
+                            { 20, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17378, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17378), { 6, 0, height },
+                            { 20, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17372, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17372), { 6, 0, height },
+                            { 20, 32, 3 });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -4750,22 +4777,22 @@ static void flying_rc_track_left_quarter_turn_3_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27422, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27422), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27424, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27424), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27426, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27426), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27420, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27420), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                 }
@@ -4794,22 +4821,22 @@ static void flying_rc_track_left_quarter_turn_3_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27421, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27421), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27423, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27423), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27425, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27425), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27419, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27419), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                 }
@@ -4850,19 +4877,23 @@ static void flying_rc_track_right_quarter_turn_3_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17364, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17364), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17366, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17366), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17368, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17368), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17370, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17370), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -4887,25 +4918,29 @@ static void flying_rc_track_right_quarter_turn_3_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17365, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17365), { 6, 0, height },
+                            { 20, 32, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17367, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17367), { 6, 0, height },
+                            { 20, 32, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17369, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17369), { 6, 0, height },
+                            { 20, 32, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 4, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17371, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17371), { 6, 0, height },
+                            { 20, 32, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -4935,22 +4970,22 @@ static void flying_rc_track_right_quarter_turn_3_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27411, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27411), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27413, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27413), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27415, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27415), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27417, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27417), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                 }
@@ -4979,22 +5014,22 @@ static void flying_rc_track_right_quarter_turn_3_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27412, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27412), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27414, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27414), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27416, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27416), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27418, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27418), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                 }
@@ -5051,26 +5086,26 @@ static void flying_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17399, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17399), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17406, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17406), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17402, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17402), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17405, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17405), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17396, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17396), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -5092,23 +5127,23 @@ static void flying_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17398, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17398), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17401, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17401), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17404, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17404), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17395, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17395), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5120,26 +5155,26 @@ static void flying_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17397, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17397), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17400, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17400), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17403, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17403), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17407, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17407), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17394, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17394), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 8 });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -5163,26 +5198,26 @@ static void flying_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17396, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17396), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17399, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17399), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17406, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17406), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17402, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17402), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17405, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17405), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -5209,23 +5244,23 @@ static void flying_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17395, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17395), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17398, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17398), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17401, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17401), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17404, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17404), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5237,26 +5272,26 @@ static void flying_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17394, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17394), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17397, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17397), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17400, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17400), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17403, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17403), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17407, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17407), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -5285,26 +5320,26 @@ static void flying_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17380, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17380), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17383, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17383), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17386, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17386), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17389, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17389), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17393, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17393), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -5326,23 +5361,23 @@ static void flying_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17381, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17381), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17384, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17384), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17387, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17387), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17390, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17390), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5354,26 +5389,26 @@ static void flying_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17382, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17382), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17385, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17385), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17392, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17392), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17388, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17388), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17391, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17391), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -5397,26 +5432,26 @@ static void flying_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17383, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17383), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17386, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17386), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17389, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17389), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17393, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17393), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17380, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17380), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -5443,23 +5478,23 @@ static void flying_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17384, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17384), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17387, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17387), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17390, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17390), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17381, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17381), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5471,26 +5506,26 @@ static void flying_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17385, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17385), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17392, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17392), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17388, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17388), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17391, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17391), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17382, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17382), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -5547,26 +5582,26 @@ static void flying_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17439, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17439), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17450, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17450), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17444, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17444), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17449, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17449), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17434, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17434), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -5588,23 +5623,23 @@ static void flying_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17438, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17438), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17443, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17443), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17448, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17448), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17433, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17433), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5619,23 +5654,23 @@ static void flying_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17437, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17437), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17442, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17442), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17447, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17447), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17432, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17432), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5650,23 +5685,23 @@ static void flying_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17436, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17436), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17441, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17441), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17446, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17446), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17431, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17431), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5681,26 +5716,26 @@ static void flying_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17435, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17435), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17440, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17440), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17445, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17445), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17451, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17451), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17430, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17430), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 8 });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -5724,26 +5759,26 @@ static void flying_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17434, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17434), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17439, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17439), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17450, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17450), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17444, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17444), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17449, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17449), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -5770,23 +5805,23 @@ static void flying_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17433, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17433), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17438, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17438), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17443, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17443), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17448, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17448), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5801,23 +5836,23 @@ static void flying_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17432, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17432), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17437, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17437), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17442, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17442), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17447, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17447), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5832,23 +5867,23 @@ static void flying_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17431, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17431), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17436, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17436), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17441, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17441), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17446, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17446), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5863,26 +5898,26 @@ static void flying_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17430, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17430), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17435, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17435), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17440, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17440), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17445, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17445), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17451, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17451), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -5911,26 +5946,26 @@ static void flying_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17408, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17408), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17413, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17413), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17418, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17418), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17423, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17423), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17429, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17429), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -5952,23 +5987,23 @@ static void flying_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17409, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17409), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17414, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17414), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17419, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17419), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17424, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17424), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5983,23 +6018,23 @@ static void flying_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17410, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17410), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17415, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17415), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17420, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17420), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17425, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17425), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6014,23 +6049,23 @@ static void flying_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17411, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17411), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17416, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17416), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17421, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17421), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17426, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17426), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6045,26 +6080,26 @@ static void flying_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17412, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17412), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17417, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17417), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17428, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17428), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17422, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17422), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17427, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17427), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -6088,26 +6123,26 @@ static void flying_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17413, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17413), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17418, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17418), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17423, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17423), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17429, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17429), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17408, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17408), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -6134,23 +6169,23 @@ static void flying_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17414, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17414), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17419, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17419), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17424, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17424), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17409, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17409), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6165,23 +6200,23 @@ static void flying_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17415, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17415), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17420, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17420), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17425, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17425), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17410, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17410), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6196,23 +6231,23 @@ static void flying_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17416, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17416), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17421, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17421), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17426, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17426), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17411, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17411), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6227,26 +6262,26 @@ static void flying_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17417, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17417), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17428, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17428), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17422, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17422), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17427, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17427), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17412, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17412), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -6302,34 +6337,34 @@ static void flying_rc_track_left_quarter_turn_1_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17301, { 0, 0, height }, { 28, 28, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17301), { 0, 0, height }, { 28, 28, 3 },
                     { 2, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17305, { 0, 0, height }, { 28, 28, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17305), { 0, 0, height }, { 28, 28, 1 },
                     { 2, 2, height + 99 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17302, { 0, 0, height }, { 28, 28, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17302), { 0, 0, height }, { 28, 28, 3 },
                     { 2, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17306, { 0, 0, height }, { 28, 28, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17306), { 0, 0, height }, { 28, 28, 1 },
                     { 2, 2, height + 99 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17303, { 0, 0, height }, { 28, 28, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17303), { 0, 0, height }, { 28, 28, 3 },
                     { 2, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17307, { 0, 0, height }, { 28, 28, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17307), { 0, 0, height }, { 28, 28, 1 },
                     { 2, 2, height + 99 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17300, { 0, 0, height }, { 28, 28, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17300), { 0, 0, height }, { 28, 28, 3 },
                     { 2, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17304, { 0, 0, height }, { 28, 28, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17304), { 0, 0, height }, { 28, 28, 1 },
                     { 2, 2, height + 99 });
                 break;
         }
@@ -6340,35 +6375,35 @@ static void flying_rc_track_left_quarter_turn_1_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27352, { 0, 0, height - 5 }, { 28, 28, 3 },
-                    { 2, 2, height - 5 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27352), { 0, 0, height - 5 },
+                    { 28, 28, 3 }, { 2, 2, height - 5 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27348, { 0, 0, height - 5 }, { 28, 28, 1 },
-                    { 2, 2, height + 94 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27348), { 0, 0, height - 5 },
+                    { 28, 28, 1 }, { 2, 2, height + 94 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27353, { 0, 0, height - 5 }, { 28, 28, 3 },
-                    { 2, 2, height - 5 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27353), { 0, 0, height - 5 },
+                    { 28, 28, 3 }, { 2, 2, height - 5 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27349, { 0, 0, height - 5 }, { 28, 28, 1 },
-                    { 2, 2, height + 94 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27349), { 0, 0, height - 5 },
+                    { 28, 28, 1 }, { 2, 2, height + 94 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27354, { 0, 0, height - 5 }, { 28, 28, 3 },
-                    { 2, 2, height - 5 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27354), { 0, 0, height - 5 },
+                    { 28, 28, 3 }, { 2, 2, height - 5 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27350, { 0, 0, height - 5 }, { 28, 28, 1 },
-                    { 2, 2, height + 94 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27350), { 0, 0, height - 5 },
+                    { 28, 28, 1 }, { 2, 2, height + 94 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27351, { 0, 0, height - 5 }, { 28, 28, 3 },
-                    { 2, 2, height - 5 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27351), { 0, 0, height - 5 },
+                    { 28, 28, 3 }, { 2, 2, height - 5 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27347, { 0, 0, height - 5 }, { 28, 28, 1 },
-                    { 2, 2, height + 94 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27347), { 0, 0, height - 5 },
+                    { 28, 28, 1 }, { 2, 2, height + 94 });
                 break;
         }
     }
@@ -6389,34 +6424,34 @@ static void flying_rc_track_right_quarter_turn_1_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17292, { 0, 0, height }, { 28, 28, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17292), { 0, 0, height }, { 28, 28, 3 },
                     { 2, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17296, { 0, 0, height }, { 28, 28, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17296), { 0, 0, height }, { 28, 28, 1 },
                     { 2, 2, height + 99 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17293, { 0, 0, height }, { 28, 28, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17293), { 0, 0, height }, { 28, 28, 3 },
                     { 2, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17297, { 0, 0, height }, { 28, 28, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17297), { 0, 0, height }, { 28, 28, 1 },
                     { 2, 2, height + 99 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17294, { 0, 0, height }, { 28, 28, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17294), { 0, 0, height }, { 28, 28, 3 },
                     { 2, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17298, { 0, 0, height }, { 28, 28, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17298), { 0, 0, height }, { 28, 28, 1 },
                     { 2, 2, height + 99 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17295, { 0, 0, height }, { 28, 28, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17295), { 0, 0, height }, { 28, 28, 3 },
                     { 2, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17299, { 0, 0, height }, { 28, 28, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17299), { 0, 0, height }, { 28, 28, 1 },
                     { 2, 2, height + 99 });
                 break;
         }
@@ -6427,35 +6462,35 @@ static void flying_rc_track_right_quarter_turn_1_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27343, { 0, 0, height - 5 }, { 28, 28, 3 },
-                    { 2, 2, height - 5 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27343), { 0, 0, height - 5 },
+                    { 28, 28, 3 }, { 2, 2, height - 5 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27339, { 0, 0, height - 5 }, { 28, 28, 1 },
-                    { 2, 2, height + 94 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27339), { 0, 0, height - 5 },
+                    { 28, 28, 1 }, { 2, 2, height + 94 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27344, { 0, 0, height - 5 }, { 28, 28, 3 },
-                    { 2, 2, height - 5 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27344), { 0, 0, height - 5 },
+                    { 28, 28, 3 }, { 2, 2, height - 5 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27340, { 0, 0, height - 5 }, { 28, 28, 1 },
-                    { 2, 2, height + 94 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27340), { 0, 0, height - 5 },
+                    { 28, 28, 1 }, { 2, 2, height + 94 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27345, { 0, 0, height - 5 }, { 28, 28, 3 },
-                    { 2, 2, height - 5 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27345), { 0, 0, height - 5 },
+                    { 28, 28, 3 }, { 2, 2, height - 5 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27341, { 0, 0, height - 5 }, { 28, 28, 1 },
-                    { 2, 2, height + 94 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27341), { 0, 0, height - 5 },
+                    { 28, 28, 1 }, { 2, 2, height + 94 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27346, { 0, 0, height - 5 }, { 28, 28, 3 },
-                    { 2, 2, height - 5 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27346), { 0, 0, height - 5 },
+                    { 28, 28, 3 }, { 2, 2, height - 5 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27342, { 0, 0, height - 5 }, { 28, 28, 1 },
-                    { 2, 2, height + 94 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27342), { 0, 0, height - 5 },
+                    { 28, 28, 1 }, { 2, 2, height + 94 });
                 break;
         }
     }
@@ -6492,13 +6527,13 @@ static void flying_rc_track_brakes(
             case 0:
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17148, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17148), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17149, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17149), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -6519,14 +6554,14 @@ static void flying_rc_track_brakes(
             case 0:
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27337, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 24 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27337), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 24 });
                 break;
             case 1:
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27338, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 24 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27338), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 24 });
                 break;
         }
 
@@ -6571,23 +6606,23 @@ static void flying_rc_track_left_quarter_banked_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27202, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 30 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27202), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 30 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27207, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 30 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27207), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 30 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27212, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 30 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27212), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 30 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27197, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 30 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27197), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 30 });
                     break;
             }
 
@@ -6611,23 +6646,23 @@ static void flying_rc_track_left_quarter_banked_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27201, { 0, 0, height + 24 }, { 32, 16, 3 },
-                        { 0, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27201), { 0, 0, height + 24 },
+                        { 32, 16, 3 }, { 0, 0, height + 38 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27206, { 0, 0, height + 24 }, { 32, 16, 3 },
-                        { 0, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27206), { 0, 0, height + 24 },
+                        { 32, 16, 3 }, { 0, 0, height + 38 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27211, { 0, 0, height + 24 }, { 32, 16, 3 },
-                        { 0, 16, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27211), { 0, 0, height + 24 },
+                        { 32, 16, 3 }, { 0, 16, height + 38 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27196, { 0, 0, height + 24 }, { 32, 16, 3 },
-                        { 0, 16, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27196), { 0, 0, height + 24 },
+                        { 32, 16, 3 }, { 0, 16, height + 38 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6642,23 +6677,23 @@ static void flying_rc_track_left_quarter_banked_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27200, { 0, 0, height + 24 }, { 16, 16, 3 },
-                        { 0, 16, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27200), { 0, 0, height + 24 },
+                        { 16, 16, 3 }, { 0, 16, height + 38 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27205, { 0, 0, height + 24 }, { 16, 16, 3 },
-                        { 16, 16, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27205), { 0, 0, height + 24 },
+                        { 16, 16, 3 }, { 16, 16, height + 38 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27210, { 0, 0, height + 24 }, { 16, 16, 3 },
-                        { 16, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27210), { 0, 0, height + 24 },
+                        { 16, 16, 3 }, { 16, 0, height + 38 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27195, { 0, 0, height + 24 }, { 16, 16, 3 },
-                        { 0, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27195), { 0, 0, height + 24 },
+                        { 16, 16, 3 }, { 0, 0, height + 38 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6673,23 +6708,23 @@ static void flying_rc_track_left_quarter_banked_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27199, { 0, 0, height + 24 }, { 16, 32, 3 },
-                        { 16, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27199), { 0, 0, height + 24 },
+                        { 16, 32, 3 }, { 16, 0, height + 38 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27204, { 0, 0, height + 24 }, { 16, 32, 3 },
-                        { 0, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27204), { 0, 0, height + 24 },
+                        { 16, 32, 3 }, { 0, 0, height + 38 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27209, { 0, 0, height + 24 }, { 16, 32, 3 },
-                        { 0, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27209), { 0, 0, height + 24 },
+                        { 16, 32, 3 }, { 0, 0, height + 38 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27194, { 0, 0, height + 24 }, { 16, 32, 3 },
-                        { 16, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27194), { 0, 0, height + 24 },
+                        { 16, 32, 3 }, { 16, 0, height + 38 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6704,23 +6739,23 @@ static void flying_rc_track_left_quarter_banked_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27198, { 0, 0, height + 24 }, { 20, 32, 3 },
-                        { 6, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27198), { 0, 0, height + 24 },
+                        { 20, 32, 3 }, { 6, 0, height + 38 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27203, { 0, 0, height + 24 }, { 20, 32, 3 },
-                        { 6, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27203), { 0, 0, height + 24 },
+                        { 20, 32, 3 }, { 6, 0, height + 38 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27208, { 0, 0, height + 24 }, { 20, 32, 3 },
-                        { 6, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27208), { 0, 0, height + 24 },
+                        { 20, 32, 3 }, { 6, 0, height + 38 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27193, { 0, 0, height + 24 }, { 20, 32, 3 },
-                        { 6, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27193), { 0, 0, height + 24 },
+                        { 20, 32, 3 }, { 6, 0, height + 38 });
                     break;
             }
 
@@ -6756,23 +6791,23 @@ static void flying_rc_track_right_quarter_banked_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27173, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 30 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27173), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 30 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27178, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 30 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27178), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 30 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27183, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 30 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27183), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 30 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27188, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 30 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27188), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 30 });
                     break;
             }
 
@@ -6796,23 +6831,23 @@ static void flying_rc_track_right_quarter_banked_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27174, { 0, 0, height + 24 }, { 32, 16, 3 },
-                        { 0, 16, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27174), { 0, 0, height + 24 },
+                        { 32, 16, 3 }, { 0, 16, height + 38 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27179, { 0, 0, height + 24 }, { 32, 16, 3 },
-                        { 0, 16, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27179), { 0, 0, height + 24 },
+                        { 32, 16, 3 }, { 0, 16, height + 38 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27184, { 0, 0, height + 24 }, { 32, 16, 3 },
-                        { 0, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27184), { 0, 0, height + 24 },
+                        { 32, 16, 3 }, { 0, 0, height + 38 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27189, { 0, 0, height + 24 }, { 32, 16, 3 },
-                        { 0, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27189), { 0, 0, height + 24 },
+                        { 32, 16, 3 }, { 0, 0, height + 38 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6827,23 +6862,23 @@ static void flying_rc_track_right_quarter_banked_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27175, { 0, 0, height + 24 }, { 16, 16, 3 },
-                        { 0, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27175), { 0, 0, height + 24 },
+                        { 16, 16, 3 }, { 0, 0, height + 38 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27180, { 0, 0, height + 24 }, { 16, 16, 3 },
-                        { 16, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27180), { 0, 0, height + 24 },
+                        { 16, 16, 3 }, { 16, 0, height + 38 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27185, { 0, 0, height + 24 }, { 16, 16, 3 },
-                        { 16, 16, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27185), { 0, 0, height + 24 },
+                        { 16, 16, 3 }, { 16, 16, height + 38 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27190, { 0, 0, height + 24 }, { 16, 16, 3 },
-                        { 0, 16, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27190), { 0, 0, height + 24 },
+                        { 16, 16, 3 }, { 0, 16, height + 38 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6858,23 +6893,23 @@ static void flying_rc_track_right_quarter_banked_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27176, { 0, 0, height + 24 }, { 16, 32, 3 },
-                        { 16, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27176), { 0, 0, height + 24 },
+                        { 16, 32, 3 }, { 16, 0, height + 38 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27181, { 0, 0, height + 24 }, { 16, 32, 3 },
-                        { 0, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27181), { 0, 0, height + 24 },
+                        { 16, 32, 3 }, { 0, 0, height + 38 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27186, { 0, 0, height + 24 }, { 16, 32, 3 },
-                        { 0, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27186), { 0, 0, height + 24 },
+                        { 16, 32, 3 }, { 0, 0, height + 38 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27191, { 0, 0, height + 24 }, { 16, 32, 3 },
-                        { 16, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27191), { 0, 0, height + 24 },
+                        { 16, 32, 3 }, { 16, 0, height + 38 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6889,23 +6924,23 @@ static void flying_rc_track_right_quarter_banked_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27177, { 0, 0, height + 24 }, { 20, 32, 3 },
-                        { 6, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27177), { 0, 0, height + 24 },
+                        { 20, 32, 3 }, { 6, 0, height + 38 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27182, { 0, 0, height + 24 }, { 20, 32, 3 },
-                        { 6, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27182), { 0, 0, height + 24 },
+                        { 20, 32, 3 }, { 6, 0, height + 38 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27187, { 0, 0, height + 24 }, { 20, 32, 3 },
-                        { 6, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27187), { 0, 0, height + 24 },
+                        { 20, 32, 3 }, { 6, 0, height + 38 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27192, { 0, 0, height + 24 }, { 20, 32, 3 },
-                        { 6, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27192), { 0, 0, height + 24 },
+                        { 20, 32, 3 }, { 6, 0, height + 38 });
                     break;
             }
 
@@ -6941,23 +6976,23 @@ static void flying_rc_track_left_quarter_banked_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27182, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27182), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 38 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27187, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27187), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 38 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27192, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27192), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 38 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27177, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27177), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 38 });
                     break;
             }
 
@@ -6981,23 +7016,23 @@ static void flying_rc_track_left_quarter_banked_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27181, { 0, 0, height + 24 }, { 32, 16, 3 },
-                        { 0, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27181), { 0, 0, height + 24 },
+                        { 32, 16, 3 }, { 0, 0, height + 38 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27186, { 0, 0, height + 24 }, { 32, 16, 3 },
-                        { 0, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27186), { 0, 0, height + 24 },
+                        { 32, 16, 3 }, { 0, 0, height + 38 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27191, { 0, 0, height + 24 }, { 32, 16, 3 },
-                        { 0, 16, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27191), { 0, 0, height + 24 },
+                        { 32, 16, 3 }, { 0, 16, height + 38 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27176, { 0, 0, height + 24 }, { 32, 16, 3 },
-                        { 0, 16, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27176), { 0, 0, height + 24 },
+                        { 32, 16, 3 }, { 0, 16, height + 38 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7012,23 +7047,23 @@ static void flying_rc_track_left_quarter_banked_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27180, { 0, 0, height + 24 }, { 16, 16, 3 },
-                        { 0, 16, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27180), { 0, 0, height + 24 },
+                        { 16, 16, 3 }, { 0, 16, height + 38 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27185, { 0, 0, height + 24 }, { 16, 16, 3 },
-                        { 16, 16, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27185), { 0, 0, height + 24 },
+                        { 16, 16, 3 }, { 16, 16, height + 38 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27190, { 0, 0, height + 24 }, { 16, 16, 3 },
-                        { 16, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27190), { 0, 0, height + 24 },
+                        { 16, 16, 3 }, { 16, 0, height + 38 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27175, { 0, 0, height + 24 }, { 16, 16, 3 },
-                        { 0, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27175), { 0, 0, height + 24 },
+                        { 16, 16, 3 }, { 0, 0, height + 38 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7043,23 +7078,23 @@ static void flying_rc_track_left_quarter_banked_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27179, { 0, 0, height + 24 }, { 16, 32, 3 },
-                        { 16, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27179), { 0, 0, height + 24 },
+                        { 16, 32, 3 }, { 16, 0, height + 38 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27184, { 0, 0, height + 24 }, { 16, 32, 3 },
-                        { 0, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27184), { 0, 0, height + 24 },
+                        { 16, 32, 3 }, { 0, 0, height + 38 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27189, { 0, 0, height + 24 }, { 16, 32, 3 },
-                        { 0, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27189), { 0, 0, height + 24 },
+                        { 16, 32, 3 }, { 0, 0, height + 38 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27174, { 0, 0, height + 24 }, { 16, 32, 3 },
-                        { 16, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27174), { 0, 0, height + 24 },
+                        { 16, 32, 3 }, { 16, 0, height + 38 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7074,23 +7109,23 @@ static void flying_rc_track_left_quarter_banked_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27178, { 0, 0, height + 24 }, { 20, 32, 3 },
-                        { 6, 0, height + 30 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27178), { 0, 0, height + 24 },
+                        { 20, 32, 3 }, { 6, 0, height + 30 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27183, { 0, 0, height + 24 }, { 20, 32, 3 },
-                        { 6, 0, height + 30 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27183), { 0, 0, height + 24 },
+                        { 20, 32, 3 }, { 6, 0, height + 30 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27188, { 0, 0, height + 24 }, { 20, 32, 3 },
-                        { 6, 0, height + 30 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27188), { 0, 0, height + 24 },
+                        { 20, 32, 3 }, { 6, 0, height + 30 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27173, { 0, 0, height + 24 }, { 20, 32, 3 },
-                        { 6, 0, height + 30 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27173), { 0, 0, height + 24 },
+                        { 20, 32, 3 }, { 6, 0, height + 30 });
                     break;
             }
 
@@ -7126,23 +7161,23 @@ static void flying_rc_track_right_quarter_banked_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27193, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27193), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 38 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27198, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27198), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 38 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27203, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27203), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 38 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27208, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27208), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 38 });
                     break;
             }
 
@@ -7166,23 +7201,23 @@ static void flying_rc_track_right_quarter_banked_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27194, { 0, 0, height + 24 }, { 32, 16, 3 },
-                        { 0, 16, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27194), { 0, 0, height + 24 },
+                        { 32, 16, 3 }, { 0, 16, height + 38 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27199, { 0, 0, height + 24 }, { 32, 16, 3 },
-                        { 0, 16, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27199), { 0, 0, height + 24 },
+                        { 32, 16, 3 }, { 0, 16, height + 38 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27204, { 0, 0, height + 24 }, { 32, 16, 3 },
-                        { 0, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27204), { 0, 0, height + 24 },
+                        { 32, 16, 3 }, { 0, 0, height + 38 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27209, { 0, 0, height + 24 }, { 32, 16, 3 },
-                        { 0, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27209), { 0, 0, height + 24 },
+                        { 32, 16, 3 }, { 0, 0, height + 38 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7197,23 +7232,23 @@ static void flying_rc_track_right_quarter_banked_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27195, { 0, 0, height + 24 }, { 16, 16, 3 },
-                        { 0, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27195), { 0, 0, height + 24 },
+                        { 16, 16, 3 }, { 0, 0, height + 38 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27200, { 0, 0, height + 24 }, { 16, 16, 3 },
-                        { 16, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27200), { 0, 0, height + 24 },
+                        { 16, 16, 3 }, { 16, 0, height + 38 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27205, { 0, 0, height + 24 }, { 16, 16, 3 },
-                        { 16, 16, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27205), { 0, 0, height + 24 },
+                        { 16, 16, 3 }, { 16, 16, height + 38 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27210, { 0, 0, height + 24 }, { 16, 16, 3 },
-                        { 0, 16, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27210), { 0, 0, height + 24 },
+                        { 16, 16, 3 }, { 0, 16, height + 38 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7228,23 +7263,23 @@ static void flying_rc_track_right_quarter_banked_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27196, { 0, 0, height + 24 }, { 16, 32, 3 },
-                        { 16, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27196), { 0, 0, height + 24 },
+                        { 16, 32, 3 }, { 16, 0, height + 38 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27201, { 0, 0, height + 24 }, { 16, 32, 3 },
-                        { 0, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27201), { 0, 0, height + 24 },
+                        { 16, 32, 3 }, { 0, 0, height + 38 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27206, { 0, 0, height + 24 }, { 16, 32, 3 },
-                        { 0, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27206), { 0, 0, height + 24 },
+                        { 16, 32, 3 }, { 0, 0, height + 38 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27211, { 0, 0, height + 24 }, { 16, 32, 3 },
-                        { 16, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27211), { 0, 0, height + 24 },
+                        { 16, 32, 3 }, { 16, 0, height + 38 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7259,23 +7294,23 @@ static void flying_rc_track_right_quarter_banked_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27197, { 0, 0, height + 24 }, { 20, 32, 3 },
-                        { 6, 0, height + 30 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27197), { 0, 0, height + 24 },
+                        { 20, 32, 3 }, { 6, 0, height + 30 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27202, { 0, 0, height + 24 }, { 20, 32, 3 },
-                        { 6, 0, height + 30 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27202), { 0, 0, height + 24 },
+                        { 20, 32, 3 }, { 6, 0, height + 30 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27207, { 0, 0, height + 24 }, { 20, 32, 3 },
-                        { 6, 0, height + 30 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27207), { 0, 0, height + 24 },
+                        { 20, 32, 3 }, { 6, 0, height + 30 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27212, { 0, 0, height + 24 }, { 20, 32, 3 },
-                        { 6, 0, height + 30 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27212), { 0, 0, height + 24 },
+                        { 20, 32, 3 }, { 6, 0, height + 30 });
                     break;
             }
 
@@ -7310,22 +7345,22 @@ static void flying_rc_track_25_deg_up_left_banked(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17914, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17914), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17915, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17915), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17916, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17916), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17917, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17917), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -7352,23 +7387,23 @@ static void flying_rc_track_25_deg_up_left_banked(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27711, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27711), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 40 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27712, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27712), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 40 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27713, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27713), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 40 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27714, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27714), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 40 });
                 break;
         }
 
@@ -7420,22 +7455,22 @@ static void flying_rc_track_25_deg_up_right_banked(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17918, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17918), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17919, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17919), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17920, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17920), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17921, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17921), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -7462,23 +7497,23 @@ static void flying_rc_track_25_deg_up_right_banked(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27715, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27715), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 40 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27716, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27716), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 40 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27717, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27717), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 40 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27718, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27718), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 40 });
                 break;
         }
 
@@ -7530,46 +7565,46 @@ static void flying_rc_track_on_ride_photo(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                    session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17146, { 0, 0, height }, { 32, 20, 0 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17146), { 0, 0, height }, { 32, 20, 0 },
                     { 0, 6, height + 3 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                    session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17147, { 0, 0, height }, { 32, 20, 0 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17147), { 0, 0, height }, { 32, 20, 0 },
                     { 0, 6, height + 3 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                    session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17146, { 0, 0, height }, { 32, 20, 0 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17146), { 0, 0, height }, { 32, 20, 0 },
                     { 0, 6, height + 3 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                    session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17147, { 0, 0, height }, { 32, 20, 0 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17147), { 0, 0, height }, { 32, 20, 0 },
                     { 0, 6, height + 3 });
                 break;
         }
@@ -7584,47 +7619,47 @@ static void flying_rc_track_on_ride_photo(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                    session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27129, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 24 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27129), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 24 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                    session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27130, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 24 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27130), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 24 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                    session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27129, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 24 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27129), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 24 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                    session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27130, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 24 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27130), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 24 });
                 break;
         }
         track_paint_util_onride_photo_paint(session, direction, height + 3, trackElement);
@@ -7664,23 +7699,23 @@ static void flying_rc_track_left_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17546, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17546), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17550, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17550), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17554, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17554), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17558, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17558), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -7698,23 +7733,23 @@ static void flying_rc_track_left_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17547, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17547), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17551, { 0, 0, height }, { 34, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17551), { 0, 0, height },
+                            { 34, 16, 3 }, { 0, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17555, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17555), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17559, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17559), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -7729,23 +7764,23 @@ static void flying_rc_track_left_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17548, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17548), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17552, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17552), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 16, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17556, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17556), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17560, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17560), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -7765,29 +7800,29 @@ static void flying_rc_track_left_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17549, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17549), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17553, { 0, 0, height }, { 16, 18, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17553), { 0, 0, height },
+                            { 16, 18, 3 }, { 0, 16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17557, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17557), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17561, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17561), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7810,22 +7845,22 @@ static void flying_rc_track_left_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27507, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27507), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27511, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27511), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27515, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27515), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27519, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27519), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                 }
@@ -7846,22 +7881,22 @@ static void flying_rc_track_left_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27508, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27508), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27512, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27512), { 0, 0, height + 24 },
                             { 34, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27516, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27516), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 16, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27520, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27520), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 16, height + 22 });
                         break;
                 }
@@ -7877,22 +7912,22 @@ static void flying_rc_track_left_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27509, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27509), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 16, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27513, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27513), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 16, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27517, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27517), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 0, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27521, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27521), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 0, height + 22 });
                         break;
                 }
@@ -7913,22 +7948,22 @@ static void flying_rc_track_left_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27510, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27510), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 16, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27514, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27514), { 0, 0, height + 24 },
                             { 16, 18, 3 }, { 0, 16, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27518, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27518), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27522, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27522), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 0, height + 22 });
                         break;
                 }
@@ -7978,23 +8013,23 @@ static void flying_rc_track_right_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17530, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17530), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17534, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17534), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17538, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17538), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17542, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17542), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -8012,23 +8047,23 @@ static void flying_rc_track_right_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17531, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17531), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17535, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17535), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17539, { 0, 0, height }, { 34, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17539), { 0, 0, height },
+                            { 34, 16, 3 }, { 0, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17543, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17543), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -8043,23 +8078,23 @@ static void flying_rc_track_right_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17532, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17532), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17536, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17536), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17540, { 0, 0, height }, { 28, 28, 3 },
-                            { 4, 4, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17540), { 0, 0, height },
+                            { 28, 28, 3 }, { 4, 4, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17544, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17544), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -8079,29 +8114,29 @@ static void flying_rc_track_right_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17533, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17533), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17537, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17537), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17541, { 0, 0, height }, { 16, 18, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17541), { 0, 0, height },
+                            { 16, 18, 3 }, { 0, 16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17545, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17545), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -8124,22 +8159,22 @@ static void flying_rc_track_right_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27491, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27491), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27495, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27495), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27499, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27499), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27503, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27503), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                 }
@@ -8160,22 +8195,22 @@ static void flying_rc_track_right_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27492, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27492), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 16, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27496, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27496), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 16, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27500, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27500), { 0, 0, height + 24 },
                             { 34, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27504, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27504), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 0, height + 22 });
                         break;
                 }
@@ -8191,22 +8226,22 @@ static void flying_rc_track_right_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27493, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27493), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27497, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27497), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27501, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27501), { 0, 0, height + 24 },
                             { 28, 28, 3 }, { 4, 4, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27505, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27505), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 16, height + 22 });
                         break;
                 }
@@ -8227,22 +8262,22 @@ static void flying_rc_track_right_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27494, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27494), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27498, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27498), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27502, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27502), { 0, 0, height + 24 },
                             { 16, 18, 3 }, { 0, 16, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27506, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27506), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 16, height + 22 });
                         break;
                 }
@@ -8310,23 +8345,23 @@ static void flying_rc_track_left_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17578, { 0, 0, height }, { 32, 1, 26 },
-                            { 0, 27, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17578), { 0, 0, height },
+                            { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17582, { 0, 0, height }, { 32, 1, 26 },
-                            { 0, 27, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17582), { 0, 0, height },
+                            { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17586, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17586), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17590, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17590), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -8344,23 +8379,23 @@ static void flying_rc_track_left_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17579, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17579), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17583, { 0, 0, height }, { 34, 16, 0 },
-                            { 0, 0, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17583), { 0, 0, height },
+                            { 34, 16, 0 }, { 0, 0, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17587, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17587), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17591, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17591), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -8375,23 +8410,23 @@ static void flying_rc_track_left_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17580, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17580), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17584, { 0, 0, height }, { 16, 16, 0 },
-                            { 16, 16, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17584), { 0, 0, height },
+                            { 16, 16, 0 }, { 16, 16, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17588, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17588), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17592, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17592), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -8411,29 +8446,29 @@ static void flying_rc_track_left_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17581, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17581), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17585, { 0, 0, height }, { 16, 18, 0 },
-                            { 0, 16, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17585), { 0, 0, height },
+                            { 16, 18, 0 }, { 0, 16, height + 27 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17589, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17589), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17593, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17593), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -8456,22 +8491,22 @@ static void flying_rc_track_left_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27539, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27539), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27543, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27543), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27547, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27547), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27551, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27551), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                 }
@@ -8493,22 +8528,22 @@ static void flying_rc_track_left_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27540, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27540), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27544, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27544), { 0, 0, height + 24 },
                             { 34, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27548, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27548), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 16, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27552, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27552), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 16, height + 22 });
                         break;
                 }
@@ -8524,22 +8559,22 @@ static void flying_rc_track_left_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27541, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27541), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 16, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27545, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27545), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 16, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27549, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27549), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 0, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27553, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27553), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 0, height + 22 });
                         break;
                 }
@@ -8560,22 +8595,22 @@ static void flying_rc_track_left_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27542, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27542), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 16, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27546, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27546), { 0, 0, height + 24 },
                             { 16, 18, 3 }, { 0, 16, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27550, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27550), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27554, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27554), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 0, height + 22 });
                         break;
                 }
@@ -8625,23 +8660,23 @@ static void flying_rc_track_right_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17562, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17562), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17566, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17566), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17570, { 0, 0, height }, { 32, 1, 26 },
-                            { 0, 27, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17570), { 0, 0, height },
+                            { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17574, { 0, 0, height }, { 32, 1, 26 },
-                            { 0, 27, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17574), { 0, 0, height },
+                            { 32, 1, 26 }, { 0, 27, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -8659,23 +8694,23 @@ static void flying_rc_track_right_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17563, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17563), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17567, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17567), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17571, { 0, 0, height }, { 34, 16, 0 },
-                            { 0, 0, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17571), { 0, 0, height },
+                            { 34, 16, 0 }, { 0, 0, height + 27 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17575, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17575), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -8690,23 +8725,23 @@ static void flying_rc_track_right_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17564, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17564), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17568, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17568), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17572, { 0, 0, height }, { 28, 28, 0 },
-                            { 4, 4, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17572), { 0, 0, height },
+                            { 28, 28, 0 }, { 4, 4, height + 27 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17576, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17576), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -8726,29 +8761,29 @@ static void flying_rc_track_right_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17565, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17565), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17569, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17569), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17573, { 0, 0, height }, { 16, 18, 0 },
-                            { 0, 16, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17573), { 0, 0, height },
+                            { 16, 18, 0 }, { 0, 16, height + 27 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17577, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17577), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -8771,22 +8806,22 @@ static void flying_rc_track_right_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27523, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27523), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27527, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27527), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27531, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27531), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27535, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27535), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                 }
@@ -8808,22 +8843,22 @@ static void flying_rc_track_right_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27524, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27524), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 16, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27528, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27528), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 16, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27532, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27532), { 0, 0, height + 24 },
                             { 34, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27536, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27536), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 0, height + 22 });
                         break;
                 }
@@ -8839,22 +8874,22 @@ static void flying_rc_track_right_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27525, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27525), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27529, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27529), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27533, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27533), { 0, 0, height + 24 },
                             { 28, 28, 3 }, { 4, 4, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27537, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27537), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 16, height + 22 });
                         break;
                 }
@@ -8875,22 +8910,22 @@ static void flying_rc_track_right_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27526, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27526), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27530, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27530), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27534, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27534), { 0, 0, height + 24 },
                             { 16, 18, 3 }, { 0, 16, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27538, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27538), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 16, height + 22 });
                         break;
                 }
@@ -8960,7 +8995,7 @@ static void flying_rc_track_diag_flat(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17861, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17861), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -8971,7 +9006,7 @@ static void flying_rc_track_diag_flat(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17791, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17791), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -8988,7 +9023,7 @@ static void flying_rc_track_diag_flat(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17858, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17858), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -8999,7 +9034,7 @@ static void flying_rc_track_diag_flat(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17788, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17788), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9016,7 +9051,7 @@ static void flying_rc_track_diag_flat(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17860, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17860), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9027,7 +9062,7 @@ static void flying_rc_track_diag_flat(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17790, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17790), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9048,7 +9083,7 @@ static void flying_rc_track_diag_flat(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17859, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17859), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_a_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -9073,7 +9108,7 @@ static void flying_rc_track_diag_flat(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17789, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17789), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_a_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -9106,8 +9141,8 @@ static void flying_rc_track_diag_flat(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 27614, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 22 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27614),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 22 });
                             break;
                     }
                 }
@@ -9117,8 +9152,8 @@ static void flying_rc_track_diag_flat(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 27558, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 22 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27558),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 22 });
                             break;
                     }
                 }
@@ -9134,8 +9169,8 @@ static void flying_rc_track_diag_flat(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 27611, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 22 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27611),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 22 });
                             break;
                     }
                 }
@@ -9145,8 +9180,8 @@ static void flying_rc_track_diag_flat(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 27555, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 22 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27555),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 22 });
                             break;
                     }
                 }
@@ -9162,8 +9197,8 @@ static void flying_rc_track_diag_flat(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 27613, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 22 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27613),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 22 });
                             break;
                     }
                 }
@@ -9173,8 +9208,8 @@ static void flying_rc_track_diag_flat(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 27557, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 22 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27557),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 22 });
                             break;
                     }
                 }
@@ -9190,8 +9225,8 @@ static void flying_rc_track_diag_flat(
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 27612, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 22 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27612),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 22 });
                             break;
                     }
                 }
@@ -9201,8 +9236,8 @@ static void flying_rc_track_diag_flat(
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 27556, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 22 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27556),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 22 });
                             break;
                     }
                 }
@@ -9252,7 +9287,7 @@ static void flying_rc_track_diag_25_deg_up(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17873, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17873), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9263,7 +9298,7 @@ static void flying_rc_track_diag_25_deg_up(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17803, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17803), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9280,7 +9315,7 @@ static void flying_rc_track_diag_25_deg_up(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17870, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17870), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9291,7 +9326,7 @@ static void flying_rc_track_diag_25_deg_up(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17800, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17800), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9308,7 +9343,7 @@ static void flying_rc_track_diag_25_deg_up(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17872, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17872), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9319,7 +9354,7 @@ static void flying_rc_track_diag_25_deg_up(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17802, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17802), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9340,7 +9375,7 @@ static void flying_rc_track_diag_25_deg_up(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17871, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17871), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -9365,7 +9400,7 @@ static void flying_rc_track_diag_25_deg_up(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17801, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17801), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -9398,8 +9433,8 @@ static void flying_rc_track_diag_25_deg_up(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 27626, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 40 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27626),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 40 });
                             break;
                     }
                 }
@@ -9409,8 +9444,8 @@ static void flying_rc_track_diag_25_deg_up(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 27570, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 40 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27570),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 40 });
                             break;
                     }
                 }
@@ -9426,8 +9461,8 @@ static void flying_rc_track_diag_25_deg_up(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 27623, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 40 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27623),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 40 });
                             break;
                     }
                 }
@@ -9437,8 +9472,8 @@ static void flying_rc_track_diag_25_deg_up(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 27567, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 40 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27567),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 40 });
                             break;
                     }
                 }
@@ -9454,8 +9489,8 @@ static void flying_rc_track_diag_25_deg_up(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 27625, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 40 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27625),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 40 });
                             break;
                     }
                 }
@@ -9465,8 +9500,8 @@ static void flying_rc_track_diag_25_deg_up(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 27569, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 40 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27569),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 40 });
                             break;
                     }
                 }
@@ -9482,8 +9517,8 @@ static void flying_rc_track_diag_25_deg_up(
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 27624, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 40 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27624),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 40 });
                             break;
                     }
                 }
@@ -9493,8 +9528,8 @@ static void flying_rc_track_diag_25_deg_up(
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 27568, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 40 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27568),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 40 });
                             break;
                     }
                 }
@@ -9544,7 +9579,7 @@ static void flying_rc_track_diag_60_deg_up(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17885, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17885), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9555,7 +9590,7 @@ static void flying_rc_track_diag_60_deg_up(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17815, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17815), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9572,7 +9607,7 @@ static void flying_rc_track_diag_60_deg_up(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17882, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17882), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9583,7 +9618,7 @@ static void flying_rc_track_diag_60_deg_up(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17812, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17812), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9600,7 +9635,7 @@ static void flying_rc_track_diag_60_deg_up(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17884, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17884), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9611,7 +9646,7 @@ static void flying_rc_track_diag_60_deg_up(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17814, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17814), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9632,7 +9667,7 @@ static void flying_rc_track_diag_60_deg_up(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17883, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17883), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 36, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -9657,7 +9692,7 @@ static void flying_rc_track_diag_60_deg_up(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17813, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17813), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 36, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -9688,7 +9723,7 @@ static void flying_rc_track_diag_60_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27582, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27582), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 88 });
                         break;
                 }
@@ -9702,7 +9737,7 @@ static void flying_rc_track_diag_60_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27579, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27579), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 88 });
                         break;
                 }
@@ -9716,7 +9751,7 @@ static void flying_rc_track_diag_60_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27581, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27581), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 88 });
                         break;
                 }
@@ -9730,7 +9765,7 @@ static void flying_rc_track_diag_60_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27580, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27580), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 24 });
                         break;
                 }
@@ -9780,7 +9815,7 @@ static void flying_rc_track_diag_flat_to_25_deg_up(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17865, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17865), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9791,7 +9826,7 @@ static void flying_rc_track_diag_flat_to_25_deg_up(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17795, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17795), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9808,7 +9843,7 @@ static void flying_rc_track_diag_flat_to_25_deg_up(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17862, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17862), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9819,7 +9854,7 @@ static void flying_rc_track_diag_flat_to_25_deg_up(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17792, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17792), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9836,7 +9871,7 @@ static void flying_rc_track_diag_flat_to_25_deg_up(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17864, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17864), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9847,7 +9882,7 @@ static void flying_rc_track_diag_flat_to_25_deg_up(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17794, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17794), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9868,7 +9903,7 @@ static void flying_rc_track_diag_flat_to_25_deg_up(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17863, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17863), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -9893,7 +9928,7 @@ static void flying_rc_track_diag_flat_to_25_deg_up(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17793, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17793), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -9926,8 +9961,8 @@ static void flying_rc_track_diag_flat_to_25_deg_up(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 27618, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27618),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -9937,8 +9972,8 @@ static void flying_rc_track_diag_flat_to_25_deg_up(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 27562, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27562),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -9954,8 +9989,8 @@ static void flying_rc_track_diag_flat_to_25_deg_up(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 27615, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27615),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -9965,8 +10000,8 @@ static void flying_rc_track_diag_flat_to_25_deg_up(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 27559, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27559),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -9982,8 +10017,8 @@ static void flying_rc_track_diag_flat_to_25_deg_up(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 27617, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27617),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -9993,8 +10028,8 @@ static void flying_rc_track_diag_flat_to_25_deg_up(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 27561, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27561),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -10010,8 +10045,8 @@ static void flying_rc_track_diag_flat_to_25_deg_up(
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 27616, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27616),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -10021,8 +10056,8 @@ static void flying_rc_track_diag_flat_to_25_deg_up(
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 27560, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27560),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -10072,7 +10107,7 @@ static void flying_rc_track_diag_25_deg_up_to_60_deg_up(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17877, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17877), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10083,7 +10118,7 @@ static void flying_rc_track_diag_25_deg_up_to_60_deg_up(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17807, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17807), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10100,7 +10135,7 @@ static void flying_rc_track_diag_25_deg_up_to_60_deg_up(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17874, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17874), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10111,7 +10146,7 @@ static void flying_rc_track_diag_25_deg_up_to_60_deg_up(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17804, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17804), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10128,7 +10163,7 @@ static void flying_rc_track_diag_25_deg_up_to_60_deg_up(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17876, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17876), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10139,7 +10174,7 @@ static void flying_rc_track_diag_25_deg_up_to_60_deg_up(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17806, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17806), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10160,7 +10195,7 @@ static void flying_rc_track_diag_25_deg_up_to_60_deg_up(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17875, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17875), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -10185,7 +10220,7 @@ static void flying_rc_track_diag_25_deg_up_to_60_deg_up(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17805, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17805), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -10216,7 +10251,7 @@ static void flying_rc_track_diag_25_deg_up_to_60_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27574, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27574), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 56 });
                         break;
                 }
@@ -10230,7 +10265,7 @@ static void flying_rc_track_diag_25_deg_up_to_60_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27571, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27571), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 56 });
                         break;
                 }
@@ -10244,7 +10279,7 @@ static void flying_rc_track_diag_25_deg_up_to_60_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27573, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27573), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 56 });
                         break;
                 }
@@ -10258,7 +10293,7 @@ static void flying_rc_track_diag_25_deg_up_to_60_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27572, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27572), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 56 });
                         break;
                 }
@@ -10308,7 +10343,7 @@ static void flying_rc_track_diag_60_deg_up_to_25_deg_up(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17881, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17881), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10319,7 +10354,7 @@ static void flying_rc_track_diag_60_deg_up_to_25_deg_up(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17811, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17811), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10336,7 +10371,7 @@ static void flying_rc_track_diag_60_deg_up_to_25_deg_up(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17878, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17878), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10347,7 +10382,7 @@ static void flying_rc_track_diag_60_deg_up_to_25_deg_up(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17808, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17808), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10364,7 +10399,7 @@ static void flying_rc_track_diag_60_deg_up_to_25_deg_up(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17880, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17880), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10375,7 +10410,7 @@ static void flying_rc_track_diag_60_deg_up_to_25_deg_up(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17810, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17810), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10396,7 +10431,7 @@ static void flying_rc_track_diag_60_deg_up_to_25_deg_up(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17879, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17879), { -16, -16, height },
                                 { 16, 16, 3 }, { 0, 0, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 21, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -10421,7 +10456,7 @@ static void flying_rc_track_diag_60_deg_up_to_25_deg_up(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17809, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17809), { -16, -16, height },
                                 { 16, 16, 3 }, { 0, 0, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 21, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -10452,7 +10487,7 @@ static void flying_rc_track_diag_60_deg_up_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27578, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27578), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 56 });
                         break;
                 }
@@ -10466,7 +10501,7 @@ static void flying_rc_track_diag_60_deg_up_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27575, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27575), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 56 });
                         break;
                 }
@@ -10480,7 +10515,7 @@ static void flying_rc_track_diag_60_deg_up_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27577, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27577), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 56 });
                         break;
                 }
@@ -10494,7 +10529,7 @@ static void flying_rc_track_diag_60_deg_up_to_25_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27576, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27576), { -16, -16, height + 24 },
                             { 16, 16, 3 }, { 0, 0, height + 56 });
                         break;
                 }
@@ -10544,7 +10579,7 @@ static void flying_rc_track_diag_25_deg_up_to_flat(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17869, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17869), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10555,7 +10590,7 @@ static void flying_rc_track_diag_25_deg_up_to_flat(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17799, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17799), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10572,7 +10607,7 @@ static void flying_rc_track_diag_25_deg_up_to_flat(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17866, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17866), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10583,7 +10618,7 @@ static void flying_rc_track_diag_25_deg_up_to_flat(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17796, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17796), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10600,7 +10635,7 @@ static void flying_rc_track_diag_25_deg_up_to_flat(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17868, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17868), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10611,7 +10646,7 @@ static void flying_rc_track_diag_25_deg_up_to_flat(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17798, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17798), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10632,7 +10667,7 @@ static void flying_rc_track_diag_25_deg_up_to_flat(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17867, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17867), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -10657,7 +10692,7 @@ static void flying_rc_track_diag_25_deg_up_to_flat(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17797, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17797), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -10690,8 +10725,8 @@ static void flying_rc_track_diag_25_deg_up_to_flat(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 27622, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27622),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -10701,8 +10736,8 @@ static void flying_rc_track_diag_25_deg_up_to_flat(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 27566, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27566),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -10718,8 +10753,8 @@ static void flying_rc_track_diag_25_deg_up_to_flat(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 27619, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27619),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -10729,8 +10764,8 @@ static void flying_rc_track_diag_25_deg_up_to_flat(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 27563, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27563),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -10746,8 +10781,8 @@ static void flying_rc_track_diag_25_deg_up_to_flat(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 27621, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27621),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -10757,8 +10792,8 @@ static void flying_rc_track_diag_25_deg_up_to_flat(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 27565, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27565),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -10774,8 +10809,8 @@ static void flying_rc_track_diag_25_deg_up_to_flat(
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 27620, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27620),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -10785,8 +10820,8 @@ static void flying_rc_track_diag_25_deg_up_to_flat(
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 27564, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27564),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -10836,7 +10871,7 @@ static void flying_rc_track_diag_25_deg_down(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17871, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17871), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10847,7 +10882,7 @@ static void flying_rc_track_diag_25_deg_down(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17801, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17801), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10864,7 +10899,7 @@ static void flying_rc_track_diag_25_deg_down(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17872, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17872), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10875,7 +10910,7 @@ static void flying_rc_track_diag_25_deg_down(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17802, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17802), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10892,7 +10927,7 @@ static void flying_rc_track_diag_25_deg_down(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17870, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17870), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10903,7 +10938,7 @@ static void flying_rc_track_diag_25_deg_down(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17800, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17800), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10924,7 +10959,7 @@ static void flying_rc_track_diag_25_deg_down(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17873, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17873), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -10949,7 +10984,7 @@ static void flying_rc_track_diag_25_deg_down(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17803, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17803), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -10980,7 +11015,7 @@ static void flying_rc_track_diag_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27568, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27568), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 40 });
                         break;
                 }
@@ -10994,7 +11029,7 @@ static void flying_rc_track_diag_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27569, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27569), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 40 });
                         break;
                 }
@@ -11008,7 +11043,7 @@ static void flying_rc_track_diag_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27567, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27567), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 40 });
                         break;
                 }
@@ -11022,7 +11057,7 @@ static void flying_rc_track_diag_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27570, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27570), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 40 });
                         break;
                 }
@@ -11072,7 +11107,7 @@ static void flying_rc_track_diag_60_deg_down(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17883, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17883), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -11083,7 +11118,7 @@ static void flying_rc_track_diag_60_deg_down(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17813, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17813), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -11100,7 +11135,7 @@ static void flying_rc_track_diag_60_deg_down(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17884, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17884), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -11111,7 +11146,7 @@ static void flying_rc_track_diag_60_deg_down(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17814, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17814), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -11128,7 +11163,7 @@ static void flying_rc_track_diag_60_deg_down(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17882, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17882), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -11139,7 +11174,7 @@ static void flying_rc_track_diag_60_deg_down(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17812, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17812), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -11160,7 +11195,7 @@ static void flying_rc_track_diag_60_deg_down(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17885, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17885), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 28, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11185,7 +11220,7 @@ static void flying_rc_track_diag_60_deg_down(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17815, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17815), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 28, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11216,7 +11251,7 @@ static void flying_rc_track_diag_60_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27580, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27580), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 24 });
                         break;
                 }
@@ -11230,7 +11265,7 @@ static void flying_rc_track_diag_60_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27581, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27581), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 88 });
                         break;
                 }
@@ -11244,7 +11279,7 @@ static void flying_rc_track_diag_60_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27579, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27579), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 88 });
                         break;
                 }
@@ -11258,7 +11293,7 @@ static void flying_rc_track_diag_60_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27582, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27582), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 88 });
                         break;
                 }
@@ -11308,7 +11343,7 @@ static void flying_rc_track_diag_flat_to_25_deg_down(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17867, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17867), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -11319,7 +11354,7 @@ static void flying_rc_track_diag_flat_to_25_deg_down(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17797, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17797), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -11335,7 +11370,7 @@ static void flying_rc_track_diag_flat_to_25_deg_down(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17868, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17868), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -11346,7 +11381,7 @@ static void flying_rc_track_diag_flat_to_25_deg_down(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17798, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17798), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -11362,7 +11397,7 @@ static void flying_rc_track_diag_flat_to_25_deg_down(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17866, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17866), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -11373,7 +11408,7 @@ static void flying_rc_track_diag_flat_to_25_deg_down(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17796, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17796), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -11393,7 +11428,7 @@ static void flying_rc_track_diag_flat_to_25_deg_down(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17869, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17869), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11418,7 +11453,7 @@ static void flying_rc_track_diag_flat_to_25_deg_down(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17799, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17799), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11448,7 +11483,7 @@ static void flying_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27564, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27564), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -11461,7 +11496,7 @@ static void flying_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27565, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27565), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -11474,7 +11509,7 @@ static void flying_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27563, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27563), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -11487,7 +11522,7 @@ static void flying_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27566, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27566), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -11537,7 +11572,7 @@ static void flying_rc_track_diag_25_deg_down_to_60_deg_down(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17879, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17879), { -16, -16, height },
                                 { 16, 16, 3 }, { 0, 0, height });
                             break;
                     }
@@ -11548,7 +11583,7 @@ static void flying_rc_track_diag_25_deg_down_to_60_deg_down(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17809, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17809), { -16, -16, height },
                                 { 16, 16, 3 }, { 0, 0, height });
                             break;
                     }
@@ -11565,7 +11600,7 @@ static void flying_rc_track_diag_25_deg_down_to_60_deg_down(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17880, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17880), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -11576,7 +11611,7 @@ static void flying_rc_track_diag_25_deg_down_to_60_deg_down(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17810, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17810), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -11593,7 +11628,7 @@ static void flying_rc_track_diag_25_deg_down_to_60_deg_down(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17878, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17878), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -11604,7 +11639,7 @@ static void flying_rc_track_diag_25_deg_down_to_60_deg_down(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17808, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17808), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -11625,7 +11660,7 @@ static void flying_rc_track_diag_25_deg_down_to_60_deg_down(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17881, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17881), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 17, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11650,7 +11685,7 @@ static void flying_rc_track_diag_25_deg_down_to_60_deg_down(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17811, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17811), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 17, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11681,7 +11716,7 @@ static void flying_rc_track_diag_25_deg_down_to_60_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27576, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27576), { -16, -16, height + 24 },
                             { 16, 16, 3 }, { 0, 0, height + 56 });
                         break;
                 }
@@ -11695,7 +11730,7 @@ static void flying_rc_track_diag_25_deg_down_to_60_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27577, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27577), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 56 });
                         break;
                 }
@@ -11709,7 +11744,7 @@ static void flying_rc_track_diag_25_deg_down_to_60_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27575, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27575), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 56 });
                         break;
                 }
@@ -11723,7 +11758,7 @@ static void flying_rc_track_diag_25_deg_down_to_60_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27578, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27578), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 56 });
                         break;
                 }
@@ -11773,7 +11808,7 @@ static void flying_rc_track_diag_60_deg_down_to_25_deg_down(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17875, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17875), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -11784,7 +11819,7 @@ static void flying_rc_track_diag_60_deg_down_to_25_deg_down(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17805, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17805), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -11801,7 +11836,7 @@ static void flying_rc_track_diag_60_deg_down_to_25_deg_down(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17876, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17876), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -11812,7 +11847,7 @@ static void flying_rc_track_diag_60_deg_down_to_25_deg_down(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17806, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17806), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -11829,7 +11864,7 @@ static void flying_rc_track_diag_60_deg_down_to_25_deg_down(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17874, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17874), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -11840,7 +11875,7 @@ static void flying_rc_track_diag_60_deg_down_to_25_deg_down(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17804, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17804), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -11861,7 +11896,7 @@ static void flying_rc_track_diag_60_deg_down_to_25_deg_down(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17877, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17877), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11886,7 +11921,7 @@ static void flying_rc_track_diag_60_deg_down_to_25_deg_down(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17807, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17807), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11917,7 +11952,7 @@ static void flying_rc_track_diag_60_deg_down_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27572, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27572), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 56 });
                         break;
                 }
@@ -11931,7 +11966,7 @@ static void flying_rc_track_diag_60_deg_down_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27573, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27573), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 56 });
                         break;
                 }
@@ -11945,7 +11980,7 @@ static void flying_rc_track_diag_60_deg_down_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27571, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27571), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 56 });
                         break;
                 }
@@ -11959,7 +11994,7 @@ static void flying_rc_track_diag_60_deg_down_to_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27574, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27574), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 56 });
                         break;
                 }
@@ -12009,7 +12044,7 @@ static void flying_rc_track_diag_25_deg_down_to_flat(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17863, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17863), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -12020,7 +12055,7 @@ static void flying_rc_track_diag_25_deg_down_to_flat(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17793, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17793), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -12037,7 +12072,7 @@ static void flying_rc_track_diag_25_deg_down_to_flat(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17864, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17864), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -12048,7 +12083,7 @@ static void flying_rc_track_diag_25_deg_down_to_flat(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17794, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17794), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -12065,7 +12100,7 @@ static void flying_rc_track_diag_25_deg_down_to_flat(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17862, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17862), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -12076,7 +12111,7 @@ static void flying_rc_track_diag_25_deg_down_to_flat(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17792, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17792), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -12097,7 +12132,7 @@ static void flying_rc_track_diag_25_deg_down_to_flat(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17865, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17865), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -12122,7 +12157,7 @@ static void flying_rc_track_diag_25_deg_down_to_flat(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 17795, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17795), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -12153,7 +12188,7 @@ static void flying_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27560, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27560), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -12167,7 +12202,7 @@ static void flying_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27561, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27561), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -12181,7 +12216,7 @@ static void flying_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27559, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27559), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -12195,7 +12230,7 @@ static void flying_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27562, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27562), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -12243,8 +12278,8 @@ static void flying_rc_track_diag_flat_to_left_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17831, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17831), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -12257,11 +12292,11 @@ static void flying_rc_track_diag_flat_to_left_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17828, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17828), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17832, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17832), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 27 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -12274,8 +12309,8 @@ static void flying_rc_track_diag_flat_to_left_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17830, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17830), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -12292,8 +12327,8 @@ static void flying_rc_track_diag_flat_to_left_bank(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17829, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17829), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -12322,7 +12357,7 @@ static void flying_rc_track_diag_flat_to_left_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27590, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27590), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -12336,7 +12371,7 @@ static void flying_rc_track_diag_flat_to_left_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27587, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27587), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -12350,7 +12385,7 @@ static void flying_rc_track_diag_flat_to_left_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27589, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27589), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -12364,7 +12399,7 @@ static void flying_rc_track_diag_flat_to_left_bank(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27588, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27588), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -12413,8 +12448,8 @@ static void flying_rc_track_diag_flat_to_right_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17836, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17836), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -12427,8 +12462,8 @@ static void flying_rc_track_diag_flat_to_right_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17833, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17833), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -12441,11 +12476,11 @@ static void flying_rc_track_diag_flat_to_right_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17835, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17835), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17837, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17837), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 27 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -12462,8 +12497,8 @@ static void flying_rc_track_diag_flat_to_right_bank(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17834, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17834), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -12492,7 +12527,7 @@ static void flying_rc_track_diag_flat_to_right_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27594, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27594), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -12506,7 +12541,7 @@ static void flying_rc_track_diag_flat_to_right_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27591, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27591), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -12520,7 +12555,7 @@ static void flying_rc_track_diag_flat_to_right_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27593, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27593), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -12534,7 +12569,7 @@ static void flying_rc_track_diag_flat_to_right_bank(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27592, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27592), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -12583,8 +12618,8 @@ static void flying_rc_track_diag_left_bank_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17834, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17834), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -12597,11 +12632,11 @@ static void flying_rc_track_diag_left_bank_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17835, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17835), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17837, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17837), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 27 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -12614,8 +12649,8 @@ static void flying_rc_track_diag_left_bank_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17833, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17833), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -12632,8 +12667,8 @@ static void flying_rc_track_diag_left_bank_to_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17836, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17836), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -12662,7 +12697,7 @@ static void flying_rc_track_diag_left_bank_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27592, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27592), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -12676,7 +12711,7 @@ static void flying_rc_track_diag_left_bank_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27593, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27593), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -12690,7 +12725,7 @@ static void flying_rc_track_diag_left_bank_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27591, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27591), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -12704,7 +12739,7 @@ static void flying_rc_track_diag_left_bank_to_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27594, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27594), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -12753,8 +12788,8 @@ static void flying_rc_track_diag_right_bank_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17829, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17829), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -12767,8 +12802,8 @@ static void flying_rc_track_diag_right_bank_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17830, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17830), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -12781,11 +12816,11 @@ static void flying_rc_track_diag_right_bank_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17828, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17828), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17832, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17832), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 27 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -12802,8 +12837,8 @@ static void flying_rc_track_diag_right_bank_to_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17831, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17831), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -12832,7 +12867,7 @@ static void flying_rc_track_diag_right_bank_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27588, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27588), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -12846,7 +12881,7 @@ static void flying_rc_track_diag_right_bank_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27589, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27589), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -12860,7 +12895,7 @@ static void flying_rc_track_diag_right_bank_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27587, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27587), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -12874,7 +12909,7 @@ static void flying_rc_track_diag_right_bank_to_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27590, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27590), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -12923,8 +12958,8 @@ static void flying_rc_track_diag_left_bank_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17851, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17851), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -12937,11 +12972,11 @@ static void flying_rc_track_diag_left_bank_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17848, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17848), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17852, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 35 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17852), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 35 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -12954,8 +12989,8 @@ static void flying_rc_track_diag_left_bank_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17850, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17850), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -12972,8 +13007,8 @@ static void flying_rc_track_diag_left_bank_to_25_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17849, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17849), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -13002,7 +13037,7 @@ static void flying_rc_track_diag_left_bank_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27606, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27606), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13016,7 +13051,7 @@ static void flying_rc_track_diag_left_bank_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27603, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27603), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13030,7 +13065,7 @@ static void flying_rc_track_diag_left_bank_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27605, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27605), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13044,7 +13079,7 @@ static void flying_rc_track_diag_left_bank_to_25_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27604, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27604), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13092,8 +13127,8 @@ static void flying_rc_track_diag_right_bank_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17856, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17856), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -13106,8 +13141,8 @@ static void flying_rc_track_diag_right_bank_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17853, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17853), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -13120,11 +13155,11 @@ static void flying_rc_track_diag_right_bank_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17855, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17855), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17857, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 35 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17857), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 35 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -13141,8 +13176,8 @@ static void flying_rc_track_diag_right_bank_to_25_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17854, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17854), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -13171,7 +13206,7 @@ static void flying_rc_track_diag_right_bank_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27610, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27610), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13185,7 +13220,7 @@ static void flying_rc_track_diag_right_bank_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27607, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27607), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13199,7 +13234,7 @@ static void flying_rc_track_diag_right_bank_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27609, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27609), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13213,7 +13248,7 @@ static void flying_rc_track_diag_right_bank_to_25_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27608, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27608), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13261,8 +13296,8 @@ static void flying_rc_track_diag_25_deg_up_to_left_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17841, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17841), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -13275,11 +13310,11 @@ static void flying_rc_track_diag_25_deg_up_to_left_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17838, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17838), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17842, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 35 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17842), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 35 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -13292,8 +13327,8 @@ static void flying_rc_track_diag_25_deg_up_to_left_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17840, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17840), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -13310,8 +13345,8 @@ static void flying_rc_track_diag_25_deg_up_to_left_bank(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17839, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17839), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -13340,7 +13375,7 @@ static void flying_rc_track_diag_25_deg_up_to_left_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27598, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27598), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13354,7 +13389,7 @@ static void flying_rc_track_diag_25_deg_up_to_left_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27595, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27595), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13368,7 +13403,7 @@ static void flying_rc_track_diag_25_deg_up_to_left_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27597, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27597), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13382,7 +13417,7 @@ static void flying_rc_track_diag_25_deg_up_to_left_bank(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27596, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27596), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13430,8 +13465,8 @@ static void flying_rc_track_diag_25_deg_up_to_right_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17846, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17846), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -13444,8 +13479,8 @@ static void flying_rc_track_diag_25_deg_up_to_right_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17843, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17843), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -13458,11 +13493,11 @@ static void flying_rc_track_diag_25_deg_up_to_right_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17845, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17845), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17847, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 35 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17847), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 35 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -13479,8 +13514,8 @@ static void flying_rc_track_diag_25_deg_up_to_right_bank(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17844, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17844), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -13509,7 +13544,7 @@ static void flying_rc_track_diag_25_deg_up_to_right_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27602, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27602), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13523,7 +13558,7 @@ static void flying_rc_track_diag_25_deg_up_to_right_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27599, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27599), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13537,7 +13572,7 @@ static void flying_rc_track_diag_25_deg_up_to_right_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27601, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27601), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13551,7 +13586,7 @@ static void flying_rc_track_diag_25_deg_up_to_right_bank(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27600, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27600), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13599,8 +13634,8 @@ static void flying_rc_track_diag_left_bank_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17844, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17844), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -13612,11 +13647,11 @@ static void flying_rc_track_diag_left_bank_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17845, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17845), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17847, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 35 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17847), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 35 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -13628,8 +13663,8 @@ static void flying_rc_track_diag_left_bank_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17843, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17843), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -13645,8 +13680,8 @@ static void flying_rc_track_diag_left_bank_to_25_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17846, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17846), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -13674,7 +13709,7 @@ static void flying_rc_track_diag_left_bank_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27600, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27600), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13687,7 +13722,7 @@ static void flying_rc_track_diag_left_bank_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27601, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27601), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13700,7 +13735,7 @@ static void flying_rc_track_diag_left_bank_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27599, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27599), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13713,7 +13748,7 @@ static void flying_rc_track_diag_left_bank_to_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27602, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27602), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13761,8 +13796,8 @@ static void flying_rc_track_diag_right_bank_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17839, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17839), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -13774,8 +13809,8 @@ static void flying_rc_track_diag_right_bank_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17840, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17840), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -13787,11 +13822,11 @@ static void flying_rc_track_diag_right_bank_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17838, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17838), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17842, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 35 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17842), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 35 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -13807,8 +13842,8 @@ static void flying_rc_track_diag_right_bank_to_25_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17841, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17841), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -13836,7 +13871,7 @@ static void flying_rc_track_diag_right_bank_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27596, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27596), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13849,7 +13884,7 @@ static void flying_rc_track_diag_right_bank_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27597, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27597), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13862,7 +13897,7 @@ static void flying_rc_track_diag_right_bank_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27595, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27595), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13875,7 +13910,7 @@ static void flying_rc_track_diag_right_bank_to_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27598, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27598), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13923,8 +13958,8 @@ static void flying_rc_track_diag_25_deg_down_to_left_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17854, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17854), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -13937,11 +13972,11 @@ static void flying_rc_track_diag_25_deg_down_to_left_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17855, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17855), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17857, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 35 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17857), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 35 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -13954,8 +13989,8 @@ static void flying_rc_track_diag_25_deg_down_to_left_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17853, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17853), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -13972,8 +14007,8 @@ static void flying_rc_track_diag_25_deg_down_to_left_bank(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17856, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17856), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -14002,7 +14037,7 @@ static void flying_rc_track_diag_25_deg_down_to_left_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27608, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27608), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -14016,7 +14051,7 @@ static void flying_rc_track_diag_25_deg_down_to_left_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27609, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27609), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -14030,7 +14065,7 @@ static void flying_rc_track_diag_25_deg_down_to_left_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27607, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27607), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -14044,7 +14079,7 @@ static void flying_rc_track_diag_25_deg_down_to_left_bank(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27610, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27610), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -14092,8 +14127,8 @@ static void flying_rc_track_diag_25_deg_down_to_right_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17849, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17849), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -14106,8 +14141,8 @@ static void flying_rc_track_diag_25_deg_down_to_right_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17850, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17850), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -14120,11 +14155,11 @@ static void flying_rc_track_diag_25_deg_down_to_right_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17848, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17848), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17852, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 35 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17852), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 35 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -14141,8 +14176,8 @@ static void flying_rc_track_diag_25_deg_down_to_right_bank(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17851, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17851), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -14171,7 +14206,7 @@ static void flying_rc_track_diag_25_deg_down_to_right_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27604, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27604), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -14185,7 +14220,7 @@ static void flying_rc_track_diag_25_deg_down_to_right_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27605, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27605), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -14199,7 +14234,7 @@ static void flying_rc_track_diag_25_deg_down_to_right_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27603, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27603), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -14213,7 +14248,7 @@ static void flying_rc_track_diag_25_deg_down_to_right_bank(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27606, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27606), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -14261,8 +14296,8 @@ static void flying_rc_track_diag_left_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17827, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17827), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -14275,8 +14310,8 @@ static void flying_rc_track_diag_left_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17824, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17824), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 27 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -14289,8 +14324,8 @@ static void flying_rc_track_diag_left_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17826, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17826), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -14307,8 +14342,8 @@ static void flying_rc_track_diag_left_bank(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17825, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17825), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -14337,7 +14372,7 @@ static void flying_rc_track_diag_left_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27586, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27586), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -14351,7 +14386,7 @@ static void flying_rc_track_diag_left_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27583, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27583), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -14365,7 +14400,7 @@ static void flying_rc_track_diag_left_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27585, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27585), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -14379,7 +14414,7 @@ static void flying_rc_track_diag_left_bank(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27584, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27584), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -14428,8 +14463,8 @@ static void flying_rc_track_diag_right_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17825, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17825), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -14442,8 +14477,8 @@ static void flying_rc_track_diag_right_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17826, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17826), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -14456,8 +14491,8 @@ static void flying_rc_track_diag_right_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17824, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17824), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 27 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -14474,8 +14509,8 @@ static void flying_rc_track_diag_right_bank(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17827, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17827), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -14504,7 +14539,7 @@ static void flying_rc_track_diag_right_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27584, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27584), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -14518,7 +14553,7 @@ static void flying_rc_track_diag_right_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27585, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27585), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -14532,7 +14567,7 @@ static void flying_rc_track_diag_right_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27583, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27583), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -14546,7 +14581,7 @@ static void flying_rc_track_diag_right_bank(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27586, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27586), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -14593,23 +14628,23 @@ static void flying_rc_track_left_flyer_twist_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27430, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 6, height + 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27430), { 0, 6, height - 5 },
+                        { 32, 20, 3 }, { 0, 6, height + 6 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27436, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 6, height + 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27436), { 0, 6, height - 5 },
+                        { 32, 20, 3 }, { 0, 6, height + 6 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27429, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 6, height + 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27429), { 0, 6, height - 5 },
+                        { 32, 20, 3 }, { 0, 6, height + 6 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27435, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 6, height + 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27435), { 0, 6, height - 5 },
+                        { 32, 20, 3 }, { 0, 6, height + 6 });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -14630,20 +14665,23 @@ static void flying_rc_track_left_flyer_twist_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27431, { 0, 6, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27431), { 0, 6, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 24 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27437, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27437), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27428, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27428), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27434, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27434), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -14658,20 +14696,23 @@ static void flying_rc_track_left_flyer_twist_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27432, { 0, 6, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27432), { 0, 6, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 24 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27438, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27438), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27427, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27427), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27433, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27433), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
             }
 
@@ -14709,23 +14750,23 @@ static void flying_rc_track_right_flyer_twist_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27442, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 6, height + 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27442), { 0, 6, height - 5 },
+                        { 32, 20, 3 }, { 0, 6, height + 6 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27448, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 6, height + 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27448), { 0, 6, height - 5 },
+                        { 32, 20, 3 }, { 0, 6, height + 6 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27441, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 6, height + 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27441), { 0, 6, height - 5 },
+                        { 32, 20, 3 }, { 0, 6, height + 6 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27447, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 6, height + 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27447), { 0, 6, height - 5 },
+                        { 32, 20, 3 }, { 0, 6, height + 6 });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -14746,19 +14787,23 @@ static void flying_rc_track_right_flyer_twist_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27443, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27443), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27449, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27449), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27440, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27440), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27446, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27446), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -14773,19 +14818,23 @@ static void flying_rc_track_right_flyer_twist_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27444, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27444), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27450, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27450), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27439, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27439), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27445, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27445), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
             }
 
@@ -14823,20 +14872,23 @@ static void flying_rc_track_left_flyer_twist_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27427, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27427), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27433, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27433), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27432, { 0, 6, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27432), { 0, 6, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 24 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27438, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27438), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
             }
 
@@ -14859,20 +14911,23 @@ static void flying_rc_track_left_flyer_twist_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27428, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27428), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27434, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27434), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27431, { 0, 6, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27431), { 0, 6, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 24 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27437, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27437), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -14887,23 +14942,23 @@ static void flying_rc_track_left_flyer_twist_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27429, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 6, height + 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27429), { 0, 6, height - 5 },
+                        { 32, 20, 3 }, { 0, 6, height + 6 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27435, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 6, height + 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27435), { 0, 6, height - 5 },
+                        { 32, 20, 3 }, { 0, 6, height + 6 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27430, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 6, height + 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27430), { 0, 6, height - 5 },
+                        { 32, 20, 3 }, { 0, 6, height + 6 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27436, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 6, height + 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27436), { 0, 6, height - 5 },
+                        { 32, 20, 3 }, { 0, 6, height + 6 });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -14939,19 +14994,23 @@ static void flying_rc_track_right_flyer_twist_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27439, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27439), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27445, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27445), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27444, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27444), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27450, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27450), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
             }
 
@@ -14974,19 +15033,23 @@ static void flying_rc_track_right_flyer_twist_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27440, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27440), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27446, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27446), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27443, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27443), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27449, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27449), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -15001,23 +15064,23 @@ static void flying_rc_track_right_flyer_twist_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27441, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 6, height + 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27441), { 0, 6, height - 5 },
+                        { 32, 20, 3 }, { 0, 6, height + 6 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27447, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 6, height + 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27447), { 0, 6, height - 5 },
+                        { 32, 20, 3 }, { 0, 6, height + 6 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27442, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 6, height + 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27442), { 0, 6, height - 5 },
+                        { 32, 20, 3 }, { 0, 6, height + 6 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27448, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 6, height + 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27448), { 0, 6, height - 5 },
+                        { 32, 20, 3 }, { 0, 6, height + 6 });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -15053,19 +15116,23 @@ static void flying_rc_track_flyer_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17626, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17626), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17634, { 0, 6, height }, { 32, 20, 11 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17634), { 0, 6, height },
+                        { 32, 20, 11 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17633, { 0, 6, height }, { 32, 20, 9 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17633), { 0, 6, height },
+                        { 32, 20, 9 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17641, { 0, 6, height }, { 32, 20, 7 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17641), { 0, 6, height },
+                        { 32, 20, 7 });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -15083,28 +15150,29 @@ static void flying_rc_track_flyer_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17627, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17627), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES_INVERTED, 4, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17635, { 0, 14, height }, { 3, 20, 63 },
-                        { 28, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17635), { 0, 14, height },
+                        { 3, 20, 63 }, { 28, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES_INVERTED, 4, 15, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17632, { 0, 6, height }, { 3, 20, 63 },
-                        { 28, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17632), { 0, 6, height },
+                        { 3, 20, 63 }, { 28, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES_INVERTED, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17640, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17640), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES_INVERTED, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -15117,21 +15185,23 @@ static void flying_rc_track_flyer_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17628, { 16, 0, height }, { 2, 16, 119 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17628), { 16, 0, height },
+                        { 2, 16, 119 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17636, { 12, 0, height }, { 3, 16, 119 },
-                        { 12, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17636), { 12, 0, height },
+                        { 3, 16, 119 }, { 12, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17631, { 10, 16, height }, { 4, 12, 119 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17631), { 10, 16, height },
+                        { 4, 12, 119 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17639, { 16, 16, height }, { 2, 16, 119 },
-                        { 15, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17639), { 16, 16, height },
+                        { 2, 16, 119 }, { 15, 6, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -15146,19 +15216,23 @@ static void flying_rc_track_flyer_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17629, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17629), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17637, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17637), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17630, { 0, 16, height + 32 }, { 32, 12, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17630), { 0, 16, height + 32 },
+                        { 32, 12, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17638, { 0, 16, height + 32 }, { 32, 12, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17638), { 0, 16, height + 32 },
+                        { 32, 12, 3 });
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -15184,19 +15258,23 @@ static void flying_rc_track_flyer_half_loop_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17629, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17629), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17637, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17637), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17630, { 0, 16, height + 32 }, { 32, 12, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17630), { 0, 16, height + 32 },
+                        { 32, 12, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17638, { 0, 16, height + 32 }, { 32, 12, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17638), { 0, 16, height + 32 },
+                        { 32, 12, 3 });
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -15212,21 +15290,23 @@ static void flying_rc_track_flyer_half_loop_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17628, { 16, 0, height }, { 2, 16, 119 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17628), { 16, 0, height },
+                        { 2, 16, 119 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17636, { 12, 0, height }, { 3, 16, 119 },
-                        { 12, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17636), { 12, 0, height },
+                        { 3, 16, 119 }, { 12, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17631, { 10, 16, height }, { 4, 12, 119 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17631), { 10, 16, height },
+                        { 4, 12, 119 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17639, { 16, 16, height }, { 2, 16, 119 },
-                        { 15, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17639), { 16, 16, height },
+                        { 2, 16, 119 }, { 15, 6, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -15241,28 +15321,29 @@ static void flying_rc_track_flyer_half_loop_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17627, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17627), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES_INVERTED, 4, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17635, { 0, 14, height }, { 3, 20, 63 },
-                        { 28, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17635), { 0, 14, height },
+                        { 3, 20, 63 }, { 28, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES_INVERTED, 4, 15, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17632, { 0, 6, height }, { 3, 20, 63 },
-                        { 28, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17632), { 0, 6, height },
+                        { 3, 20, 63 }, { 28, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES_INVERTED, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17640, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17640), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES_INVERTED, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -15275,19 +15356,23 @@ static void flying_rc_track_flyer_half_loop_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17626, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17626), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17634, { 0, 6, height }, { 32, 20, 11 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17634), { 0, 6, height },
+                        { 32, 20, 11 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17633, { 0, 6, height }, { 32, 20, 9 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17633), { 0, 6, height },
+                        { 32, 20, 9 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17641, { 0, 6, height }, { 32, 20, 7 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17641), { 0, 6, height },
+                        { 32, 20, 7 });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -15315,13 +15400,13 @@ static void flying_rc_track_block_brakes(
             case 0:
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17150, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17150), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17151, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17151), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -15339,14 +15424,14 @@ static void flying_rc_track_block_brakes(
             case 0:
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27337, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 24 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27337), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 24 });
                 break;
             case 1:
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27338, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 24 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27338), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 24 });
                 break;
         }
 
@@ -15377,20 +15462,23 @@ static void flying_rc_track_left_banked_quarter_turn_3_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18025, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18025), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18027, { 0, 6, height }, { 32, 1, 34 },
-                            { 0, 27, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18027), { 0, 6, height },
+                            { 32, 1, 34 }, { 0, 27, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18029, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18029), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18023, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18023), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -15415,21 +15503,23 @@ static void flying_rc_track_left_banked_quarter_turn_3_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18024, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18024), { 6, 0, height },
+                            { 20, 32, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18026, { 6, 0, height }, { 1, 32, 34 },
-                            { 27, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18026), { 6, 0, height },
+                            { 1, 32, 34 }, { 27, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18028, { 6, 0, height }, { 1, 32, 34 },
-                            { 27, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18028), { 6, 0, height },
+                            { 1, 32, 34 }, { 27, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18022, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18022), { 6, 0, height },
+                            { 20, 32, 3 });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -15459,22 +15549,22 @@ static void flying_rc_track_left_banked_quarter_turn_3_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27762, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27762), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27764, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27764), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27766, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27766), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27760, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27760), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                 }
@@ -15503,22 +15593,22 @@ static void flying_rc_track_left_banked_quarter_turn_3_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27761, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27761), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27763, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27763), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27765, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27765), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27759, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27759), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                 }
@@ -15559,20 +15649,23 @@ static void flying_rc_track_right_banked_quarter_turn_3_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18014, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18014), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18016, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18016), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18018, { 0, 6, height }, { 32, 1, 34 },
-                            { 0, 27, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18018), { 0, 6, height },
+                            { 32, 1, 34 }, { 0, 27, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18020, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18020), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -15597,27 +15690,29 @@ static void flying_rc_track_right_banked_quarter_turn_3_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18015, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18015), { 6, 0, height },
+                            { 20, 32, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18017, { 6, 0, height }, { 1, 32, 34 },
-                            { 27, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18017), { 6, 0, height },
+                            { 1, 32, 34 }, { 27, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18019, { 6, 0, height }, { 1, 32, 34 },
-                            { 27, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18019), { 6, 0, height },
+                            { 1, 32, 34 }, { 27, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 4, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18021, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18021), { 6, 0, height },
+                            { 20, 32, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -15647,22 +15742,22 @@ static void flying_rc_track_right_banked_quarter_turn_3_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27751, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27751), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27753, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27753), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27755, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27755), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27757, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27757), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                 }
@@ -15691,22 +15786,22 @@ static void flying_rc_track_right_banked_quarter_turn_3_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27752, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27752), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27754, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27754), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27756, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27756), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27758, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27758), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                 }
@@ -15767,23 +15862,23 @@ static void flying_rc_track_left_banked_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17978, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17978), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17983, { 0, 0, height }, { 32, 1, 34 },
-                            { 0, 27, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17983), { 0, 0, height },
+                            { 32, 1, 34 }, { 0, 27, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17988, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17988), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17993, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17993), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -15805,22 +15900,23 @@ static void flying_rc_track_left_banked_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17979, { 0, 0, height }, { 32, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17979), { 0, 0, height },
+                            { 32, 16, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17984, { 0, 0, height }, { 1, 1, 34 },
-                            { 30, 30, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17984), { 0, 0, height },
+                            { 1, 1, 34 }, { 30, 30, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17989, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17989), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17994, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17994), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -15835,22 +15931,23 @@ static void flying_rc_track_left_banked_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17980, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17980), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17985, { 0, 0, height }, { 1, 1, 34 },
-                            { 30, 30, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17985), { 0, 0, height },
+                            { 1, 1, 34 }, { 30, 30, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17990, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17990), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17995, { 0, 0, height }, { 16, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17995), { 0, 0, height },
+                            { 16, 16, 3 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -15866,23 +15963,23 @@ static void flying_rc_track_left_banked_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17981, { 0, 0, height }, { 16, 32, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17981), { 0, 0, height },
+                            { 16, 32, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17986, { 0, 0, height }, { 1, 1, 34 },
-                            { 30, 30, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17986), { 0, 0, height },
+                            { 1, 1, 34 }, { 30, 30, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17991, { 0, 0, height }, { 1, 32, 34 },
-                            { 27, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17991), { 0, 0, height },
+                            { 1, 32, 34 }, { 27, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17996, { 0, 0, height }, { 16, 32, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17996), { 0, 0, height },
+                            { 16, 32, 3 }, { 16, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -15897,23 +15994,23 @@ static void flying_rc_track_left_banked_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17982, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17982), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17987, { 0, 0, height }, { 1, 32, 34 },
-                            { 27, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17987), { 0, 0, height },
+                            { 1, 32, 34 }, { 27, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17992, { 0, 0, height }, { 1, 32, 34 },
-                            { 27, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17992), { 0, 0, height },
+                            { 1, 32, 34 }, { 27, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17997, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17997), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -15943,22 +16040,22 @@ static void flying_rc_track_left_banked_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27787, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27787), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27792, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27792), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27797, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27797), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27802, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27802), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                 }
@@ -15984,22 +16081,22 @@ static void flying_rc_track_left_banked_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27788, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27788), { 0, 0, height + 24 },
                             { 32, 16, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27793, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27793), { 0, 0, height + 24 },
                             { 32, 16, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27798, { 0, 16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27798), { 0, 16, height + 24 },
                             { 32, 16, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27803, { 0, 16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27803), { 0, 16, height + 24 },
                             { 32, 16, 3 });
                         break;
                 }
@@ -16015,22 +16112,22 @@ static void flying_rc_track_left_banked_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27789, { 0, 16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27789), { 0, 16, height + 24 },
                             { 16, 16, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27794, { 16, 16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27794), { 16, 16, height + 24 },
                             { 16, 16, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27799, { 16, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27799), { 16, 0, height + 24 },
                             { 16, 16, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27804, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27804), { 0, 0, height + 24 },
                             { 16, 16, 3 });
                         break;
                 }
@@ -16047,22 +16144,22 @@ static void flying_rc_track_left_banked_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27790, { 16, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27790), { 16, 0, height + 24 },
                             { 16, 32, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27795, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27795), { 0, 0, height + 24 },
                             { 16, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27800, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27800), { 0, 0, height + 24 },
                             { 16, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27805, { 16, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27805), { 16, 0, height + 24 },
                             { 16, 32, 3 });
                         break;
                 }
@@ -16078,22 +16175,22 @@ static void flying_rc_track_left_banked_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27791, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27791), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27796, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27796), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27801, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27801), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27806, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27806), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                 }
@@ -16134,23 +16231,23 @@ static void flying_rc_track_right_banked_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17958, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17958), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17963, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17963), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17968, { 0, 0, height }, { 32, 1, 34 },
-                            { 0, 27, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17968), { 0, 0, height },
+                            { 32, 1, 34 }, { 0, 27, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17973, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17973), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -16172,22 +16269,23 @@ static void flying_rc_track_right_banked_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17959, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17959), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17964, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17964), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17969, { 0, 0, height }, { 1, 1, 34 },
-                            { 30, 30, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17969), { 0, 0, height },
+                            { 1, 1, 34 }, { 30, 30, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17974, { 0, 0, height }, { 32, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17974), { 0, 0, height },
+                            { 32, 16, 3 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -16202,22 +16300,23 @@ static void flying_rc_track_right_banked_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17960, { 0, 0, height }, { 16, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17960), { 0, 0, height },
+                            { 16, 16, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17965, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17965), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17970, { 0, 0, height }, { 1, 1, 34 },
-                            { 30, 30, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17970), { 0, 0, height },
+                            { 1, 1, 34 }, { 30, 30, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17975, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17975), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -16233,23 +16332,23 @@ static void flying_rc_track_right_banked_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17961, { 0, 0, height }, { 16, 32, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17961), { 0, 0, height },
+                            { 16, 32, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17966, { 0, 0, height }, { 1, 32, 34 },
-                            { 27, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17966), { 0, 0, height },
+                            { 1, 32, 34 }, { 27, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17971, { 0, 0, height }, { 1, 1, 34 },
-                            { 30, 30, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17971), { 0, 0, height },
+                            { 1, 1, 34 }, { 30, 30, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17976, { 0, 0, height }, { 16, 32, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17976), { 0, 0, height },
+                            { 16, 32, 3 }, { 16, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -16264,23 +16363,23 @@ static void flying_rc_track_right_banked_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17962, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17962), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17967, { 0, 0, height }, { 1, 32, 34 },
-                            { 27, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17967), { 0, 0, height },
+                            { 1, 32, 34 }, { 27, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17972, { 0, 0, height }, { 1, 32, 34 },
-                            { 27, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17972), { 0, 0, height },
+                            { 1, 32, 34 }, { 27, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 17977, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17977), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -16310,22 +16409,22 @@ static void flying_rc_track_right_banked_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27767, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27767), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27772, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27772), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27777, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27777), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27782, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27782), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                 }
@@ -16351,22 +16450,22 @@ static void flying_rc_track_right_banked_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27768, { 0, 16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27768), { 0, 16, height + 24 },
                             { 32, 16, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27773, { 0, 16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27773), { 0, 16, height + 24 },
                             { 32, 16, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27778, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27778), { 0, 0, height + 24 },
                             { 32, 16, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27783, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27783), { 0, 0, height + 24 },
                             { 32, 16, 3 });
                         break;
                 }
@@ -16382,22 +16481,22 @@ static void flying_rc_track_right_banked_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27769, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27769), { 0, 0, height + 24 },
                             { 16, 16, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27774, { 16, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27774), { 16, 0, height + 24 },
                             { 16, 16, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27779, { 16, 16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27779), { 16, 16, height + 24 },
                             { 16, 16, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27784, { 0, 16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27784), { 0, 16, height + 24 },
                             { 16, 16, 3 });
                         break;
                 }
@@ -16414,22 +16513,22 @@ static void flying_rc_track_right_banked_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27770, { 16, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27770), { 16, 0, height + 24 },
                             { 16, 32, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27775, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27775), { 0, 0, height + 24 },
                             { 16, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27780, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27780), { 0, 0, height + 24 },
                             { 16, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27785, { 16, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27785), { 16, 0, height + 24 },
                             { 16, 32, 3 });
                         break;
                 }
@@ -16445,22 +16544,22 @@ static void flying_rc_track_right_banked_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27771, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27771), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27776, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27776), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27781, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27781), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27786, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27786), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                 }
@@ -16518,25 +16617,25 @@ static void flying_rc_track_25_deg_up_to_left_banked_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17922, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17922), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17923, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17923), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17930, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17930), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17924, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17924), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17925, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17925), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -16563,23 +16662,23 @@ static void flying_rc_track_25_deg_up_to_left_banked_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27719, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27719), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 40 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27720, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27720), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 40 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27721, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27721), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 40 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27722, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27722), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 40 });
                 break;
         }
 
@@ -16631,25 +16730,25 @@ static void flying_rc_track_25_deg_up_to_right_banked_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17926, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17926), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17927, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17927), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17928, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17928), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17931, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17931), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17929, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17929), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -16676,23 +16775,23 @@ static void flying_rc_track_25_deg_up_to_right_banked_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27723, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27723), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 40 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27724, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27724), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 40 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27725, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27725), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 40 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27726, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27726), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 40 });
                 break;
         }
 
@@ -16744,25 +16843,25 @@ static void flying_rc_track_left_banked_25_deg_up_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17932, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17932), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17933, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17933), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17940, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17940), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17934, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17934), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17935, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17935), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -16789,23 +16888,23 @@ static void flying_rc_track_left_banked_25_deg_up_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27727, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27727), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 40 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27728, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27728), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 40 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27729, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27729), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 40 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27730, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27730), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 40 });
                 break;
         }
 
@@ -16857,25 +16956,25 @@ static void flying_rc_track_right_banked_25_deg_up_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17936, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17936), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17937, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17937), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17938, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17938), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17941, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17941), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17939, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17939), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -16902,23 +17001,23 @@ static void flying_rc_track_right_banked_25_deg_up_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27731, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27731), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 40 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27732, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27732), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 40 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27733, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27733), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 40 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27734, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27734), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 40 });
                 break;
         }
 
@@ -17004,22 +17103,22 @@ static void flying_rc_track_left_banked_flat_to_left_banked_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17942, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17942), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17943, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17943), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17944, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17944), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17945, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17945), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -17046,23 +17145,23 @@ static void flying_rc_track_left_banked_flat_to_left_banked_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27735, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27735), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27736, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27736), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27737, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27737), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27738, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27738), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
         }
 
@@ -17114,22 +17213,22 @@ static void flying_rc_track_right_banked_flat_to_right_banked_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17946, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17946), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17947, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17947), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17948, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17948), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17949, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17949), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -17156,23 +17255,23 @@ static void flying_rc_track_right_banked_flat_to_right_banked_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27739, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27739), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27740, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27740), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27741, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27741), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27742, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27742), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
         }
 
@@ -17224,22 +17323,22 @@ static void flying_rc_track_left_banked_25_deg_up_to_left_banked_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17950, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17950), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17951, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17951), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17952, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17952), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17953, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17953), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -17266,23 +17365,23 @@ static void flying_rc_track_left_banked_25_deg_up_to_left_banked_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27743, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27743), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27744, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27744), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27745, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27745), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27746, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27746), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
         }
 
@@ -17334,22 +17433,22 @@ static void flying_rc_track_right_banked_25_deg_up_to_right_banked_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17954, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17954), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17955, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17955), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17956, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17956), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17957, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17957), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -17376,23 +17475,23 @@ static void flying_rc_track_right_banked_25_deg_up_to_right_banked_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27747, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27747), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27748, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27748), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27749, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27749), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27750, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27750), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
         }
 
@@ -17480,25 +17579,25 @@ static void flying_rc_track_flat_to_left_banked_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17894, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17894), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17895, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17895), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17902, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17902), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17896, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17896), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17897, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17897), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -17525,23 +17624,23 @@ static void flying_rc_track_flat_to_left_banked_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27695, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27695), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27696, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27696), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27697, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27697), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27698, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27698), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
         }
 
@@ -17593,25 +17692,25 @@ static void flying_rc_track_flat_to_right_banked_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17898, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17898), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17899, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17899), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17900, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17900), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17903, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17903), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17901, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17901), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -17638,23 +17737,23 @@ static void flying_rc_track_flat_to_right_banked_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27699, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27699), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27700, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27700), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27701, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27701), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27702, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27702), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
         }
 
@@ -17706,25 +17805,25 @@ static void flying_rc_track_left_banked_25_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17904, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17904), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17905, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17905), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17912, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17912), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17906, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17906), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17907, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17907), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -17751,23 +17850,23 @@ static void flying_rc_track_left_banked_25_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27703, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27703), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27704, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27704), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27705, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27705), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27706, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27706), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
         }
 
@@ -17819,25 +17918,25 @@ static void flying_rc_track_right_banked_25_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17908, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17908), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17909, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17909), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17910, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17910), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17913, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17913), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17911, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17911), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -17864,23 +17963,23 @@ static void flying_rc_track_right_banked_25_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27707, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27707), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27708, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27708), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27709, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27709), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27710, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27710), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
         }
 
@@ -17968,23 +18067,23 @@ static void flying_rc_track_90_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17526, { 0, 0, height }, { 2, 20, 31 },
-                        { 4, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17526), { 0, 0, height },
+                        { 2, 20, 31 }, { 4, 6, height + 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17527, { 0, 0, height }, { 2, 20, 31 },
-                        { 24, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17527), { 0, 0, height },
+                        { 2, 20, 31 }, { 24, 6, height + 8 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17528, { 0, 0, height }, { 2, 20, 31 },
-                        { 24, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17528), { 0, 0, height },
+                        { 2, 20, 31 }, { 24, 6, height + 8 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17529, { 0, 0, height }, { 2, 20, 31 },
-                        { 4, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17529), { 0, 0, height },
+                        { 2, 20, 31 }, { 4, 6, height + 8 });
                     break;
             }
             paint_util_set_vertical_tunnel(session, height + 32);
@@ -18017,23 +18116,23 @@ static void flying_rc_track_60_deg_up_to_90_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17518, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17518), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17519, { 0, 0, height }, { 2, 20, 55 },
-                        { 24, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17519), { 0, 0, height },
+                        { 2, 20, 55 }, { 24, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17520, { 0, 0, height }, { 2, 20, 55 },
-                        { 24, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17520), { 0, 0, height },
+                        { 2, 20, 55 }, { 24, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17521, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17521), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -18067,22 +18166,22 @@ static void flying_rc_track_90_deg_up_to_60_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17522, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17522), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height + 8 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17523, { 0, 0, height }, { 2, 20, 31 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17523), { 0, 0, height }, { 2, 20, 31 },
                 { 24, 6, height + 8 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17524, { 0, 0, height }, { 2, 20, 31 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17524), { 0, 0, height }, { 2, 20, 31 },
                 { 24, 6, height + 8 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17525, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17525), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height + 8 });
             break;
     }
@@ -18113,23 +18212,23 @@ static void flying_rc_track_60_deg_down_to_90_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17524, { 0, 0, height }, { 2, 20, 31 },
-                        { 24, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17524), { 0, 0, height },
+                        { 2, 20, 31 }, { 24, 6, height + 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17525, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17525), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17522, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17522), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17523, { 0, 0, height }, { 2, 20, 31 },
-                        { 24, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17523), { 0, 0, height },
+                        { 2, 20, 31 }, { 24, 6, height + 8 });
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -18156,23 +18255,23 @@ static void flying_rc_track_90_deg_to_inverted_flat_quarter_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18062, { 0, 0, height }, { 2, 20, 31 },
-                        { 4, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18062), { 0, 0, height },
+                        { 2, 20, 31 }, { 4, 6, height + 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18065, { 0, 0, height }, { 2, 20, 31 },
-                        { 24, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18065), { 0, 0, height },
+                        { 2, 20, 31 }, { 24, 6, height + 8 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18068, { 0, 0, height }, { 2, 20, 31 },
-                        { 24, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18068), { 0, 0, height },
+                        { 2, 20, 31 }, { 24, 6, height + 8 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18071, { 0, 0, height }, { 2, 20, 31 },
-                        { 4, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18071), { 0, 0, height },
+                        { 2, 20, 31 }, { 4, 6, height + 8 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -18184,23 +18283,23 @@ static void flying_rc_track_90_deg_to_inverted_flat_quarter_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18063, { 0, 0, height }, { 2, 20, 31 },
-                        { -8, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18063), { 0, 0, height },
+                        { 2, 20, 31 }, { -8, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18066, { 0, 0, height }, { 2, 20, 63 },
-                        { 24, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18066), { 0, 0, height },
+                        { 2, 20, 63 }, { 24, 6, height + 8 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18069, { 0, 0, height }, { 2, 20, 63 },
-                        { 24, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18069), { 0, 0, height },
+                        { 2, 20, 63 }, { 24, 6, height + 8 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18072, { 0, 0, height }, { 2, 20, 31 },
-                        { -8, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18072), { 0, 0, height },
+                        { 2, 20, 31 }, { -8, 6, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -18212,23 +18311,23 @@ static void flying_rc_track_90_deg_to_inverted_flat_quarter_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18064, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18064), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 24 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18067, { 0, 0, height }, { 2, 20, 31 },
-                        { 24, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18067), { 0, 0, height },
+                        { 2, 20, 31 }, { 24, 6, height + 8 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18070, { 0, 0, height }, { 2, 20, 31 },
-                        { 24, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18070), { 0, 0, height },
+                        { 2, 20, 31 }, { 24, 6, height + 8 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18073, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18073), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 24 });
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -18299,23 +18398,23 @@ static void flying_rc_track_half_loop_inverted_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27451, { 0, 6, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 45 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27451), { 0, 6, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 45 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27459, { 0, 6, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 45 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27459), { 0, 6, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 45 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27458, { 0, 6, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 45 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27458), { 0, 6, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 45 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27466, { 0, 6, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 45 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27466), { 0, 6, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 45 });
                     break;
             }
 
@@ -18352,23 +18451,23 @@ static void flying_rc_track_half_loop_inverted_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27452, { 0, 0, height + 24 }, { 32, 2, 3 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27452), { 0, 0, height + 24 },
+                        { 32, 2, 3 }, { 0, 29, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27460, { 0, 14, height + 24 }, { 32, 2, 63 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27460), { 0, 14, height + 24 },
+                        { 32, 2, 63 }, { 0, 29, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27457, { 0, 6, height + 24 }, { 32, 2, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27457), { 0, 6, height + 24 },
+                        { 32, 2, 3 }, { 0, 0, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27465, { 0, 6, height + 24 }, { 2, 2, 3 },
-                        { 29, 20, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27465), { 0, 6, height + 24 },
+                        { 2, 2, 3 }, { 29, 20, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -18379,23 +18478,23 @@ static void flying_rc_track_half_loop_inverted_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27453, { 16, 0, height - 3 }, { 5, 2, 119 },
-                        { 16, 29, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27453), { 16, 0, height - 3 },
+                        { 5, 2, 119 }, { 16, 29, height + 2 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27461, { 12, 0, height - 3 }, { 32, 2, 119 },
-                        { 0, -6, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27461), { 12, 0, height - 3 },
+                        { 32, 2, 119 }, { 0, -6, height + 2 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27456, { 10, 16, height - 3 }, { 4, 2, 119 },
-                        { 10, 0, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27456), { 10, 16, height - 3 },
+                        { 4, 2, 119 }, { 10, 0, height + 2 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27464, { 16, 16, height - 3 }, { 2, 2, 119 },
-                        { 29, 29, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27464), { 16, 16, height - 3 },
+                        { 2, 2, 119 }, { 29, 29, height + 2 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -18410,23 +18509,23 @@ static void flying_rc_track_half_loop_inverted_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27454, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 34 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27454), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 34 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27462, { 0, 0, height + 29 }, { 2, 2, 3 },
-                        { 0, 0, height - 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27462), { 0, 0, height + 29 },
+                        { 2, 2, 3 }, { 0, 0, height - 6 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27455, { 0, 16, height + 29 }, { 32, 2, 3 },
-                        { 0, 0, height - 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27455), { 0, 16, height + 29 },
+                        { 32, 2, 3 }, { 0, 0, height - 6 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27463, { 0, 16, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 34 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27463), { 0, 16, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 34 });
                     break;
             }
             if (direction == 0 || direction == 3)

--- a/src/openrct2/ride/coaster/GigaCoaster.cpp
+++ b/src/openrct2/ride/coaster/GigaCoaster.cpp
@@ -51,13 +51,13 @@ static void giga_rc_track_flat(
             case 0:
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18692, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18692), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18693, { 0, 0, height }, { 20, 32, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18693), { 0, 0, height }, { 20, 32, 3 },
                     { 6, 0, height });
                 break;
         }
@@ -72,22 +72,22 @@ static void giga_rc_track_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18382, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18382), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18383, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18383), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18384, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18384), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18385, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18385), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -103,13 +103,13 @@ static void giga_rc_track_flat(
             case 0:
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18074, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18074), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18075, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18075), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -139,17 +139,18 @@ static void giga_rc_track_station(
     {
         bool isClosed = trackElement.BlockBrakeClosed();
         PaintAddImageAsParentRotated(
-            session, direction, _GigaCoasterBrakeImages[direction][isClosed][0] | session.TrackColours[SCHEME_TRACK],
+            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(_GigaCoasterBrakeImages[direction][isClosed][0]),
             { 0, 0, height }, { 32, 20, 1 }, { 0, 6, height + 3 });
     }
     else
     {
         PaintAddImageAsParentRotated(
-            session, direction, imageIds[direction][0] | session.TrackColours[SCHEME_TRACK], { 0, 0, height }, { 32, 20, 1 },
-            { 0, 6, height + 3 });
+            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]), { 0, 0, height },
+            { 32, 20, 1 }, { 0, 6, height + 3 });
     }
     PaintAddImageAsParentRotated(
-        session, direction, imageIds[direction][1] | session.TrackColours[SCHEME_MISC], { 0, 0, height }, { 32, 32, 1 });
+        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][1]), { 0, 0, height },
+        { 32, 32, 1 });
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], 0);
     track_paint_util_draw_station_2(session, ride, direction, height, trackElement, 9, 11);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -168,22 +169,22 @@ static void giga_rc_track_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18702, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18702), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18703, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18703), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18704, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18704), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18705, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18705), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -198,22 +199,22 @@ static void giga_rc_track_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18394, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18394), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18395, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18395), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18396, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18396), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18397, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18397), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -228,22 +229,22 @@ static void giga_rc_track_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18134, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18134), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18135, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18135), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18136, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18136), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18137, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18137), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -276,22 +277,22 @@ static void giga_rc_track_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18718, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18718), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18719, { 0, 0, height }, { 32, 1, 98 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18719), { 0, 0, height }, { 32, 1, 98 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18720, { 0, 0, height }, { 32, 1, 98 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18720), { 0, 0, height }, { 32, 1, 98 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18721, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18721), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -306,22 +307,22 @@ static void giga_rc_track_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18150, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18150), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18151, { 0, 0, height }, { 32, 1, 98 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18151), { 0, 0, height }, { 32, 1, 98 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18152, { 0, 0, height }, { 32, 1, 98 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18152), { 0, 0, height }, { 32, 1, 98 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18153, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18153), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -354,22 +355,22 @@ static void giga_rc_track_flat_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18694, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18694), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18695, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18695), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18696, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18696), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18697, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18697), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -384,22 +385,22 @@ static void giga_rc_track_flat_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18386, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18386), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18387, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18387), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18388, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18388), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18389, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18389), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -414,22 +415,22 @@ static void giga_rc_track_flat_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18126, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18126), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18127, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18127), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18128, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18128), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18129, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18129), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -462,28 +463,28 @@ static void giga_rc_track_25_deg_up_to_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18706, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18706), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18707, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18707), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18710, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18710), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18708, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18708), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18711, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18711), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18709, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18709), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -498,28 +499,28 @@ static void giga_rc_track_25_deg_up_to_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18138, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18138), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18139, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18139), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18142, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18142), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18140, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18140), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18143, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18143), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18141, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18141), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -552,28 +553,28 @@ static void giga_rc_track_60_deg_up_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18712, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18712), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18713, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18713), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18716, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18716), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18714, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18714), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18717, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18717), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18715, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18715), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -588,28 +589,28 @@ static void giga_rc_track_60_deg_up_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18144, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18144), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18145, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18145), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18148, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18148), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18146, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18146), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18149, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18149), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18147, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18147), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -642,22 +643,22 @@ static void giga_rc_track_25_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18698, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18698), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18699, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18699), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18700, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18700), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18701, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18701), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -672,22 +673,22 @@ static void giga_rc_track_25_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18390, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18390), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18391, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18391), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18392, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18392), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18393, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18393), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -702,22 +703,22 @@ static void giga_rc_track_25_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18130, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18130), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18131, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18131), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18132, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18132), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18133, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18133), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -799,23 +800,23 @@ static void giga_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18189, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18189), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18194, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18194), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18199, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18199), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18184, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18184), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -835,23 +836,23 @@ static void giga_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18188, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18188), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18193, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18193), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18198, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18198), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18183, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18183), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -866,23 +867,23 @@ static void giga_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18187, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18187), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18192, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18192), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18197, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18197), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18182, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18182), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -897,23 +898,23 @@ static void giga_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18186, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18186), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18191, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18191), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18196, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18196), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18181, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18181), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -928,23 +929,23 @@ static void giga_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18185, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18185), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18190, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18190), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18195, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18195), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18180, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18180), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -982,28 +983,28 @@ static void giga_rc_track_flat_to_left_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18086, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18086), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18094, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18094), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18087, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18087), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18095, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18095), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18088, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18088), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18089, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18089), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -1026,28 +1027,28 @@ static void giga_rc_track_flat_to_right_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18090, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18090), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18091, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18091), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18092, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18092), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18096, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18096), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18093, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18093), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18097, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18097), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
     }
@@ -1070,28 +1071,28 @@ static void giga_rc_track_left_bank_to_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18092, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18092), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18096, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18096), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18093, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18093), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18097, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18097), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18090, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18090), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18091, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18091), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -1114,28 +1115,28 @@ static void giga_rc_track_right_bank_to_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18088, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18088), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18089, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18089), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18086, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18086), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18094, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18094), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18087, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18087), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18095, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18095), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
     }
@@ -1161,26 +1162,26 @@ static void giga_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18209, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18209), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18220, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18220), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18214, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18214), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18219, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18219), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18204, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18204), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1200,23 +1201,23 @@ static void giga_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18208, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18208), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18213, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18213), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18218, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18218), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18203, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18203), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1231,23 +1232,23 @@ static void giga_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18207, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18207), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18212, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18212), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18217, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18217), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18202, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18202), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1262,23 +1263,23 @@ static void giga_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18206, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18206), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18211, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18211), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18216, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18216), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18201, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18201), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1293,26 +1294,26 @@ static void giga_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18205, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18205), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18210, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18210), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18215, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18215), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18221, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18221), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18200, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18200), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1350,28 +1351,28 @@ static void giga_rc_track_left_bank_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18098, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18098), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18102, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18102), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18099, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18099), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18103, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18103), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18100, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18100), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18101, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18101), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -1401,28 +1402,28 @@ static void giga_rc_track_right_bank_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18104, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18104), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18105, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18105), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18106, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18106), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18108, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18108), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18107, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18107), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18109, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18109), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
     }
@@ -1452,28 +1453,28 @@ static void giga_rc_track_25_deg_up_to_left_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18110, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18110), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18114, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18114), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18111, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18111), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18115, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18115), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18112, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18112), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18113, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18113), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -1503,28 +1504,28 @@ static void giga_rc_track_25_deg_up_to_right_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18116, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18116), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18117, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18117), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18118, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18118), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18120, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18120), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18119, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18119), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18121, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18121), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
     }
@@ -1586,22 +1587,22 @@ static void giga_rc_track_left_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18122, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18122), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18123, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18123), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18124, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18124), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18125, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18125), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -1635,23 +1636,23 @@ static void giga_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18274, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18274), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18279, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18279), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18284, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18284), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18289, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18289), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1671,21 +1672,23 @@ static void giga_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18275, { 0, 0, height }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18275), { 0, 0, height },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18280, { 0, 0, height }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18280), { 0, 0, height },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18285, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18285), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18290, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18290), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1700,22 +1703,23 @@ static void giga_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18276, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18276), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18281, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18281), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18286, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18286), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18291, { 0, 0, height }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18291), { 0, 0, height },
+                        { 16, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1730,21 +1734,23 @@ static void giga_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18277, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18277), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18282, { 0, 0, height }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18282), { 0, 0, height },
+                        { 16, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18287, { 0, 0, height }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18287), { 0, 0, height },
+                        { 16, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18292, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18292), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1759,23 +1765,23 @@ static void giga_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18278, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18278), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18283, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18283), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18288, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18288), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18293, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18293), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1807,23 +1813,23 @@ static void giga_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18254, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18254), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18259, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18259), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18264, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18264), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18269, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18269), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1843,21 +1849,23 @@ static void giga_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18255, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18255), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18260, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18260), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18265, { 0, 0, height }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18265), { 0, 0, height },
+                        { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18270, { 0, 0, height }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18270), { 0, 0, height },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1872,22 +1880,23 @@ static void giga_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18256, { 0, 0, height }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18256), { 0, 0, height },
+                        { 16, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18261, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18261), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18266, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18266), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18271, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18271), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1902,21 +1911,23 @@ static void giga_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18257, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18257), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18262, { 0, 0, height }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18262), { 0, 0, height },
+                        { 16, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18267, { 0, 0, height }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18267), { 0, 0, height },
+                        { 16, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18272, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18272), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1931,23 +1942,23 @@ static void giga_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18258, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18258), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18263, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18263), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18268, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18268), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18273, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18273), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1997,23 +2008,23 @@ static void giga_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18238, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18238), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18242, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18242), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18241, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18241), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18245, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18245), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2030,25 +2041,27 @@ static void giga_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18239, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18239), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18243, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18243), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 6, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18240, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18240), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18244, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18244), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2063,23 +2076,25 @@ static void giga_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18240, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18240), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18244, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18244), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18239, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18239), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18243, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18243), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 6, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2096,23 +2111,23 @@ static void giga_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18241, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18241), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18245, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18245), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18238, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18238), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18242, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18242), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2144,23 +2159,23 @@ static void giga_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18246, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18246), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18250, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18250), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18249, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18249), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18253, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18253), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2177,25 +2192,27 @@ static void giga_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18247, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18247), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18251, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18251), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18248, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18248), { 0, 0, height },
+                        { 32, 26, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18252, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18252), { 0, 0, height },
+                        { 32, 26, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2210,23 +2227,25 @@ static void giga_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18248, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18248), { 0, 0, height },
+                        { 32, 26, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18252, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18252), { 0, 0, height },
+                        { 32, 26, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18247, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18247), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18251, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18251), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2243,23 +2262,23 @@ static void giga_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18249, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18249), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18253, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18253), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18246, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18246), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18250, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18250), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2291,23 +2310,23 @@ static void giga_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18159, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18159), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18162, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18162), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18165, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18165), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18156, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18156), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2327,23 +2346,23 @@ static void giga_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18158, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18158), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18161, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18161), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18164, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18164), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18155, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18155), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2355,23 +2374,23 @@ static void giga_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18157, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18157), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18160, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18160), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18163, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18163), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18154, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18154), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2412,26 +2431,26 @@ static void giga_rc_track_left_quarter_turn_3_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18171, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18171), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18178, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18178), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18174, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18174), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18177, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18177), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18168, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18168), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2451,23 +2470,23 @@ static void giga_rc_track_left_quarter_turn_3_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18170, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18170), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18173, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18173), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18176, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18176), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18167, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18167), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2479,26 +2498,26 @@ static void giga_rc_track_left_quarter_turn_3_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18169, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18169), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18172, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18172), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18175, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18175), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18179, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18179), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18166, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18166), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2539,19 +2558,23 @@ static void giga_rc_track_left_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18305, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18305), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18307, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18307), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18309, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18309), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18303, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18303), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2574,19 +2597,23 @@ static void giga_rc_track_left_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18304, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18304), { 6, 0, height },
+                        { 20, 32, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18306, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18306), { 6, 0, height },
+                        { 20, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18308, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18308), { 6, 0, height },
+                        { 20, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18302, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18302), { 6, 0, height },
+                        { 20, 32, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2618,19 +2645,23 @@ static void giga_rc_track_right_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18294, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18294), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18296, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18296), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18298, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18298), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18300, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18300), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2653,25 +2684,29 @@ static void giga_rc_track_right_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18295, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18295), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18297, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18297), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18299, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18299), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18301, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18301), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2722,26 +2757,26 @@ static void giga_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18329, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18329), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18336, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18336), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18332, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18332), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18335, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18335), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18326, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18326), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2762,23 +2797,23 @@ static void giga_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18328, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18328), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18331, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18331), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18334, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18334), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18325, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18325), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2790,26 +2825,26 @@ static void giga_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18327, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18327), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18330, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18330), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18333, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18333), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18337, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18337), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18324, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18324), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 8 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2832,26 +2867,26 @@ static void giga_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18326, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18326), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18329, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18329), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18336, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18336), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18332, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18332), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18335, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18335), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2877,23 +2912,23 @@ static void giga_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18325, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18325), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18328, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18328), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18331, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18331), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18334, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18334), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2905,26 +2940,26 @@ static void giga_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18324, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18324), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18327, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18327), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18330, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18330), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18333, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18333), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18337, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18337), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2952,26 +2987,26 @@ static void giga_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18310, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18310), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18313, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18313), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18316, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18316), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18319, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18319), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18323, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18323), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2992,23 +3027,23 @@ static void giga_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18311, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18311), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18314, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18314), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18317, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18317), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18320, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18320), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3020,26 +3055,26 @@ static void giga_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18312, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18312), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18315, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18315), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18322, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18322), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18318, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18318), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18321, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18321), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3062,26 +3097,26 @@ static void giga_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18313, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18313), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18316, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18316), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18319, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18319), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18323, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18323), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18310, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18310), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3107,23 +3142,23 @@ static void giga_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18314, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18314), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18317, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18317), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18320, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18320), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18311, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18311), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3135,26 +3170,26 @@ static void giga_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18315, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18315), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18322, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18322), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18318, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18318), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18321, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18321), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18312, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18312), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3210,26 +3245,26 @@ static void giga_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18369, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18369), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18380, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18380), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18374, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18374), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18379, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18379), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18364, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18364), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3250,23 +3285,23 @@ static void giga_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18368, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18368), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18373, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18373), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18378, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18378), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18363, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18363), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3281,23 +3316,23 @@ static void giga_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18367, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18367), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18372, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18372), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18377, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18377), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18362, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18362), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3312,23 +3347,23 @@ static void giga_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18366, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18366), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18371, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18371), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18376, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18376), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18361, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18361), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3343,26 +3378,26 @@ static void giga_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18365, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18365), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18370, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18370), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18375, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18375), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18381, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18381), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18360, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18360), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 8 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3385,26 +3420,26 @@ static void giga_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18364, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18364), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18369, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18369), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18380, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18380), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18374, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18374), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18379, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18379), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3430,23 +3465,23 @@ static void giga_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18363, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18363), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18368, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18368), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18373, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18373), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18378, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18378), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3461,23 +3496,23 @@ static void giga_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18362, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18362), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18367, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18367), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18372, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18372), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18377, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18377), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3492,23 +3527,23 @@ static void giga_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18361, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18361), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18366, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18366), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18371, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18371), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18376, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18376), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3523,26 +3558,26 @@ static void giga_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18360, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18360), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18365, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18365), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18370, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18370), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18375, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18375), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18381, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18381), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3570,26 +3605,26 @@ static void giga_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18338, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18338), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18343, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18343), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18348, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18348), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18353, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18353), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18359, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18359), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3610,23 +3645,23 @@ static void giga_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18339, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18339), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18344, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18344), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18349, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18349), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18354, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18354), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3641,23 +3676,23 @@ static void giga_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18340, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18340), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18345, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18345), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18350, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18350), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18355, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18355), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3672,23 +3707,23 @@ static void giga_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18341, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18341), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18346, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18346), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18351, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18351), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18356, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18356), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3703,32 +3738,32 @@ static void giga_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18342, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18342), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 8 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18347, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18347), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18358, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18358), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18352, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18352), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18357, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18357), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3752,26 +3787,26 @@ static void giga_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18343, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18343), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18348, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18348), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18353, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18353), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18359, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18359), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18338, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18338), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3797,23 +3832,23 @@ static void giga_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18344, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18344), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18349, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18349), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18354, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18354), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18339, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18339), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3828,23 +3863,23 @@ static void giga_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18345, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18345), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18350, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18350), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18355, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18355), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18340, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18340), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3859,23 +3894,23 @@ static void giga_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18346, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18346), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18351, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18351), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18356, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18356), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18341, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18341), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3890,32 +3925,32 @@ static void giga_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18347, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18347), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18358, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18358), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18352, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18352), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18357, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18357), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18342, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18342), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3969,34 +4004,34 @@ static void giga_rc_track_left_quarter_turn_1_60_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18231, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18231), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18235, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18235), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18232, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18232), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18236, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18236), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18233, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18233), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18237, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18237), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18230, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18230), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18234, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18234), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
     }
@@ -4014,34 +4049,34 @@ static void giga_rc_track_right_quarter_turn_1_60_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18222, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18222), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18226, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18226), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18223, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18223), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18227, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18227), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18224, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18224), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18228, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18228), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18225, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18225), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18229, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18229), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
     }
@@ -4076,20 +4111,20 @@ static void giga_rc_track_brakes(
         case 0:
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | GIGA_COASTER_BRAKE_SW_NE_CLOSED_1, { 0, 0, height },
-                { 32, 20, 3 }, { 0, 6, height });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(GIGA_COASTER_BRAKE_SW_NE_CLOSED_1),
+                { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | GIGA_COASTER_BRAKE_SW_NE_CLOSED_2, { 0, 0, height },
-                { 32, 1, 11 }, { 0, 27, height + 5 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(GIGA_COASTER_BRAKE_SW_NE_CLOSED_2),
+                { 0, 0, height }, { 32, 1, 11 }, { 0, 27, height + 5 });
             break;
         case 1:
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | GIGA_COASTER_BRAKE_NW_SE_CLOSED_1, { 0, 0, height },
-                { 32, 20, 3 }, { 0, 6, height });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(GIGA_COASTER_BRAKE_NW_SE_CLOSED_1),
+                { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | GIGA_COASTER_BRAKE_NW_SE_CLOSED_2, { 0, 0, height },
-                { 32, 1, 11 }, { 0, 27, height + 5 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(GIGA_COASTER_BRAKE_NW_SE_CLOSED_2),
+                { 0, 0, height }, { 32, 1, 11 }, { 0, 27, height + 5 });
             break;
     }
     if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -4111,22 +4146,22 @@ static void giga_rc_track_25_deg_up_left_banked(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18560, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18560), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18561, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18561), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18562, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18562), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18563, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18563), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -4156,22 +4191,22 @@ static void giga_rc_track_25_deg_up_right_banked(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18564, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18564), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18565, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18565), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18566, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18566), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18567, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18567), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -4201,38 +4236,38 @@ static void giga_rc_track_on_ride_photo(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18074, { 0, 0, height }, { 32, 20, 0 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18074), { 0, 0, height }, { 32, 20, 0 },
                 { 0, 6, height + 3 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18075, { 0, 0, height }, { 32, 20, 0 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18075), { 0, 0, height }, { 32, 20, 0 },
                 { 0, 6, height + 3 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18074, { 0, 0, height }, { 32, 20, 0 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18074), { 0, 0, height }, { 32, 20, 0 },
                 { 0, 6, height + 3 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18075, { 0, 0, height }, { 32, 20, 0 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18075), { 0, 0, height }, { 32, 20, 0 },
                 { 0, 6, height + 3 });
             break;
     }
@@ -4272,23 +4307,23 @@ static void giga_rc_track_flat_to_60_deg_up_long_base(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18722, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18722), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18726, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18726), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18730, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18730), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18734, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18734), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -4303,23 +4338,23 @@ static void giga_rc_track_flat_to_60_deg_up_long_base(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18660, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18660), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18664, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18664), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18668, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18668), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18672, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18672), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -4343,23 +4378,23 @@ static void giga_rc_track_flat_to_60_deg_up_long_base(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18723, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18723), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18727, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18727), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18731, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18731), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18735, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18735), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -4374,23 +4409,23 @@ static void giga_rc_track_flat_to_60_deg_up_long_base(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18661, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18661), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18665, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18665), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18669, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18669), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18673, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18673), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -4410,23 +4445,23 @@ static void giga_rc_track_flat_to_60_deg_up_long_base(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18724, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18724), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18728, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18728), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18732, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18732), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18736, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18736), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -4441,23 +4476,23 @@ static void giga_rc_track_flat_to_60_deg_up_long_base(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18662, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18662), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18666, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18666), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18670, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18670), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18674, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18674), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -4477,23 +4512,23 @@ static void giga_rc_track_flat_to_60_deg_up_long_base(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18725, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18725), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18729, { 0, 0, height }, { 32, 1, 98 },
-                            { 0, 27, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18729), { 0, 0, height },
+                            { 32, 1, 98 }, { 0, 27, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18733, { 0, 0, height }, { 32, 1, 98 },
-                            { 0, 27, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18733), { 0, 0, height },
+                            { 32, 1, 98 }, { 0, 27, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18737, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18737), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -4508,23 +4543,23 @@ static void giga_rc_track_flat_to_60_deg_up_long_base(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18663, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18663), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18667, { 0, 0, height }, { 32, 1, 98 },
-                            { 0, 27, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18667), { 0, 0, height },
+                            { 32, 1, 98 }, { 0, 27, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18671, { 0, 0, height }, { 32, 1, 98 },
-                            { 0, 27, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18671), { 0, 0, height },
+                            { 32, 1, 98 }, { 0, 27, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18675, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18675), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -4561,23 +4596,23 @@ static void giga_rc_track_60_deg_up_to_flat_long_base(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18676, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18676), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18680, { 0, 0, height }, { 32, 1, 98 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18680), { 0, 0, height },
+                        { 32, 1, 98 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18684, { 0, 0, height }, { 32, 1, 98 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18684), { 0, 0, height },
+                        { 32, 1, 98 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18688, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18688), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -4598,23 +4633,23 @@ static void giga_rc_track_60_deg_up_to_flat_long_base(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18677, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18677), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18681, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18681), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18685, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18685), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18689, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18689), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -4631,23 +4666,23 @@ static void giga_rc_track_60_deg_up_to_flat_long_base(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18678, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18678), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18682, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18682), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18686, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18686), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18690, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18690), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -4664,23 +4699,23 @@ static void giga_rc_track_60_deg_up_to_flat_long_base(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18679, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18679), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18683, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18683), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18687, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18687), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18691, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18691), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -4732,23 +4767,23 @@ static void giga_rc_track_cable_lift_hill(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18698, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18698), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18699, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18699), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18700, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18700), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18701, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18701), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -4773,23 +4808,23 @@ static void giga_rc_track_cable_lift_hill(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18700, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18700), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18701, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18701), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18698, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18698), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18699, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18699), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -4814,29 +4849,29 @@ static void giga_rc_track_cable_lift_hill(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18714, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18714), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18717, { 0, 0, height }, { 32, 1, 66 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18717), { 0, 0, height },
+                        { 32, 1, 66 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18715, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18715), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18712, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18712), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18713, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18713), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18716, { 0, 0, height }, { 32, 1, 66 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18716), { 0, 0, height },
+                        { 32, 1, 66 }, { 0, 27, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -4861,23 +4896,23 @@ static void giga_rc_track_cable_lift_hill(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18720, { 0, 0, height }, { 32, 1, 98 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18720), { 0, 0, height },
+                        { 32, 1, 98 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18721, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18721), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18718, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18718), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18719, { 0, 0, height }, { 32, 1, 98 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18719), { 0, 0, height },
+                        { 32, 1, 98 }, { 0, 27, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -4912,23 +4947,23 @@ static void giga_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18414, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18414), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18418, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18418), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18422, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18422), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18426, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18426), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4945,23 +4980,23 @@ static void giga_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18415, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18415), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18419, { 0, 0, height }, { 34, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18419), { 0, 0, height },
+                        { 34, 16, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18423, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18423), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18427, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18427), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4976,23 +5011,23 @@ static void giga_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18416, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18416), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18420, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18420), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18424, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18424), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18428, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18428), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5010,29 +5045,29 @@ static void giga_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18417, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18417), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18421, { 0, 0, height }, { 16, 18, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18421), { 0, 0, height },
+                        { 16, 18, 3 }, { 0, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18425, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18425), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18429, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18429), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -5059,23 +5094,23 @@ static void giga_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18398, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18398), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18402, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18402), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18406, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18406), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18410, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18410), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -5092,23 +5127,23 @@ static void giga_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18399, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18399), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18403, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18403), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18407, { 0, 0, height }, { 34, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18407), { 0, 0, height },
+                        { 34, 16, 3 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18411, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18411), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5123,23 +5158,23 @@ static void giga_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18400, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18400), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18404, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18404), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18408, { 0, 0, height }, { 28, 28, 3 },
-                        { 4, 4, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18408), { 0, 0, height },
+                        { 28, 28, 3 }, { 4, 4, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18412, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18412), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5157,29 +5192,29 @@ static void giga_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18401, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18401), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18405, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18405), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18409, { 0, 0, height }, { 16, 18, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18409), { 0, 0, height },
+                        { 16, 18, 3 }, { 0, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18413, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18413), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -5224,23 +5259,23 @@ static void giga_rc_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18446, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18446), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18450, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18450), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18454, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18454), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18458, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18458), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -5257,23 +5292,23 @@ static void giga_rc_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18447, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18447), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18451, { 0, 0, height }, { 34, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18451), { 0, 0, height },
+                        { 34, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18455, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18455), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18459, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18459), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5288,23 +5323,23 @@ static void giga_rc_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18448, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18448), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18452, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18452), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18456, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18456), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18460, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18460), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5322,29 +5357,29 @@ static void giga_rc_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18449, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18449), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18453, { 0, 0, height }, { 16, 18, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18453), { 0, 0, height },
+                        { 16, 18, 0 }, { 0, 16, height + 27 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18457, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18457), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18461, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18461), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -5371,23 +5406,23 @@ static void giga_rc_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18430, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18430), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18434, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18434), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18438, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18438), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18442, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18442), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -5404,23 +5439,23 @@ static void giga_rc_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18431, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18431), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18435, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18435), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18439, { 0, 0, height }, { 34, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18439), { 0, 0, height },
+                        { 34, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18443, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18443), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5435,23 +5470,23 @@ static void giga_rc_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18432, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18432), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18436, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18436), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18440, { 0, 0, height }, { 28, 28, 0 },
-                        { 4, 4, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18440), { 0, 0, height },
+                        { 28, 28, 0 }, { 4, 4, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18444, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18444), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5469,29 +5504,29 @@ static void giga_rc_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18433, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18433), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18437, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18437), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18441, { 0, 0, height }, { 16, 18, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18441), { 0, 0, height },
+                        { 16, 18, 0 }, { 0, 16, height + 27 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18445, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18445), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -5538,8 +5573,8 @@ static void giga_rc_track_diag_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18527, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18527), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5549,8 +5584,8 @@ static void giga_rc_track_diag_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18465, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18465), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5565,8 +5600,8 @@ static void giga_rc_track_diag_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18524, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18524), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5576,8 +5611,8 @@ static void giga_rc_track_diag_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18462, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18462), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5592,8 +5627,8 @@ static void giga_rc_track_diag_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18526, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18526), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5603,8 +5638,8 @@ static void giga_rc_track_diag_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18464, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18464), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5623,8 +5658,8 @@ static void giga_rc_track_diag_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18525, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18525), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5648,8 +5683,8 @@ static void giga_rc_track_diag_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18463, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18463), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5684,8 +5719,8 @@ static void giga_rc_track_diag_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18539, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18539), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5695,8 +5730,8 @@ static void giga_rc_track_diag_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18477, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18477), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5711,8 +5746,8 @@ static void giga_rc_track_diag_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18536, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18536), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5722,8 +5757,8 @@ static void giga_rc_track_diag_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18474, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18474), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5738,8 +5773,8 @@ static void giga_rc_track_diag_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18538, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18538), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5749,8 +5784,8 @@ static void giga_rc_track_diag_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18476, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18476), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5769,8 +5804,8 @@ static void giga_rc_track_diag_25_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18537, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18537), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5794,8 +5829,8 @@ static void giga_rc_track_diag_25_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18475, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18475), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5828,8 +5863,8 @@ static void giga_rc_track_diag_60_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18489, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18489), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5841,8 +5876,8 @@ static void giga_rc_track_diag_60_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18486, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18486), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5854,8 +5889,8 @@ static void giga_rc_track_diag_60_deg_up(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18488, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18488), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5871,8 +5906,8 @@ static void giga_rc_track_diag_60_deg_up(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18487, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18487), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 36, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -5906,8 +5941,8 @@ static void giga_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18531, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18531), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5917,8 +5952,8 @@ static void giga_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18469, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18469), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5933,8 +5968,8 @@ static void giga_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18528, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18528), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5944,8 +5979,8 @@ static void giga_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18466, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18466), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5960,8 +5995,8 @@ static void giga_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18530, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18530), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5971,8 +6006,8 @@ static void giga_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18468, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18468), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5991,8 +6026,8 @@ static void giga_rc_track_diag_flat_to_25_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18529, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18529), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6016,8 +6051,8 @@ static void giga_rc_track_diag_flat_to_25_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18467, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18467), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6050,8 +6085,8 @@ static void giga_rc_track_diag_25_deg_up_to_60_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18481, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18481), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6063,8 +6098,8 @@ static void giga_rc_track_diag_25_deg_up_to_60_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18478, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18478), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6076,8 +6111,8 @@ static void giga_rc_track_diag_25_deg_up_to_60_deg_up(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18480, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18480), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6093,8 +6128,8 @@ static void giga_rc_track_diag_25_deg_up_to_60_deg_up(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18479, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18479), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -6126,8 +6161,8 @@ static void giga_rc_track_diag_60_deg_up_to_25_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18485, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18485), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6139,8 +6174,8 @@ static void giga_rc_track_diag_60_deg_up_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18482, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18482), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6152,8 +6187,8 @@ static void giga_rc_track_diag_60_deg_up_to_25_deg_up(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18484, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18484), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6169,8 +6204,8 @@ static void giga_rc_track_diag_60_deg_up_to_25_deg_up(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18483, { -16, -16, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18483), { -16, -16, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 21, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -6204,8 +6239,8 @@ static void giga_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18535, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18535), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6215,8 +6250,8 @@ static void giga_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18473, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18473), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6231,8 +6266,8 @@ static void giga_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18532, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18532), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6242,8 +6277,8 @@ static void giga_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18470, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18470), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6258,8 +6293,8 @@ static void giga_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18534, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18534), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6269,8 +6304,8 @@ static void giga_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18472, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18472), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6289,8 +6324,8 @@ static void giga_rc_track_diag_25_deg_up_to_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18533, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18533), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6314,8 +6349,8 @@ static void giga_rc_track_diag_25_deg_up_to_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18471, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18471), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6350,8 +6385,8 @@ static void giga_rc_track_diag_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18537, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18537), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6361,8 +6396,8 @@ static void giga_rc_track_diag_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18475, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18475), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6377,8 +6412,8 @@ static void giga_rc_track_diag_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18538, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18538), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6388,8 +6423,8 @@ static void giga_rc_track_diag_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18476, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18476), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6404,8 +6439,8 @@ static void giga_rc_track_diag_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18536, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18536), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6415,8 +6450,8 @@ static void giga_rc_track_diag_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18474, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18474), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6435,8 +6470,8 @@ static void giga_rc_track_diag_25_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18539, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18539), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6460,8 +6495,8 @@ static void giga_rc_track_diag_25_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18477, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18477), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6494,8 +6529,8 @@ static void giga_rc_track_diag_60_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18487, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18487), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6507,8 +6542,8 @@ static void giga_rc_track_diag_60_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18488, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18488), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6520,8 +6555,8 @@ static void giga_rc_track_diag_60_deg_down(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18486, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18486), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6537,8 +6572,8 @@ static void giga_rc_track_diag_60_deg_down(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18489, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18489), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 28, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -6572,8 +6607,8 @@ static void giga_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18533, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18533), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6583,8 +6618,8 @@ static void giga_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18471, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18471), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6598,8 +6633,8 @@ static void giga_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18534, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18534), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6609,8 +6644,8 @@ static void giga_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18472, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18472), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6624,8 +6659,8 @@ static void giga_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18532, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18532), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6635,8 +6670,8 @@ static void giga_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18470, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18470), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6654,8 +6689,8 @@ static void giga_rc_track_diag_flat_to_25_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18535, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18535), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6679,8 +6714,8 @@ static void giga_rc_track_diag_flat_to_25_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18473, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18473), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6714,8 +6749,8 @@ static void giga_rc_track_diag_25_deg_down_to_60_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18483, { -16, -16, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18483), { -16, -16, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6727,8 +6762,8 @@ static void giga_rc_track_diag_25_deg_down_to_60_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18484, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18484), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6740,8 +6775,8 @@ static void giga_rc_track_diag_25_deg_down_to_60_deg_down(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18482, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18482), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6757,8 +6792,8 @@ static void giga_rc_track_diag_25_deg_down_to_60_deg_down(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18485, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18485), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 17, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -6790,8 +6825,8 @@ static void giga_rc_track_diag_60_deg_down_to_25_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18479, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18479), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6803,8 +6838,8 @@ static void giga_rc_track_diag_60_deg_down_to_25_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18480, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18480), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6816,8 +6851,8 @@ static void giga_rc_track_diag_60_deg_down_to_25_deg_down(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18478, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18478), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6833,8 +6868,8 @@ static void giga_rc_track_diag_60_deg_down_to_25_deg_down(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18481, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18481), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -6868,8 +6903,8 @@ static void giga_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18529, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18529), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6879,8 +6914,8 @@ static void giga_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18467, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18467), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6895,8 +6930,8 @@ static void giga_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18530, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18530), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6906,8 +6941,8 @@ static void giga_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18468, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18468), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6922,8 +6957,8 @@ static void giga_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18528, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18528), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6933,8 +6968,8 @@ static void giga_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18466, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18466), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6953,8 +6988,8 @@ static void giga_rc_track_diag_25_deg_down_to_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18531, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18531), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6978,8 +7013,8 @@ static void giga_rc_track_diag_25_deg_down_to_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 18469, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18469), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7012,8 +7047,8 @@ static void giga_rc_track_diag_flat_to_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18497, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18497), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7025,11 +7060,11 @@ static void giga_rc_track_diag_flat_to_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18494, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18494), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18498, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18498), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7041,8 +7076,8 @@ static void giga_rc_track_diag_flat_to_left_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18496, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18496), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7058,8 +7093,8 @@ static void giga_rc_track_diag_flat_to_left_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18495, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18495), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7091,8 +7126,8 @@ static void giga_rc_track_diag_flat_to_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18502, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18502), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7104,8 +7139,8 @@ static void giga_rc_track_diag_flat_to_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18499, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18499), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7117,11 +7152,11 @@ static void giga_rc_track_diag_flat_to_right_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18501, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18501), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18503, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18503), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7137,8 +7172,8 @@ static void giga_rc_track_diag_flat_to_right_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18500, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18500), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7170,8 +7205,8 @@ static void giga_rc_track_diag_left_bank_to_flat(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18500, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18500), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7183,11 +7218,11 @@ static void giga_rc_track_diag_left_bank_to_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18501, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18501), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18503, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18503), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7199,8 +7234,8 @@ static void giga_rc_track_diag_left_bank_to_flat(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18499, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18499), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7216,8 +7251,8 @@ static void giga_rc_track_diag_left_bank_to_flat(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18502, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18502), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7249,8 +7284,8 @@ static void giga_rc_track_diag_right_bank_to_flat(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18495, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18495), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7262,8 +7297,8 @@ static void giga_rc_track_diag_right_bank_to_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18496, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18496), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7275,11 +7310,11 @@ static void giga_rc_track_diag_right_bank_to_flat(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18494, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18494), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18498, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18498), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7295,8 +7330,8 @@ static void giga_rc_track_diag_right_bank_to_flat(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18497, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18497), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7328,8 +7363,8 @@ static void giga_rc_track_diag_left_bank_to_25_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18517, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18517), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7341,11 +7376,11 @@ static void giga_rc_track_diag_left_bank_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18514, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18514), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18518, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18518), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7357,8 +7392,8 @@ static void giga_rc_track_diag_left_bank_to_25_deg_up(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18516, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18516), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7374,8 +7409,8 @@ static void giga_rc_track_diag_left_bank_to_25_deg_up(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18515, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18515), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7407,8 +7442,8 @@ static void giga_rc_track_diag_right_bank_to_25_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18522, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18522), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7420,8 +7455,8 @@ static void giga_rc_track_diag_right_bank_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18519, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18519), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7433,11 +7468,11 @@ static void giga_rc_track_diag_right_bank_to_25_deg_up(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18521, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18521), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18523, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18523), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7453,8 +7488,8 @@ static void giga_rc_track_diag_right_bank_to_25_deg_up(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18520, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18520), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7486,8 +7521,8 @@ static void giga_rc_track_diag_25_deg_up_to_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18507, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18507), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7499,11 +7534,11 @@ static void giga_rc_track_diag_25_deg_up_to_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18504, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18504), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18508, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18508), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7515,8 +7550,8 @@ static void giga_rc_track_diag_25_deg_up_to_left_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18506, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18506), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7532,8 +7567,8 @@ static void giga_rc_track_diag_25_deg_up_to_left_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18505, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18505), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7565,8 +7600,8 @@ static void giga_rc_track_diag_25_deg_up_to_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18512, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18512), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7578,8 +7613,8 @@ static void giga_rc_track_diag_25_deg_up_to_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18509, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18509), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7591,11 +7626,11 @@ static void giga_rc_track_diag_25_deg_up_to_right_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18511, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18511), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18513, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18513), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7611,8 +7646,8 @@ static void giga_rc_track_diag_25_deg_up_to_right_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18510, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18510), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7644,8 +7679,8 @@ static void giga_rc_track_diag_left_bank_to_25_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18510, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18510), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7656,11 +7691,11 @@ static void giga_rc_track_diag_left_bank_to_25_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18511, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18511), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18513, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18513), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7671,8 +7706,8 @@ static void giga_rc_track_diag_left_bank_to_25_deg_down(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18509, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18509), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7687,8 +7722,8 @@ static void giga_rc_track_diag_left_bank_to_25_deg_down(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18512, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18512), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7721,8 +7756,8 @@ static void giga_rc_track_diag_right_bank_to_25_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18505, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18505), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7733,8 +7768,8 @@ static void giga_rc_track_diag_right_bank_to_25_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18506, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18506), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7745,11 +7780,11 @@ static void giga_rc_track_diag_right_bank_to_25_deg_down(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18504, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18504), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18508, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18508), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7764,8 +7799,8 @@ static void giga_rc_track_diag_right_bank_to_25_deg_down(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18507, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18507), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7798,8 +7833,8 @@ static void giga_rc_track_diag_25_deg_down_to_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18520, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18520), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7811,11 +7846,11 @@ static void giga_rc_track_diag_25_deg_down_to_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18521, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18521), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18523, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18523), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7827,8 +7862,8 @@ static void giga_rc_track_diag_25_deg_down_to_left_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18519, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18519), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7844,8 +7879,8 @@ static void giga_rc_track_diag_25_deg_down_to_left_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18522, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18522), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7877,8 +7912,8 @@ static void giga_rc_track_diag_25_deg_down_to_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18515, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18515), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7890,8 +7925,8 @@ static void giga_rc_track_diag_25_deg_down_to_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18516, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18516), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7903,11 +7938,11 @@ static void giga_rc_track_diag_25_deg_down_to_right_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18514, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18514), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18518, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18518), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7923,8 +7958,8 @@ static void giga_rc_track_diag_25_deg_down_to_right_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18517, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18517), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7956,8 +7991,8 @@ static void giga_rc_track_diag_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18493, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18493), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7969,8 +8004,8 @@ static void giga_rc_track_diag_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18490, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18490), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7982,8 +8017,8 @@ static void giga_rc_track_diag_left_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18492, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18492), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7999,8 +8034,8 @@ static void giga_rc_track_diag_left_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18491, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18491), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8032,8 +8067,8 @@ static void giga_rc_track_diag_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18491, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18491), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8045,8 +8080,8 @@ static void giga_rc_track_diag_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18492, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18492), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8058,8 +8093,8 @@ static void giga_rc_track_diag_right_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18490, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18490), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8075,8 +8110,8 @@ static void giga_rc_track_diag_right_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18493, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18493), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8103,10 +8138,10 @@ static void giga_rc_track_block_brakes(
 {
     bool isClosed = trackElement.BlockBrakeClosed();
     PaintAddImageAsParentRotated(
-        session, direction, session.TrackColours[SCHEME_TRACK] | _GigaCoasterBrakeImages[direction][isClosed][0],
+        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(_GigaCoasterBrakeImages[direction][isClosed][0]),
         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
     PaintAddImageAsParentRotated(
-        session, direction, session.TrackColours[SCHEME_TRACK] | _GigaCoasterBrakeImages[direction][isClosed][1],
+        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(_GigaCoasterBrakeImages[direction][isClosed][1]),
         { 0, 0, height }, { 32, 1, 11 }, { 0, 27, height + 5 });
 
     if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -8131,20 +8166,23 @@ static void giga_rc_track_left_banked_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18655, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18655), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18657, { 0, 6, height }, { 32, 1, 34 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18657), { 0, 6, height },
+                        { 32, 1, 34 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18659, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18659), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18653, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18653), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -8167,21 +8205,23 @@ static void giga_rc_track_left_banked_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18654, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18654), { 6, 0, height },
+                        { 20, 32, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18656, { 6, 0, height }, { 1, 32, 34 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18656), { 6, 0, height },
+                        { 1, 32, 34 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18658, { 6, 0, height }, { 1, 32, 34 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18658), { 6, 0, height },
+                        { 1, 32, 34 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18652, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18652), { 6, 0, height },
+                        { 20, 32, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -8213,20 +8253,23 @@ static void giga_rc_track_right_banked_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18644, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18644), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18646, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18646), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18648, { 0, 6, height }, { 32, 1, 34 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18648), { 0, 6, height },
+                        { 32, 1, 34 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18650, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18650), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -8249,27 +8292,29 @@ static void giga_rc_track_right_banked_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18645, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18645), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18647, { 6, 0, height }, { 1, 32, 34 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18647), { 6, 0, height },
+                        { 1, 32, 34 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18649, { 6, 0, height }, { 1, 32, 34 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18649), { 6, 0, height },
+                        { 1, 32, 34 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18651, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18651), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8321,23 +8366,23 @@ static void giga_rc_track_left_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18624, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18624), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18629, { 0, 0, height }, { 32, 1, 34 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18629), { 0, 0, height },
+                        { 32, 1, 34 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18634, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18634), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18639, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18639), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -8357,22 +8402,23 @@ static void giga_rc_track_left_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18625, { 0, 0, height }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18625), { 0, 0, height },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18630, { 0, 0, height }, { 1, 1, 34 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18630), { 0, 0, height }, { 1, 1, 34 },
                         { 30, 30, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18635, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18635), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18640, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18640), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8387,22 +8433,23 @@ static void giga_rc_track_left_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18626, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18626), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18631, { 0, 0, height }, { 1, 1, 34 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18631), { 0, 0, height }, { 1, 1, 34 },
                         { 30, 30, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18636, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18636), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18641, { 0, 0, height }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18641), { 0, 0, height },
+                        { 16, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8417,23 +8464,23 @@ static void giga_rc_track_left_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18627, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18627), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18632, { 0, 0, height }, { 1, 1, 34 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18632), { 0, 0, height }, { 1, 1, 34 },
                         { 30, 30, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18637, { 0, 0, height }, { 1, 32, 34 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18637), { 0, 0, height },
+                        { 1, 32, 34 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18642, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18642), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8448,23 +8495,23 @@ static void giga_rc_track_left_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18628, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18628), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18633, { 0, 0, height }, { 1, 32, 34 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18633), { 0, 0, height },
+                        { 1, 32, 34 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18638, { 0, 0, height }, { 1, 32, 34 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18638), { 0, 0, height },
+                        { 1, 32, 34 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18643, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18643), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -8496,23 +8543,23 @@ static void giga_rc_track_right_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18604, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18604), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18609, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18609), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18614, { 0, 0, height }, { 32, 1, 34 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18614), { 0, 0, height },
+                        { 32, 1, 34 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18619, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18619), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -8532,22 +8579,23 @@ static void giga_rc_track_right_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18605, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18605), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18610, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18610), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18615, { 0, 0, height }, { 1, 1, 34 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18615), { 0, 0, height }, { 1, 1, 34 },
                         { 30, 30, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18620, { 0, 0, height }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18620), { 0, 0, height },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8562,22 +8610,23 @@ static void giga_rc_track_right_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18606, { 0, 0, height }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18606), { 0, 0, height },
+                        { 16, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18611, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18611), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18616, { 0, 0, height }, { 1, 1, 34 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18616), { 0, 0, height }, { 1, 1, 34 },
                         { 30, 30, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18621, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18621), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8592,23 +8641,23 @@ static void giga_rc_track_right_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18607, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18607), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18612, { 0, 0, height }, { 1, 32, 34 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18612), { 0, 0, height },
+                        { 1, 32, 34 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18617, { 0, 0, height }, { 1, 1, 34 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18617), { 0, 0, height }, { 1, 1, 34 },
                         { 30, 30, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18622, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18622), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8623,23 +8672,23 @@ static void giga_rc_track_right_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18608, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18608), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18613, { 0, 0, height }, { 1, 32, 34 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18613), { 0, 0, height },
+                        { 1, 32, 34 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18618, { 0, 0, height }, { 1, 32, 34 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18618), { 0, 0, height },
+                        { 1, 32, 34 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18623, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18623), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -8687,25 +8736,25 @@ static void giga_rc_track_25_deg_up_to_left_banked_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18568, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18568), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18569, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18569), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18576, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18576), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18570, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18570), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18571, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18571), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -8735,25 +8784,25 @@ static void giga_rc_track_25_deg_up_to_right_banked_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18572, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18572), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18573, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18573), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18574, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18574), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18577, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18577), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18575, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18575), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -8783,25 +8832,25 @@ static void giga_rc_track_left_banked_25_deg_up_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18578, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18578), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18579, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18579), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18586, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18586), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18580, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18580), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18581, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18581), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -8831,25 +8880,25 @@ static void giga_rc_track_right_banked_25_deg_up_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18582, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18582), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18583, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18583), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18584, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18584), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18587, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18587), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18585, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18585), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -8911,22 +8960,22 @@ static void giga_rc_track_left_banked_flat_to_left_banked_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18588, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18588), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18589, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18589), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18590, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18590), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18591, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18591), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -8956,22 +9005,22 @@ static void giga_rc_track_right_banked_flat_to_right_banked_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18592, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18592), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18593, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18593), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18594, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18594), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18595, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18595), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -9001,22 +9050,22 @@ static void giga_rc_track_left_banked_25_deg_up_to_left_banked_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18596, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18596), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18597, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18597), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18598, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18598), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18599, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18599), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -9046,22 +9095,22 @@ static void giga_rc_track_right_banked_25_deg_up_to_right_banked_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18600, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18600), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18601, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18601), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18602, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18602), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18603, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18603), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -9127,25 +9176,25 @@ static void giga_rc_track_flat_to_left_banked_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18540, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18540), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18541, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18541), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18548, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18548), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18542, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18542), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18543, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18543), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -9175,25 +9224,25 @@ static void giga_rc_track_flat_to_right_banked_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18544, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18544), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18545, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18545), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18546, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18546), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18549, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18549), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18547, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18547), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -9223,25 +9272,25 @@ static void giga_rc_track_left_banked_25_deg_up_to_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18550, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18550), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18551, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18551), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18558, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18558), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18552, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18552), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18553, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18553), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -9271,25 +9320,25 @@ static void giga_rc_track_right_banked_25_deg_up_to_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18554, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18554), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18555, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18555), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18556, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18556), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18559, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18559), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18557, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18557), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -9357,13 +9406,13 @@ static void giga_rc_track_booster(
         case 0:
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | SPR_G2_GIGA_RC_BOOSTER_NE_SW,
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(SPR_G2_GIGA_RC_BOOSTER_NE_SW),
                 { ne_sw_offsetX, ne_sw_offsetY, height }, { 32, 20, 3 }, { 0, 6, height });
             break;
         case 1:
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | SPR_G2_GIGA_RC_BOOSTER_NW_SE,
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(SPR_G2_GIGA_RC_BOOSTER_NW_SE),
                 { nw_se_offsetX, nw_se_offsetY, height }, { 32, 20, 3 }, { 0, 6, height });
             break;
     }

--- a/src/openrct2/ride/coaster/HeartlineTwisterCoaster.cpp
+++ b/src/openrct2/ride/coaster/HeartlineTwisterCoaster.cpp
@@ -29,37 +29,37 @@ static void heartline_twister_rc_track_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21354, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21354), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21356, { 0, 0, height }, { 32, 1, 26 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21356), { 0, 0, height }, { 32, 1, 26 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21355, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21355), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21357, { 0, 0, height }, { 32, 1, 26 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21357), { 0, 0, height }, { 32, 1, 26 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21358, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21358), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21360, { 0, 0, height }, { 32, 1, 26 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21360), { 0, 0, height }, { 32, 1, 26 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21359, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21359), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21361, { 0, 0, height }, { 32, 1, 26 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21361), { 0, 0, height }, { 32, 1, 26 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -72,20 +72,20 @@ static void heartline_twister_rc_track_flat(
             case 0:
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21294, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21294), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21296, { 0, 0, height }, { 32, 1, 26 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21296), { 0, 0, height }, { 32, 1, 26 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21295, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21295), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21297, { 0, 0, height }, { 32, 1, 26 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21297), { 0, 0, height }, { 32, 1, 26 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -108,10 +108,11 @@ static void heartline_twister_rc_track_station(
     };
 
     PaintAddImageAsParentRotated(
-        session, direction, imageIds[direction][0] | session.TrackColours[SCHEME_TRACK], { 0, 0, height }, { 32, 20, 1 },
-        { 0, 6, height + 3 });
+        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]), { 0, 0, height },
+        { 32, 20, 1 }, { 0, 6, height + 3 });
     PaintAddImageAsParentRotated(
-        session, direction, imageIds[direction][1] | session.TrackColours[SCHEME_MISC], { 0, 0, height }, { 32, 32, 1 });
+        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][1]), { 0, 0, height },
+        { 32, 32, 1 });
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], 0);
     track_paint_util_draw_station(session, ride, direction, height, trackElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -130,37 +131,37 @@ static void heartline_twister_rc_track_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21378, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21378), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21382, { 0, 0, height }, { 32, 1, 50 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21382), { 0, 0, height }, { 32, 1, 50 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 6, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21379, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21379), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21383, { 0, 0, height }, { 32, 1, 50 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21383), { 0, 0, height }, { 32, 1, 50 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 7, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21380, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21380), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21384, { 0, 0, height }, { 32, 1, 50 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21384), { 0, 0, height }, { 32, 1, 50 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 6, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21381, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21381), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21385, { 0, 0, height }, { 32, 1, 50 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21385), { 0, 0, height }, { 32, 1, 50 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 7, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -172,37 +173,37 @@ static void heartline_twister_rc_track_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21322, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21322), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21326, { 0, 0, height }, { 32, 1, 50 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21326), { 0, 0, height }, { 32, 1, 50 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 6, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21323, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21323), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21327, { 0, 0, height }, { 32, 1, 50 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21327), { 0, 0, height }, { 32, 1, 50 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 7, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21324, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21324), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21328, { 0, 0, height }, { 32, 1, 50 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21328), { 0, 0, height }, { 32, 1, 50 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 6, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21325, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21325), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21329, { 0, 0, height }, { 32, 1, 50 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21329), { 0, 0, height }, { 32, 1, 50 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 7, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -231,37 +232,37 @@ static void heartline_twister_rc_track_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21402, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21402), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21406, { 0, 0, height }, { 32, 1, 98 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21406), { 0, 0, height }, { 32, 1, 98 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 6, 21, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21403, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21403), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21407, { 0, 0, height }, { 32, 1, 98 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21407), { 0, 0, height }, { 32, 1, 98 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 7, 22, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21404, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21404), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21408, { 0, 0, height }, { 32, 1, 98 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21408), { 0, 0, height }, { 32, 1, 98 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 6, 23, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21405, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21405), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21409, { 0, 0, height }, { 32, 1, 98 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21409), { 0, 0, height }, { 32, 1, 98 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 7, 24, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -273,37 +274,37 @@ static void heartline_twister_rc_track_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21346, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21346), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21350, { 0, 0, height }, { 32, 1, 98 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21350), { 0, 0, height }, { 32, 1, 98 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 6, 21, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21347, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21347), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21351, { 0, 0, height }, { 32, 1, 98 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21351), { 0, 0, height }, { 32, 1, 98 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 7, 22, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21348, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21348), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21352, { 0, 0, height }, { 32, 1, 98 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21352), { 0, 0, height }, { 32, 1, 98 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 6, 23, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21349, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21349), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21353, { 0, 0, height }, { 32, 1, 98 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21353), { 0, 0, height }, { 32, 1, 98 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 7, 24, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -332,37 +333,37 @@ static void heartline_twister_rc_track_flat_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21362, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21362), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21366, { 0, 0, height }, { 32, 1, 42 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21366), { 0, 0, height }, { 32, 1, 42 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 6, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21363, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21363), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21367, { 0, 0, height }, { 32, 1, 42 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21367), { 0, 0, height }, { 32, 1, 42 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 7, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21364, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21364), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21368, { 0, 0, height }, { 32, 1, 42 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21368), { 0, 0, height }, { 32, 1, 42 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 6, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21365, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21365), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21369, { 0, 0, height }, { 32, 1, 42 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21369), { 0, 0, height }, { 32, 1, 42 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 7, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -374,37 +375,37 @@ static void heartline_twister_rc_track_flat_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21306, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21306), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21310, { 0, 0, height }, { 32, 1, 42 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21310), { 0, 0, height }, { 32, 1, 42 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 6, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21307, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21307), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21311, { 0, 0, height }, { 32, 1, 42 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21311), { 0, 0, height }, { 32, 1, 42 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 7, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21308, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21308), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21312, { 0, 0, height }, { 32, 1, 42 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21312), { 0, 0, height }, { 32, 1, 42 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 6, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21309, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21309), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21313, { 0, 0, height }, { 32, 1, 42 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21313), { 0, 0, height }, { 32, 1, 42 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 7, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -433,37 +434,37 @@ static void heartline_twister_rc_track_25_deg_up_to_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21386, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21386), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21390, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21390), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 6, 13, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21387, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21387), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21391, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21391), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 7, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21388, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21388), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21392, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21392), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 6, 15, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21389, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21389), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21393, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21393), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 7, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -475,37 +476,37 @@ static void heartline_twister_rc_track_25_deg_up_to_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21330, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21330), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21334, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21334), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 6, 13, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21331, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21331), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21335, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21335), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 7, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21332, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21332), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21336, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21336), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 6, 15, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21333, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21333), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21337, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21337), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 7, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -534,37 +535,37 @@ static void heartline_twister_rc_track_60_deg_up_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21394, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21394), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21398, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21398), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 6, 17, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21395, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21395), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21399, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21399), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 7, 18, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21396, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21396), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21400, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21400), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 6, 19, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21397, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21397), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21401, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21401), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 7, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -576,37 +577,37 @@ static void heartline_twister_rc_track_60_deg_up_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21338, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21338), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21342, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21342), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 6, 17, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21339, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21339), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21343, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21343), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 7, 18, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21340, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21340), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21344, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21344), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 6, 19, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21341, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21341), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21345, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21345), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 7, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -635,37 +636,37 @@ static void heartline_twister_rc_track_25_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21370, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21370), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21374, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21374), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 6, 5, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21371, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21371), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21375, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21375), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 7, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21372, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21372), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21376, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21376), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 6, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21373, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21373), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21377, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21377), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 7, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -677,37 +678,37 @@ static void heartline_twister_rc_track_25_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21314, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21314), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21318, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21318), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 6, 5, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21315, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21315), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21319, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21319), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 7, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21316, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21316), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21320, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21320), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 6, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21317, { 0, 0, height }, { 32, 20, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21317), { 0, 0, height }, { 32, 20, 2 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21321, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21321), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 wooden_a_supports_paint_setup(session, 7, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -785,38 +786,38 @@ static void heartline_twister_rc_track_heartline_transfer_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21306, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21306), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21310, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 23 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21310), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 23 });
                     wooden_a_supports_paint_setup(session, 6, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21307, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21307), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21311, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 23 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21311), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 23 });
                     wooden_a_supports_paint_setup(session, 7, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21308, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21308), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21312, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 23 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21312), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 23 });
                     wooden_a_supports_paint_setup(session, 6, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21309, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21309), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21313, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 23 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21313), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 23 });
                     wooden_a_supports_paint_setup(session, 7, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -836,62 +837,62 @@ static void heartline_twister_rc_track_heartline_transfer_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21314, { 0, 0, height + 8 }, { 32, 20, 2 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21314), { 0, 0, height + 8 },
+                        { 32, 20, 2 }, { 0, 6, height + 8 });
                     PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21308, { 0, 0, height + 16 }, { 32, 20, 2 },
-                        { 0, 6, height + 16 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21308), { 0, 0, height + 16 },
+                        { 32, 20, 2 }, { 0, 6, height + 16 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21318, { 0, 0, height + 8 }, { 32, 1, 34 },
-                        { 0, 27, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21318), { 0, 0, height + 8 },
+                        { 32, 1, 34 }, { 0, 27, height + 8 });
                     PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21312, { 0, 0, height + 16 }, { 32, 1, 34 },
-                        { 0, 27, height + 16 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21312), { 0, 0, height + 16 },
+                        { 32, 1, 34 }, { 0, 27, height + 16 });
                     wooden_a_supports_paint_setup(session, 6, 5, height + 8, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21315, { 0, 0, height + 8 }, { 32, 20, 2 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21315), { 0, 0, height + 8 },
+                        { 32, 20, 2 }, { 0, 6, height + 8 });
                     PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21309, { 0, 0, height + 16 }, { 32, 20, 2 },
-                        { 0, 6, height + 16 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21309), { 0, 0, height + 16 },
+                        { 32, 20, 2 }, { 0, 6, height + 16 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21319, { 0, 0, height + 8 }, { 32, 1, 34 },
-                        { 0, 27, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21319), { 0, 0, height + 8 },
+                        { 32, 1, 34 }, { 0, 27, height + 8 });
                     PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21313, { 0, 0, height + 16 }, { 32, 1, 34 },
-                        { 0, 27, height + 16 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21313), { 0, 0, height + 16 },
+                        { 32, 1, 34 }, { 0, 27, height + 16 });
                     wooden_a_supports_paint_setup(session, 7, 6, height + 8, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21316, { 0, 0, height + 8 }, { 32, 20, 2 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21316), { 0, 0, height + 8 },
+                        { 32, 20, 2 }, { 0, 6, height + 8 });
                     PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21306, { 0, 0, height + 16 }, { 32, 20, 2 },
-                        { 0, 6, height + 16 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21306), { 0, 0, height + 16 },
+                        { 32, 20, 2 }, { 0, 6, height + 16 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21320, { 0, 0, height + 8 }, { 32, 1, 34 },
-                        { 0, 27, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21320), { 0, 0, height + 8 },
+                        { 32, 1, 34 }, { 0, 27, height + 8 });
                     PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21310, { 0, 0, height + 16 }, { 32, 1, 34 },
-                        { 0, 27, height + 16 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21310), { 0, 0, height + 16 },
+                        { 32, 1, 34 }, { 0, 27, height + 16 });
                     wooden_a_supports_paint_setup(session, 6, 7, height + 8, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21317, { 0, 0, height + 8 }, { 32, 20, 2 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21317), { 0, 0, height + 8 },
+                        { 32, 20, 2 }, { 0, 6, height + 8 });
                     PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21307, { 0, 0, height + 16 }, { 32, 20, 2 },
-                        { 0, 6, height + 16 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21307), { 0, 0, height + 16 },
+                        { 32, 20, 2 }, { 0, 6, height + 16 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21321, { 0, 0, height + 8 }, { 32, 1, 34 },
-                        { 0, 27, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21321), { 0, 0, height + 8 },
+                        { 32, 1, 34 }, { 0, 27, height + 8 });
                     PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21311, { 0, 0, height + 16 }, { 32, 1, 34 },
-                        { 0, 27, height + 16 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21311), { 0, 0, height + 16 },
+                        { 32, 1, 34 }, { 0, 27, height + 16 });
                     wooden_a_supports_paint_setup(session, 7, 8, height + 8, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -903,38 +904,38 @@ static void heartline_twister_rc_track_heartline_transfer_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21298, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21298), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21302, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21302), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21299, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21299), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21303, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21303), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21300, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21300), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21304, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21304), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21301, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21301), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21305, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21305), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -946,35 +947,35 @@ static void heartline_twister_rc_track_heartline_transfer_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21316, { 0, 0, height - 8 }, { 32, 20, 2 },
-                        { 0, 6, height - 7 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21316), { 0, 0, height - 8 },
+                        { 32, 20, 2 }, { 0, 6, height - 7 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21320, { 0, 0, height - 8 }, { 32, 1, 34 },
-                        { 0, 27, height - 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21320), { 0, 0, height - 8 },
+                        { 32, 1, 34 }, { 0, 27, height - 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21317, { 0, 0, height - 8 }, { 32, 20, 2 },
-                        { 0, 6, height - 7 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21317), { 0, 0, height - 8 },
+                        { 32, 20, 2 }, { 0, 6, height - 7 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21321, { 0, 0, height - 8 }, { 32, 1, 34 },
-                        { 0, 27, height - 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21321), { 0, 0, height - 8 },
+                        { 32, 1, 34 }, { 0, 27, height - 8 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21314, { 0, 0, height - 8 }, { 32, 20, 2 },
-                        { 0, 6, height - 7 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21314), { 0, 0, height - 8 },
+                        { 32, 20, 2 }, { 0, 6, height - 7 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21318, { 0, 0, height - 8 }, { 32, 1, 34 },
-                        { 0, 27, height - 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21318), { 0, 0, height - 8 },
+                        { 32, 1, 34 }, { 0, 27, height - 8 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21315, { 0, 0, height - 8 }, { 32, 20, 2 },
-                        { 0, 6, height - 7 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21315), { 0, 0, height - 8 },
+                        { 32, 20, 2 }, { 0, 6, height - 7 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21319, { 0, 0, height - 8 }, { 32, 1, 34 },
-                        { 0, 27, height - 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21319), { 0, 0, height - 8 },
+                        { 32, 1, 34 }, { 0, 27, height - 8 });
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -1003,35 +1004,35 @@ static void heartline_twister_rc_track_heartline_transfer_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21316, { 0, 0, height - 8 }, { 32, 20, 2 },
-                        { 0, 6, height - 7 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21316), { 0, 0, height - 8 },
+                        { 32, 20, 2 }, { 0, 6, height - 7 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21320, { 0, 0, height - 8 }, { 32, 1, 34 },
-                        { 0, 27, height - 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21320), { 0, 0, height - 8 },
+                        { 32, 1, 34 }, { 0, 27, height - 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21317, { 0, 0, height - 8 }, { 32, 20, 2 },
-                        { 0, 6, height - 7 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21317), { 0, 0, height - 8 },
+                        { 32, 20, 2 }, { 0, 6, height - 7 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21321, { 0, 0, height - 8 }, { 32, 1, 34 },
-                        { 0, 27, height - 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21321), { 0, 0, height - 8 },
+                        { 32, 1, 34 }, { 0, 27, height - 8 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21314, { 0, 0, height - 8 }, { 32, 20, 2 },
-                        { 0, 6, height - 7 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21314), { 0, 0, height - 8 },
+                        { 32, 20, 2 }, { 0, 6, height - 7 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21318, { 0, 0, height - 8 }, { 32, 1, 34 },
-                        { 0, 27, height - 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21318), { 0, 0, height - 8 },
+                        { 32, 1, 34 }, { 0, 27, height - 8 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21315, { 0, 0, height - 8 }, { 32, 20, 2 },
-                        { 0, 6, height - 7 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21315), { 0, 0, height - 8 },
+                        { 32, 20, 2 }, { 0, 6, height - 7 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21319, { 0, 0, height - 8 }, { 32, 1, 34 },
-                        { 0, 27, height - 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21319), { 0, 0, height - 8 },
+                        { 32, 1, 34 }, { 0, 27, height - 8 });
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -1050,62 +1051,62 @@ static void heartline_twister_rc_track_heartline_transfer_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21314, { 0, 0, height + 8 }, { 32, 20, 2 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21314), { 0, 0, height + 8 },
+                        { 32, 20, 2 }, { 0, 6, height + 8 });
                     PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21308, { 0, 0, height + 16 }, { 32, 20, 2 },
-                        { 0, 6, height + 16 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21308), { 0, 0, height + 16 },
+                        { 32, 20, 2 }, { 0, 6, height + 16 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21318, { 0, 0, height + 8 }, { 32, 1, 34 },
-                        { 0, 27, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21318), { 0, 0, height + 8 },
+                        { 32, 1, 34 }, { 0, 27, height + 8 });
                     PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21312, { 0, 0, height + 16 }, { 32, 1, 34 },
-                        { 0, 27, height + 16 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21312), { 0, 0, height + 16 },
+                        { 32, 1, 34 }, { 0, 27, height + 16 });
                     wooden_a_supports_paint_setup(session, 6, 5, height + 8, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21315, { 0, 0, height + 8 }, { 32, 20, 2 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21315), { 0, 0, height + 8 },
+                        { 32, 20, 2 }, { 0, 6, height + 8 });
                     PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21309, { 0, 0, height + 16 }, { 32, 20, 2 },
-                        { 0, 6, height + 16 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21309), { 0, 0, height + 16 },
+                        { 32, 20, 2 }, { 0, 6, height + 16 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21319, { 0, 0, height + 8 }, { 32, 1, 34 },
-                        { 0, 27, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21319), { 0, 0, height + 8 },
+                        { 32, 1, 34 }, { 0, 27, height + 8 });
                     PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21313, { 0, 0, height + 16 }, { 32, 1, 34 },
-                        { 0, 27, height + 16 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21313), { 0, 0, height + 16 },
+                        { 32, 1, 34 }, { 0, 27, height + 16 });
                     wooden_a_supports_paint_setup(session, 7, 6, height + 8, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21316, { 0, 0, height + 8 }, { 32, 20, 2 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21316), { 0, 0, height + 8 },
+                        { 32, 20, 2 }, { 0, 6, height + 8 });
                     PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21306, { 0, 0, height + 16 }, { 32, 20, 2 },
-                        { 0, 6, height + 16 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21306), { 0, 0, height + 16 },
+                        { 32, 20, 2 }, { 0, 6, height + 16 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21320, { 0, 0, height + 8 }, { 32, 1, 34 },
-                        { 0, 27, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21320), { 0, 0, height + 8 },
+                        { 32, 1, 34 }, { 0, 27, height + 8 });
                     PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21310, { 0, 0, height + 16 }, { 32, 1, 34 },
-                        { 0, 27, height + 16 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21310), { 0, 0, height + 16 },
+                        { 32, 1, 34 }, { 0, 27, height + 16 });
                     wooden_a_supports_paint_setup(session, 6, 7, height + 8, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21317, { 0, 0, height + 8 }, { 32, 20, 2 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21317), { 0, 0, height + 8 },
+                        { 32, 20, 2 }, { 0, 6, height + 8 });
                     PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21307, { 0, 0, height + 16 }, { 32, 20, 2 },
-                        { 0, 6, height + 16 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21307), { 0, 0, height + 16 },
+                        { 32, 20, 2 }, { 0, 6, height + 16 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21321, { 0, 0, height + 8 }, { 32, 1, 34 },
-                        { 0, 27, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21321), { 0, 0, height + 8 },
+                        { 32, 1, 34 }, { 0, 27, height + 8 });
                     PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21311, { 0, 0, height + 16 }, { 32, 1, 34 },
-                        { 0, 27, height + 16 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21311), { 0, 0, height + 16 },
+                        { 32, 1, 34 }, { 0, 27, height + 16 });
                     wooden_a_supports_paint_setup(session, 7, 8, height + 8, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1117,38 +1118,38 @@ static void heartline_twister_rc_track_heartline_transfer_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21298, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21298), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21302, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21302), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21299, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21299), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21303, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21303), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21300, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21300), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21304, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21304), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21301, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21301), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21305, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21305), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1160,38 +1161,38 @@ static void heartline_twister_rc_track_heartline_transfer_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21306, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21306), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21310, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 23 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21310), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 23 });
                     wooden_a_supports_paint_setup(session, 6, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21307, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21307), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21311, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 23 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21311), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 23 });
                     wooden_a_supports_paint_setup(session, 7, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21308, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21308), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21312, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 23 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21312), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 23 });
                     wooden_a_supports_paint_setup(session, 6, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21309, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21309), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21313, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 23 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21313), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 23 });
                     wooden_a_supports_paint_setup(session, 7, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1221,38 +1222,38 @@ static void heartline_twister_rc_track_left_heartline_roll(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21410, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21410), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21422, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21422), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21413, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21413), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21425, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21425), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21416, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21416), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21428, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21428), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21419, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21419), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21431, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21431), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1265,38 +1266,38 @@ static void heartline_twister_rc_track_left_heartline_roll(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21411, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21411), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21423, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21423), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21414, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21414), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21426, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21426), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21417, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21417), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21429, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21429), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21420, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21420), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21432, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21432), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1308,38 +1309,38 @@ static void heartline_twister_rc_track_left_heartline_roll(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21412, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21412), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21424, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21424), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21415, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21415), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21427, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21427), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21418, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21418), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21430, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21430), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21421, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21421), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21433, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21433), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1351,38 +1352,38 @@ static void heartline_twister_rc_track_left_heartline_roll(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21418, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21418), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21430, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21430), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21421, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21421), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21433, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21433), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21412, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21412), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21424, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21424), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21415, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21415), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21427, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21427), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1394,38 +1395,38 @@ static void heartline_twister_rc_track_left_heartline_roll(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21417, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21417), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21429, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21429), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21420, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21420), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21432, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21432), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21411, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21411), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21423, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21423), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21414, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21414), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21426, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21426), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1437,38 +1438,38 @@ static void heartline_twister_rc_track_left_heartline_roll(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21416, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21416), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21428, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21428), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21419, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21419), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21431, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21431), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21410, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21410), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21422, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21422), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21413, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21413), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21425, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21425), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1491,38 +1492,38 @@ static void heartline_twister_rc_track_right_heartline_roll(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21434, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21434), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21446, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21446), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21437, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21437), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21449, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21449), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21440, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21440), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21452, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21452), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21443, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21443), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21455, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21455), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1535,38 +1536,38 @@ static void heartline_twister_rc_track_right_heartline_roll(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21435, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21435), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21447, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21447), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21438, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21438), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21450, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21450), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21441, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21441), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21453, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21453), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21444, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21444), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21456, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21456), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1578,38 +1579,38 @@ static void heartline_twister_rc_track_right_heartline_roll(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21436, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21436), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21448, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21448), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21439, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21439), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21451, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21451), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21442, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21442), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21454, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21454), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21445, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21445), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21457, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21457), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1621,38 +1622,38 @@ static void heartline_twister_rc_track_right_heartline_roll(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21442, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21442), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21454, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21454), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21445, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21445), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21457, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21457), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21436, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21436), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21448, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21448), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21439, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21439), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21451, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21451), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1664,38 +1665,38 @@ static void heartline_twister_rc_track_right_heartline_roll(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21441, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21441), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21453, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21453), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21444, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21444), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21456, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21456), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21435, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21435), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21447, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21447), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21438, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21438), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21450, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21450), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1707,38 +1708,38 @@ static void heartline_twister_rc_track_right_heartline_roll(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21440, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21440), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21452, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21452), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21443, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21443), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21455, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21455), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21434, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21434), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21446, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21446), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21437, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21437), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21449, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21449), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }

--- a/src/openrct2/ride/coaster/HybridCoaster.cpp
+++ b/src/openrct2/ride/coaster/HybridCoaster.cpp
@@ -26,13 +26,12 @@
 
 namespace HybridRC
 {
-    static uint32_t GetTrackColour(paint_session& session)
+    static ImageId GetTrackColour(paint_session& session)
     {
-        if (session.TrackColours[SCHEME_TRACK] == 0x21600000)
-            return 0x21600000; // TODO dirty hack
+        if (session.TrackColours[SCHEME_TRACK].ToUInt32() == 0x21600000)
+            return session.TrackColours[SCHEME_TRACK]; // TODO dirty hack
         else
-            return (session.TrackColours[SCHEME_TRACK] & ~0x1F000000)
-                | ((session.TrackColours[SCHEME_SUPPORTS] & 0xF80000) << 5);
+            return (session.TrackColours[SCHEME_TRACK].WithSecondary(session.TrackColours[SCHEME_SUPPORTS].GetPrimary()));
     }
 
     static void TrackFlat(
@@ -42,14 +41,14 @@ namespace HybridRC
         if (trackElement.HasChain())
         {
             PaintAddImageAsParentRotated(
-                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_FLAT + direction), { 0, 0, height },
-                { 32, 20, 3 }, { 0, 6, height });
+                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_FLAT + direction),
+                { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
         }
         else
         {
             PaintAddImageAsParentRotated(
-                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT + (direction & 1)), { 0, 0, height },
-                { 32, 20, 3 }, { 0, 6, height });
+                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_FLAT + (direction & 1)),
+                { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
         }
         wooden_a_supports_paint_setup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
         paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -71,13 +70,13 @@ namespace HybridRC
         if (trackElement.GetTrackType() == TrackElemType::EndStation)
         {
             PaintAddImageAsParentRotated(
-                session, direction, imageIds[direction][1] | GetTrackColour(session), { 0, 0, height }, { 32, 20, 1 },
+                session, direction, GetTrackColour(session).WithIndex(imageIds[direction][1]), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height + 3 });
         }
         else
         {
             PaintAddImageAsParentRotated(
-                session, direction, imageIds[direction][0] | GetTrackColour(session), { 0, 0, height }, { 32, 20, 1 },
+                session, direction, GetTrackColour(session).WithIndex(imageIds[direction][0]), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height + 3 });
         }
 
@@ -97,14 +96,14 @@ namespace HybridRC
         if (trackElement.HasChain())
         {
             PaintAddImageAsParentRotated(
-                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_GENTLE + direction + 8),
+                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_GENTLE + direction + 8),
                 { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
         }
         else
         {
             PaintAddImageAsParentRotated(
-                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE + direction + 8), { 0, 0, height },
-                { 32, 20, 2 }, { 0, 6, height + 3 });
+                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE + direction + 8),
+                { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
         }
         wooden_a_supports_paint_setup(session, direction & 1, 9 + direction, height, session.TrackColours[SCHEME_SUPPORTS]);
         if (direction == 0 || direction == 3)
@@ -151,7 +150,7 @@ namespace HybridRC
         };
 
         auto* ps = PaintAddImageAsParentRotated(
-            session, direction, GetTrackColour(session) | imageIds[trackElement.HasChain() ? 0 : 1][direction],
+            session, direction, GetTrackColour(session).WithIndex(imageIds[trackElement.HasChain() ? 0 : 1][direction]),
             { 0, 0, height }, { boundBoxLengths[direction].x, boundBoxLengths[direction].y, boundBoxLengths[direction].z },
             { boundBoxOffsets[direction].x, boundBoxOffsets[direction].y, boundBoxOffsets[direction].z });
 
@@ -180,13 +179,13 @@ namespace HybridRC
         if (trackElement.HasChain())
         {
             PaintAddImageAsParentRotated(
-                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_GENTLE + direction), { 0, 0, height },
-                { 32, 20, 3 }, { 0, 6, height });
+                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_GENTLE + direction),
+                { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
         }
         else
         {
             PaintAddImageAsParentRotated(
-                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE + direction), { 0, 0, height },
+                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE + direction), { 0, 0, height },
                 { 32, 20, 3 }, { 0, 6, height });
         }
         wooden_a_supports_paint_setup(session, direction & 1, 1 + direction, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -212,29 +211,29 @@ namespace HybridRC
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP + 0), { 0, 0, height },
-                        { 32, 20, 3 }, { 0, 6, height });
+                        session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_STEEP + 0),
+                        { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
-                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP + 1), { 0, 0, height },
-                        { 32, 20, 3 }, { 0, 3, height + 3 });
+                        session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_STEEP + 1),
+                        { 0, 0, height }, { 32, 20, 3 }, { 0, 3, height + 3 });
                     PaintAddImageAsParentRotated(
-                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP + 2), { 0, 0, height },
-                        { 32, 2, 43 }, { 0, 28, height });
+                        session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_STEEP + 2),
+                        { 0, 0, height }, { 32, 2, 43 }, { 0, 28, height });
                     break;
                 case 2:
                     session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
-                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP + 3), { 0, 0, height },
-                        { 32, 20, 3 }, { 0, 3, height + 3 });
+                        session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_STEEP + 3),
+                        { 0, 0, height }, { 32, 20, 3 }, { 0, 3, height + 3 });
                     PaintAddImageAsParentRotated(
-                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP + 4), { 0, 0, height },
-                        { 32, 2, 43 }, { 0, 28, height });
+                        session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_STEEP + 4),
+                        { 0, 0, height }, { 32, 2, 43 }, { 0, 28, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP + 5), { 0, 0, height },
-                        { 32, 20, 3 }, { 0, 6, height });
+                        session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_STEEP + 5),
+                        { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
         }
@@ -244,28 +243,28 @@ namespace HybridRC
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP + 0), { 0, 0, height },
+                        session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP + 0), { 0, 0, height },
                         { 32, 20, 3 }, { 0, 6, height + 2 });
                     break;
                 case 1:
                     session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
-                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP + 1), { 0, 0, height },
+                        session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP + 1), { 0, 0, height },
                         { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP + 2), { 0, 0, height },
+                        session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP + 2), { 0, 0, height },
                         { 32, 2, 43 }, { 0, 28, height });
                     break;
                 case 2:
                     session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
-                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP + 3), { 0, 0, height },
+                        session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP + 3), { 0, 0, height },
                         { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP + 4), { 0, 0, height },
+                        session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP + 4), { 0, 0, height },
                         { 32, 2, 43 }, { 0, 28, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP + 5), { 0, 0, height },
+                        session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP + 5), { 0, 0, height },
                         { 32, 20, 3 }, { 0, 6, height + 2 });
                     break;
             }
@@ -293,29 +292,29 @@ namespace HybridRC
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP + 6), { 0, 0, height },
-                        { 32, 20, 3 }, { 0, 6, height });
+                        session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_STEEP + 6),
+                        { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
-                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP + 7), { 0, 0, height },
-                        { 32, 20, 3 }, { 0, 6, height });
+                        session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_STEEP + 7),
+                        { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP + 8), { 0, 0, height },
-                        { 32, 1, 66 }, { 0, 27, height });
+                        session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_STEEP + 8),
+                        { 0, 0, height }, { 32, 1, 66 }, { 0, 27, height });
                     break;
                 case 2:
                     session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
-                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP + 9), { 0, 0, height },
-                        { 32, 20, 3 }, { 0, 6, height });
+                        session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_STEEP + 9),
+                        { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP + 10), { 0, 0, height },
-                        { 32, 1, 66 }, { 0, 27, height });
+                        session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_STEEP + 10),
+                        { 0, 0, height }, { 32, 1, 66 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP + 11), { 0, 0, height },
-                        { 32, 20, 3 }, { 0, 6, height });
+                        session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_STEEP + 11),
+                        { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
         }
@@ -325,29 +324,29 @@ namespace HybridRC
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP + 6), { 0, 0, height },
+                        session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP + 6), { 0, 0, height },
                         { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
-                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP + 7), { 0, 0, height },
+                        session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP + 7), { 0, 0, height },
                         { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP + 8), { 0, 0, height },
+                        session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP + 8), { 0, 0, height },
                         { 32, 1, 66 }, { 0, 27, height });
                     break;
                 case 2:
                     session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
-                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP + 9), { 0, 0, height },
+                        session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP + 9), { 0, 0, height },
                         { 32, 20, 3 }, { 0, 6, height });
 
                     PaintAddImageAsParentRotated(
-                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP + 10), { 0, 0, height },
+                        session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP + 10), { 0, 0, height },
                         { 32, 1, 66 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP + 11), { 0, 0, height },
+                        session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP + 11), { 0, 0, height },
                         { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
@@ -372,14 +371,14 @@ namespace HybridRC
         if (trackElement.HasChain())
         {
             PaintAddImageAsParentRotated(
-                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_GENTLE + direction + 4),
+                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_GENTLE + direction + 4),
                 { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
         }
         else
         {
             PaintAddImageAsParentRotated(
-                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE + direction + 4), { 0, 0, height },
-                { 32, 20, 2 }, { 0, 6, height + 3 });
+                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE + direction + 4),
+                { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
         }
         wooden_a_supports_paint_setup(session, direction & 1, 5 + direction, height, session.TrackColours[SCHEME_SUPPORTS]);
         if (direction == 0 || direction == 3)
@@ -462,7 +461,7 @@ namespace HybridRC
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | imageIds[direction], { 0, 0, height },
+                    session, direction, GetTrackColour(session).WithIndex(imageIds[direction]), { 0, 0, height },
                     { boundBoxLengths[direction].x, boundBoxLengths[direction].y, boundBoxLengths[direction].z },
                     { boundBoxOffsets[direction].x, boundBoxOffsets[direction].y, boundBoxOffsets[direction].z });
                 paint_util_set_vertical_tunnel(session, height + 32);
@@ -508,7 +507,7 @@ namespace HybridRC
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | imageIds[direction], { 0, 0, height },
+                    session, direction, GetTrackColour(session).WithIndex(imageIds[direction]), { 0, 0, height },
                     { boundBoxLengths[direction].x, boundBoxLengths[direction].y, boundBoxLengths[direction].z },
                     { boundBoxOffsets[direction].x, boundBoxOffsets[direction].y, boundBoxOffsets[direction].z });
                 wooden_a_supports_paint_setup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -556,7 +555,7 @@ namespace HybridRC
         };
 
         PaintAddImageAsParentRotated(
-            session, direction, GetTrackColour(session) | imageIds[direction], { 0, 0, height },
+            session, direction, GetTrackColour(session).WithIndex(imageIds[direction]), { 0, 0, height },
             { boundBoxLengths[direction].x, boundBoxLengths[direction].y, boundBoxLengths[direction].z },
             { boundBoxOffsets[direction].x, boundBoxOffsets[direction].y, boundBoxOffsets[direction].z });
         switch (direction)
@@ -583,23 +582,23 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 6), { 0, 0, height },
-                            { 2, 20, 31 }, { 24, 6, height + 8 });
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_VERTICAL + 6),
+                            { 0, 0, height }, { 2, 20, 31 }, { 24, 6, height + 8 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 7), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height + 8 });
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_VERTICAL + 7),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height + 8 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 4), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height + 8 });
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_VERTICAL + 4),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height + 8 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 5), { 0, 0, height },
-                            { 2, 20, 31 }, { 24, 6, height + 8 });
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_VERTICAL + 5),
+                            { 0, 0, height }, { 2, 20, 31 }, { 24, 6, height + 8 });
                         break;
                 }
                 if (direction == 0 || direction == 3)
@@ -625,25 +624,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE + 0),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_CURVE + 0),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE + 3),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_CURVE + 3),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE + 6),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_CURVE + 6),
                             { 0, 0, height }, { 32, 32, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE + 9),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_CURVE + 9),
                             { 0, 0, height }, { 32, 32, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -663,25 +662,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE + 1),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_CURVE + 1),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE + 4),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_CURVE + 4),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 0, height });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE + 7),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_CURVE + 7),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE + 10),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_CURVE + 10),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 16, height });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -696,25 +695,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE + 2),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_CURVE + 2),
                             { 0, 0, height }, { 32, 32, 3 }, { 6, 0, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE + 5),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_CURVE + 5),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE + 8),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_CURVE + 8),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE + 11),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_CURVE + 11),
                             { 0, 0, height }, { 32, 32, 3 }, { 6, 0, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -753,25 +752,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 0),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 0),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 5),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 5),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 10),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 10),
                             { 0, 0, height }, { 32, 32, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 15),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 15),
                             { 0, 0, height }, { 32, 32, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -793,25 +792,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 1),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 1),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 0, height });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 6),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 6),
                             { 0, 0, height }, { 36, 16, 3 }, { 0, 4, height });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 11),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 11),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 16),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 16),
                             { 0, 0, height }, { 32, 14, 3 }, { 0, 18, height });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -828,25 +827,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 2),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 2),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 7),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 7),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 16, height });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 12),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 12),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 17),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 17),
                             { 0, 0, height }, { 33, 33, 3 }, { 0, 0, height });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -869,25 +868,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 3),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 3),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 8),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 8),
                             { 0, 0, height }, { 16, 36, 3 }, { 4, 0, height });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 13),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 13),
                             { 0, 0, height }, { 16, 32, 3 }, { 0, 0, height });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 18),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 18),
                             { 0, 0, height }, { 14, 32, 3 }, { 18, 0, height });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -904,25 +903,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 4),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 4),
                             { 0, 0, height }, { 32, 32, 3 }, { 6, 0, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 9),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 9),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 14),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 14),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 19),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 19),
                             { 0, 0, height }, { 32, 32, 3 }, { 6, 0, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -961,25 +960,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 0),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE + 0),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 4),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE + 4),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 8),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE + 8),
                             { 0, 0, height }, { 32, 32, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 12),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE + 12),
                             { 0, 0, height }, { 32, 32, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -996,25 +995,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 1),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE + 1),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 0, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 5),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE + 5),
                             { 0, 0, height }, { 34, 16, 3 }, { 0, 0, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 9),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE + 9),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 13),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE + 13),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -1027,25 +1026,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 2),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE + 2),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 6),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE + 6),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 10),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE + 10),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 14),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE + 14),
                             { 0, 0, height }, { 34, 16, 3 }, { 0, 0, height });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -1077,22 +1076,22 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 3),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE + 3),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 7),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE + 7),
                             { 0, 0, height }, { 16, 18, 3 }, { 0, 16 + 8, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 11),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE + 11),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 15),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE + 15),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         break;
                 }
@@ -1113,25 +1112,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 16),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE + 16),
                             { 0, 0, height }, { 32, 32, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 20),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE + 20),
                             { 0, 0, height }, { 32, 32, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 24),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE + 24),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 28),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE + 28),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -1148,25 +1147,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 17),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE + 17),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 21),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE + 21),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 25),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE + 25),
                             { 0, 0, height }, { 34, 16, 3 }, { 0, 0, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 29),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE + 29),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 0, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -1179,25 +1178,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 18),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE + 18),
                             { 0, 0, height }, { 34, 16, 3 }, { 0, 0, height });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 22),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE + 22),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 26),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE + 26),
                             { 0, 0, height }, { 28, 28, 3 }, { 4, 4, height });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 30),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE + 30),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -1229,22 +1228,22 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 19),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE + 19),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 23),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE + 23),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 27),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE + 27),
                             { 0, 0, height }, { 16, 18, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 31),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE + 31),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 16, height });
                         break;
                 }
@@ -1283,7 +1282,8 @@ namespace HybridRC
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_FLAT_DIAGONAL + 3),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_FLAT_DIAGONAL + 3),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1294,7 +1294,7 @@ namespace HybridRC
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT_DIAGONAL + 3),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_FLAT_DIAGONAL + 3),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1311,7 +1311,8 @@ namespace HybridRC
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_FLAT_DIAGONAL + 0),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_FLAT_DIAGONAL + 0),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                             break;
@@ -1323,7 +1324,7 @@ namespace HybridRC
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT_DIAGONAL + 0),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_FLAT_DIAGONAL + 0),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1353,7 +1354,8 @@ namespace HybridRC
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_FLAT_DIAGONAL + 2),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_FLAT_DIAGONAL + 2),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1364,7 +1366,7 @@ namespace HybridRC
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT_DIAGONAL + 2),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_FLAT_DIAGONAL + 2),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1394,7 +1396,8 @@ namespace HybridRC
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_FLAT_DIAGONAL + 1),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_FLAT_DIAGONAL + 1),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1405,7 +1408,7 @@ namespace HybridRC
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT_DIAGONAL + 1),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_FLAT_DIAGONAL + 1),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1429,7 +1432,8 @@ namespace HybridRC
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 11),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 11),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1440,7 +1444,7 @@ namespace HybridRC
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 11),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 11),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1455,7 +1459,8 @@ namespace HybridRC
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 8),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 8),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1466,7 +1471,7 @@ namespace HybridRC
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 8),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 8),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1496,7 +1501,8 @@ namespace HybridRC
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 10),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 10),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1507,7 +1513,7 @@ namespace HybridRC
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 10),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 10),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1537,7 +1543,8 @@ namespace HybridRC
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 9),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 9),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1548,7 +1555,7 @@ namespace HybridRC
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 1),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 1),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1572,7 +1579,8 @@ namespace HybridRC
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 7),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 7),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1583,7 +1591,7 @@ namespace HybridRC
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 7),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 7),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1598,7 +1606,8 @@ namespace HybridRC
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 4),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 4),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1609,7 +1618,7 @@ namespace HybridRC
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 4),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 4),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1639,7 +1648,8 @@ namespace HybridRC
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 6),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 6),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1650,7 +1660,7 @@ namespace HybridRC
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 6),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 6),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1680,7 +1690,8 @@ namespace HybridRC
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 5),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 5),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1691,7 +1702,7 @@ namespace HybridRC
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 5),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 5),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1715,7 +1726,8 @@ namespace HybridRC
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 3),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 3),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1726,7 +1738,7 @@ namespace HybridRC
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 3),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 3),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1741,7 +1753,8 @@ namespace HybridRC
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 0),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 0),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1752,7 +1765,7 @@ namespace HybridRC
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 0),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 0),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1782,7 +1795,8 @@ namespace HybridRC
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 2),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 2),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1793,7 +1807,7 @@ namespace HybridRC
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 2),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 2),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1823,7 +1837,8 @@ namespace HybridRC
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 1),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 1),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1834,7 +1849,7 @@ namespace HybridRC
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 1),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 1),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1858,7 +1873,8 @@ namespace HybridRC
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 9),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 9),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1869,7 +1885,7 @@ namespace HybridRC
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 9),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 9),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1884,7 +1900,8 @@ namespace HybridRC
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 10),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 10),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1895,7 +1912,7 @@ namespace HybridRC
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 10),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 10),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1925,7 +1942,8 @@ namespace HybridRC
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 8),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 8),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1936,7 +1954,7 @@ namespace HybridRC
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 8),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 8),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1966,7 +1984,8 @@ namespace HybridRC
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 11),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 11),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1977,7 +1996,7 @@ namespace HybridRC
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 11),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 11),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2001,7 +2020,8 @@ namespace HybridRC
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 5),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 5),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2012,7 +2032,7 @@ namespace HybridRC
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 5),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 5),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2026,7 +2046,8 @@ namespace HybridRC
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 6),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 6),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2037,7 +2058,7 @@ namespace HybridRC
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 6),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 6),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2066,7 +2087,8 @@ namespace HybridRC
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 4),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 4),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2077,7 +2099,7 @@ namespace HybridRC
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 4),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 4),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2106,7 +2128,8 @@ namespace HybridRC
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 7),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 7),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2117,7 +2140,7 @@ namespace HybridRC
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 7),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 7),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2142,7 +2165,8 @@ namespace HybridRC
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 1),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 1),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2153,7 +2177,7 @@ namespace HybridRC
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 1),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 1),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2168,7 +2192,8 @@ namespace HybridRC
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 2),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 2),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2179,7 +2204,7 @@ namespace HybridRC
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 2),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 2),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2209,7 +2234,8 @@ namespace HybridRC
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 0),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 0),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2220,7 +2246,7 @@ namespace HybridRC
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 0),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 0),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2250,7 +2276,8 @@ namespace HybridRC
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 3),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_GENTLE_DIAGONAL + 3),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2261,7 +2288,7 @@ namespace HybridRC
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 3),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_DIAGONAL + 3),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2285,7 +2312,8 @@ namespace HybridRC
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 11),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 11),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2296,7 +2324,7 @@ namespace HybridRC
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 11),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 11),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2311,7 +2339,8 @@ namespace HybridRC
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 8),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 8),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2322,7 +2351,7 @@ namespace HybridRC
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 8),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 8),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2352,7 +2381,8 @@ namespace HybridRC
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 10),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 10),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2363,7 +2393,7 @@ namespace HybridRC
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 10),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 10),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2393,7 +2423,8 @@ namespace HybridRC
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 9),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 9),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2404,7 +2435,7 @@ namespace HybridRC
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 9),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 9),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2428,7 +2459,8 @@ namespace HybridRC
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 3),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 3),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2439,7 +2471,7 @@ namespace HybridRC
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 3),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 3),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2454,7 +2486,8 @@ namespace HybridRC
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 0),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 0),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2465,7 +2498,7 @@ namespace HybridRC
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 0),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 0),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2495,7 +2528,8 @@ namespace HybridRC
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 2),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 2),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2506,7 +2540,7 @@ namespace HybridRC
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 2),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 2),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2536,7 +2570,8 @@ namespace HybridRC
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 1),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 1),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2547,7 +2582,7 @@ namespace HybridRC
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 1),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 1),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2571,7 +2606,8 @@ namespace HybridRC
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 7),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 7),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2582,7 +2618,7 @@ namespace HybridRC
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 7),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 7),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2597,7 +2633,8 @@ namespace HybridRC
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 4),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 4),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2608,7 +2645,7 @@ namespace HybridRC
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 4),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 4),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2638,7 +2675,8 @@ namespace HybridRC
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 6),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 6),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2649,7 +2687,7 @@ namespace HybridRC
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 6),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 6),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2679,7 +2717,8 @@ namespace HybridRC
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 5),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 5),
                                 { -16, -16, height }, { 16, 16, 3 }, { 0, 0, height });
                             break;
                     }
@@ -2690,7 +2729,7 @@ namespace HybridRC
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 5),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 5),
                                 { -16, -16, height }, { 16, 16, 3 }, { 0, 0, height });
                             break;
                     }
@@ -2714,7 +2753,8 @@ namespace HybridRC
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 9),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 9),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2725,7 +2765,7 @@ namespace HybridRC
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 9),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 9),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2740,7 +2780,8 @@ namespace HybridRC
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 10),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 10),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2751,7 +2792,7 @@ namespace HybridRC
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 10),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 10),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2781,7 +2822,8 @@ namespace HybridRC
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 8),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 8),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2792,7 +2834,7 @@ namespace HybridRC
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 8),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 8),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2822,7 +2864,8 @@ namespace HybridRC
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 11),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 11),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2833,7 +2876,7 @@ namespace HybridRC
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 11),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 11),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2857,7 +2900,8 @@ namespace HybridRC
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 5),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 5),
                                 { -16, -16, height }, { 16, 16, 3 }, { 0, 0, height });
                             break;
                     }
@@ -2868,7 +2912,7 @@ namespace HybridRC
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 5),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 5),
                                 { -16, -16, height }, { 16, 16, 3 }, { 0, 0, height });
                             break;
                     }
@@ -2883,7 +2927,8 @@ namespace HybridRC
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 6),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 6),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2894,7 +2939,7 @@ namespace HybridRC
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 6),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 6),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2924,7 +2969,8 @@ namespace HybridRC
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 4),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 4),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2935,7 +2981,7 @@ namespace HybridRC
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 4),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 4),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2965,7 +3011,8 @@ namespace HybridRC
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 7),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 7),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2976,7 +3023,7 @@ namespace HybridRC
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 7),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 7),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -3000,7 +3047,8 @@ namespace HybridRC
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 1),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 1),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -3011,7 +3059,7 @@ namespace HybridRC
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 1),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 1),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -3026,7 +3074,8 @@ namespace HybridRC
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 2),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 2),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -3037,7 +3086,7 @@ namespace HybridRC
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 2),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 2),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -3067,7 +3116,8 @@ namespace HybridRC
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 0),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 0),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -3078,7 +3128,7 @@ namespace HybridRC
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 0),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 0),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -3108,7 +3158,8 @@ namespace HybridRC
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 3),
+                                session, direction,
+                                GetTrackColour(session).WithIndex(SPR_G2_HYBRID_LIFT_TRACK_STEEP_DIAGONAL + 3),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -3119,7 +3170,7 @@ namespace HybridRC
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 3),
+                                session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP_DIAGONAL + 3),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -3138,29 +3189,29 @@ namespace HybridRC
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 0), { 0, 0, height },
-                    { 32, 20, 3 }, { 0, 6, height });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 0),
+                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 1), { 0, 0, height },
-                    { 32, 1, 26 }, { 0, 27, height });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 1),
+                    { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 2), { 0, 0, height },
-                    { 32, 20, 3 }, { 0, 6, height });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 2),
+                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 3), { 0, 0, height },
-                    { 32, 1, 26 }, { 0, 27, height });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 3),
+                    { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 4), { 0, 0, height },
-                    { 32, 20, 3 }, { 0, 6, height });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 4),
+                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 5), { 0, 0, height },
-                    { 32, 20, 3 }, { 0, 6, height });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 5),
+                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
         }
         wooden_a_supports_paint_setup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3177,29 +3228,29 @@ namespace HybridRC
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 6), { 0, 0, height },
-                    { 32, 20, 3 }, { 0, 6, height });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 6),
+                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 7), { 0, 0, height },
-                    { 32, 20, 3 }, { 0, 6, height });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 7),
+                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 8), { 0, 0, height },
-                    { 32, 20, 3 }, { 0, 6, height });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 8),
+                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 9), { 0, 0, height },
-                    { 32, 1, 26 }, { 0, 27, height });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 9),
+                    { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 10), { 0, 0, height },
-                    { 32, 20, 3 }, { 0, 6, height });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 10),
+                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 11), { 0, 0, height },
-                    { 32, 1, 26 }, { 0, 27, height });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 11),
+                    { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                 break;
         }
         wooden_a_supports_paint_setup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3230,29 +3281,29 @@ namespace HybridRC
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 12), { 0, 0, height },
-                    { 32, 20, 3 }, { 0, 6, height });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 12),
+                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 13), { 0, 0, height },
-                    { 32, 1, 34 }, { 0, 27, height });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 13),
+                    { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 14), { 0, 0, height },
-                    { 32, 20, 3 }, { 0, 6, height });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 14),
+                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 15), { 0, 0, height },
-                    { 32, 1, 34 }, { 0, 27, height });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 15),
+                    { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 16), { 0, 0, height },
-                    { 32, 20, 3 }, { 0, 6, height });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 16),
+                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 17), { 0, 0, height },
-                    { 32, 20, 3 }, { 0, 6, height });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 17),
+                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
         }
         wooden_a_supports_paint_setup(session, direction & 1, 1 + direction, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3276,29 +3327,29 @@ namespace HybridRC
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 18), { 0, 0, height },
-                    { 32, 20, 3 }, { 0, 6, height });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 18),
+                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 19), { 0, 0, height },
-                    { 32, 20, 3 }, { 0, 6, height });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 19),
+                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 20), { 0, 0, height },
-                    { 32, 20, 3 }, { 0, 6, height });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 20),
+                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 21), { 0, 0, height },
-                    { 32, 1, 34 }, { 0, 27, height });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 21),
+                    { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 22), { 0, 0, height },
-                    { 32, 20, 3 }, { 0, 6, height });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 22),
+                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 23), { 0, 0, height },
-                    { 32, 1, 34 }, { 0, 27, height });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 23),
+                    { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
         }
         wooden_a_supports_paint_setup(session, direction & 1, 1 + direction, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3322,29 +3373,29 @@ namespace HybridRC
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 24), { 0, 0, height },
-                    { 32, 20, 2 }, { 0, 6, height + 3 });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 24),
+                    { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 25), { 0, 0, height },
-                    { 32, 1, 34 }, { 0, 27, height });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 25),
+                    { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 26), { 0, 0, height },
-                    { 32, 20, 2 }, { 0, 6, height + 3 });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 26),
+                    { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 27), { 0, 0, height },
-                    { 32, 1, 34 }, { 0, 27, height });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 27),
+                    { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 28), { 0, 0, height },
-                    { 32, 20, 2 }, { 0, 6, height + 3 });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 28),
+                    { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 29), { 0, 0, height },
-                    { 32, 20, 2 }, { 0, 6, height + 3 });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 29),
+                    { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 break;
         }
         wooden_a_supports_paint_setup(session, direction & 1, 5 + direction, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3368,29 +3419,29 @@ namespace HybridRC
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 30), { 0, 0, height },
-                    { 32, 20, 2 }, { 0, 6, height + 3 });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 30),
+                    { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 31), { 0, 0, height },
-                    { 32, 20, 2 }, { 0, 6, height + 3 });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 31),
+                    { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 32), { 0, 0, height },
-                    { 32, 20, 2 }, { 0, 6, height + 3 });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 32),
+                    { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 33), { 0, 0, height },
-                    { 32, 1, 34 }, { 0, 27, height });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 33),
+                    { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 34), { 0, 0, height },
-                    { 32, 20, 2 }, { 0, 6, height + 3 });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 34),
+                    { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 35), { 0, 0, height },
-                    { 32, 1, 34 }, { 0, 27, height });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 35),
+                    { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
         }
         wooden_a_supports_paint_setup(session, direction & 1, 5 + direction, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3442,29 +3493,29 @@ namespace HybridRC
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 36), { 0, 0, height },
-                    { 32, 20, 3 }, { 0, 6, height });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 36),
+                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 37), { 0, 0, height },
-                    { 32, 1, 26 }, { 0, 27, height });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 37),
+                    { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 38), { 0, 0, height },
-                    { 32, 20, 3 }, { 0, 6, height });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 38),
+                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 39), { 0, 0, height },
-                    { 32, 1, 26 }, { 0, 27, height });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 39),
+                    { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 40), { 0, 0, height },
-                    { 32, 20, 3 }, { 0, 6, height });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 40),
+                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 41), { 0, 0, height },
-                    { 32, 20, 3 }, { 0, 6, height });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION + 41),
+                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
         }
         wooden_a_supports_paint_setup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3491,7 +3542,8 @@ namespace HybridRC
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 4),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 4),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -3503,10 +3555,12 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 0),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 0),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 1),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 1),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 28 });
                         break;
                 }
@@ -3533,7 +3587,8 @@ namespace HybridRC
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 3),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 3),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -3560,7 +3615,8 @@ namespace HybridRC
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 2),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 2),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -3581,7 +3637,8 @@ namespace HybridRC
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 9),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 9),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -3593,7 +3650,8 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 5),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 5),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -3620,10 +3678,12 @@ namespace HybridRC
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 7),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 7),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 8),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 8),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 28 });
                         break;
                 }
@@ -3650,7 +3710,8 @@ namespace HybridRC
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 6),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 6),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -3671,7 +3732,8 @@ namespace HybridRC
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 6),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 6),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -3683,10 +3745,12 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 7),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 7),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 8),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 8),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 28 });
                         break;
                 }
@@ -3713,7 +3777,8 @@ namespace HybridRC
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 5),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 5),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -3740,7 +3805,8 @@ namespace HybridRC
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 9),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 9),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -3761,7 +3827,8 @@ namespace HybridRC
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 2),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 2),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -3773,7 +3840,8 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 3),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 3),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -3800,10 +3868,12 @@ namespace HybridRC
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 0),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 0),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 1),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 1),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 28 });
                         break;
                 }
@@ -3830,7 +3900,8 @@ namespace HybridRC
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 4),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 4),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -3851,7 +3922,8 @@ namespace HybridRC
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 14),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 14),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -3863,10 +3935,12 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 10),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 10),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 11),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 11),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         break;
                 }
@@ -3893,7 +3967,8 @@ namespace HybridRC
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 13),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 13),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -3920,7 +3995,8 @@ namespace HybridRC
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 12),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 12),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -3941,7 +4017,8 @@ namespace HybridRC
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 19),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 19),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -3953,7 +4030,8 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 15),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 15),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -3980,10 +4058,12 @@ namespace HybridRC
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 17),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 17),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 18),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 18),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         break;
                 }
@@ -4010,7 +4090,8 @@ namespace HybridRC
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 16),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 16),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4031,7 +4112,8 @@ namespace HybridRC
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 24),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 24),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4043,10 +4125,12 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 20),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 20),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 21),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 21),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 36 });
                         break;
                 }
@@ -4073,7 +4157,8 @@ namespace HybridRC
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 23),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 23),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4100,7 +4185,8 @@ namespace HybridRC
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 22),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 22),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4121,7 +4207,8 @@ namespace HybridRC
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 29),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 29),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4133,7 +4220,8 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 25),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 25),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4160,10 +4248,12 @@ namespace HybridRC
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 27),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 27),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 28),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 28),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 36 });
                         break;
                 }
@@ -4190,7 +4280,8 @@ namespace HybridRC
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 26),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 26),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4211,7 +4302,8 @@ namespace HybridRC
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 26),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 26),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4222,10 +4314,12 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 27),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 27),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 28),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 28),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 36 });
                         break;
                 }
@@ -4251,7 +4345,8 @@ namespace HybridRC
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 25),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 25),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4277,7 +4372,8 @@ namespace HybridRC
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 29),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 29),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4299,7 +4395,8 @@ namespace HybridRC
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 22),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 22),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4310,7 +4407,8 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 23),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 23),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4336,10 +4434,12 @@ namespace HybridRC
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 20),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 20),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 21),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 21),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 36 });
                         break;
                 }
@@ -4365,7 +4465,8 @@ namespace HybridRC
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 24),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 24),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4387,7 +4488,8 @@ namespace HybridRC
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 16),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 16),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4399,10 +4501,12 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 17),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 17),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 18),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 18),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 28 });
                         break;
                 }
@@ -4429,7 +4533,8 @@ namespace HybridRC
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 15),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 15),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4456,7 +4561,8 @@ namespace HybridRC
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 19),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 19),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4477,7 +4583,8 @@ namespace HybridRC
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 12),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 12),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4489,7 +4596,8 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 13),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 13),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4516,10 +4624,12 @@ namespace HybridRC
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 10),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 10),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 11),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 11),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 28 });
                         break;
                 }
@@ -4546,7 +4656,8 @@ namespace HybridRC
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 14),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 14),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4567,7 +4678,8 @@ namespace HybridRC
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 34),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 34),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4579,10 +4691,12 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 30),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 30),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 31),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 31),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 28 });
                         break;
                 }
@@ -4609,7 +4723,8 @@ namespace HybridRC
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 33),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 33),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4636,7 +4751,8 @@ namespace HybridRC
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 32),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 32),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4657,7 +4773,8 @@ namespace HybridRC
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 32),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 32),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4669,7 +4786,8 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 33),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 33),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4696,10 +4814,12 @@ namespace HybridRC
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 30),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 30),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 31),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 31),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 28 });
                         break;
                 }
@@ -4726,7 +4846,8 @@ namespace HybridRC
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 34),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BANK_TRANSITION_DIAGONAL + 34),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4747,31 +4868,31 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 0),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 0),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 1),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 1),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 4),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 4),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 5),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 5),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 9),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 9),
                             { 0, 0, height }, { 32, 32, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 13),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 13),
                             { 0, 0, height }, { 26, 32, 3 }, { 6, 6, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -4791,25 +4912,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 2),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 2),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 6),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 6),
                             { 0, 0, height }, { 16, 16, 1 }, { 0, 0, height + 28 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 10),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 10),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 14),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 14),
                             { 0, 0, height }, { 22, 22, 3 }, { 16, 16, height });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -4824,31 +4945,31 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 3),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 3),
                             { 0, 0, height }, { 32, 32, 3 }, { 6, 0, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 7),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 7),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 8),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 8),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 11),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 11),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 12),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 12),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 15),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 15),
                             { 0, 0, height }, { 32, 26, 3 }, { 6, 6, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -4887,31 +5008,31 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 0),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 0),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 1),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 1),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 6),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 6),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 7),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 7),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 14),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 14),
                             { 0, 0, height }, { 32, 32, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 20),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 20),
                             { 0, 0, height }, { 32, 32, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -4933,25 +5054,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 2),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 2),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 0, height });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 8),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 8),
                             { 0, 0, height }, { 48, 16, 1 }, { 0, 0, height + 28 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 15),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 15),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 21),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 21),
                             { 0, 0, height }, { 32, 14, 3 }, { 0, 18, height });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -4968,28 +5089,28 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 3),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 3),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 9),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 9),
                             { 0, 0, height }, { 38, 38, 3 }, { 0, 0, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 10),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 10),
                             { 0, 0, height }, { 16, 16, 1 }, { 16, 16, height + 28 });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 16),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 16),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 22),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 22),
                             { 0, 0, height }, { 38, 38, 3 }, { 0, 0, height });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5012,25 +5133,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 4),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 4),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 11),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 11),
                             { 0, 0, height }, { 16, 48, 1 }, { 0, 0, height + 28 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 17),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 17),
                             { 0, 0, height }, { 16, 32, 3 }, { 0, 0, height });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 23),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 23),
                             { 0, 0, height }, { 14, 32, 3 }, { 18, 0, height });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5047,31 +5168,31 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 5),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 5),
                             { 0, 0, height }, { 32, 32, 3 }, { 6, 0, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 12),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 12),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 13),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 13),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 18),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 18),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 19),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 19),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 24),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 24),
                             { 0, 0, height }, { 32, 32, 3 }, { 6, 0, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5110,31 +5231,31 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 0),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 0),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 1),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 1),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 5),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 5),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 6),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 6),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 12),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 12),
                             { 0, 0, height }, { 32, 32, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 16),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 16),
                             { 0, 0, height }, { 32, 32, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5151,28 +5272,28 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 2),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 2),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 0, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 7),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 7),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 8),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 8),
                             { 0, 0, height }, { 34, 16, 0 }, { 0, 0, height + 28 });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 13),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 13),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 17),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 17),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5185,25 +5306,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 3),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 3),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 9),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 9),
                             { 0, 0, height }, { 16, 16, 0 }, { 16, 16, height + 28 });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 14),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 14),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 18),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 18),
                             { 0, 0, height }, { 34, 16, 3 }, { 0, 0, height });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5235,25 +5356,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 4),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 4),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 10),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 10),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 11),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 11),
                             { 0, 0, height }, { 16, 18, 0 }, { 0, 16, height + 28 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 15),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 15),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 19),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 19),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         break;
                 }
@@ -5274,31 +5395,31 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 20),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 20),
                             { 0, 0, height }, { 32, 32, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 24),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 24),
                             { 0, 0, height }, { 32, 32, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 28),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 28),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 29),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 29),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 35),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 35),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 36),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 36),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5315,28 +5436,28 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 21),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 21),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 25),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 25),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 30),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 30),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 31),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 31),
                             { 0, 0, height }, { 34, 16, 0 }, { 0, 0, height + 28 });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 37),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 37),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 0, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5349,25 +5470,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 22),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 22),
                             { 0, 0, height }, { 34, 16, 3 }, { 0, 0, height });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 26),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 26),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 32),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 32),
                             { 0, 0, height }, { 28, 28, 0 }, { 4, 4, height + 28 });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 38),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 38),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5399,27 +5520,27 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 23),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 23),
                             { 0, 0, height }, { 16, 16, 3 },
                             { 16, 0, // TODO
                               height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 27),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 27),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 33),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 33),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 34),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 34),
                             { 0, 0, height }, { 16, 18, 0 }, { 0, 16, height + 28 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 39),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 39),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 16, height });
                         break;
                 }
@@ -5456,25 +5577,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 0),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 0),
                             { 0, 6, height }, { 32, 20, 3 });
                         wooden_a_supports_paint_setup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 2),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 2),
                             { 0, 6, height }, { 34, 20, 3 });
                         wooden_a_supports_paint_setup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 4),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 4),
                             { 0, 6, height }, { 32, 20, 3 });
                         wooden_a_supports_paint_setup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 6),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 6),
                             { 0, 6, height }, { 32, 20, 3 });
                         wooden_a_supports_paint_setup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5515,25 +5636,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 1),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 1),
                             { 6, 0, height }, { 20, 32, 3 });
                         wooden_a_supports_paint_setup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 3),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 3),
                             { 6, 0, height }, { 20, 34, 3 });
                         wooden_a_supports_paint_setup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 5),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 5),
                             { 6, 0, height }, { 20, 32, 3 });
                         wooden_a_supports_paint_setup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 7),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 7),
                             { 6, 0, height }, { 20, 32, 3 });
                         wooden_a_supports_paint_setup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5564,25 +5685,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 8),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 8),
                             { 0, 6, height }, { 32, 20, 3 });
                         wooden_a_supports_paint_setup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 10),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 10),
                             { 0, 6, height }, { 32, 20, 3 });
                         wooden_a_supports_paint_setup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 12),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 12),
                             { 0, 6, height }, { 34, 20, 3 });
                         wooden_a_supports_paint_setup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 14),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 14),
                             { 0, 6, height }, { 32, 20, 3 });
                         wooden_a_supports_paint_setup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5623,25 +5744,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 9),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 9),
                             { 6, 0, height }, { 20, 32, 3 });
                         wooden_a_supports_paint_setup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 11),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 11),
                             { 6, 0, height }, { 20, 32, 3 });
                         wooden_a_supports_paint_setup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 13),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 13),
                             { 6, 0, height }, { 20, 34, 3 });
                         wooden_a_supports_paint_setup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 15),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 15),
                             { 6, 0, height }, { 20, 32, 3 });
                         wooden_a_supports_paint_setup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5688,25 +5809,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 0),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 0),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 5),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 5),
                             { 0, 0, height }, { 34, 20, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 10),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 10),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 15),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 15),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5728,25 +5849,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 1),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 1),
                             { 0, 0, height }, { 32, 16, 3 });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 6),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 6),
                             { 0, 0, height }, { 32, 16, 3 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 11),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 11),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 16),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 16),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5763,25 +5884,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 2),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 2),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 7),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 7),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 16, height });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 12),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 12),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 17),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 17),
                             { 0, 0, height }, { 16, 16, 3 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5804,25 +5925,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 3),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 3),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 8),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 8),
                             { 0, 0, height }, { 16, 32, 3 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 13),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 13),
                             { 0, 0, height }, { 16, 32, 3 });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 18),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 18),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5839,25 +5960,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 4),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 4),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         wooden_a_supports_paint_setup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 9),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 9),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         wooden_a_supports_paint_setup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 14),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 14),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         wooden_a_supports_paint_setup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 19),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 19),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         wooden_a_supports_paint_setup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5888,25 +6009,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 20),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 20),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 25),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 25),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 30),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 30),
                             { 0, 0, height }, { 34, 20, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 35),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 35),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5928,25 +6049,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 21),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 21),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 26),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 26),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 31),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 31),
                             { 0, 0, height }, { 32, 16, 3 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 36),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 36),
                             { 0, 0, height }, { 32, 16, 3 });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5963,25 +6084,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 22),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 22),
                             { 0, 0, height }, { 16, 16, 3 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 27),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 27),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 32),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 32),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 16, height });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 37),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 37),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6004,25 +6125,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 23),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 23),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 28),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 28),
                             { 0, 0, height }, { 16, 32, 3 });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 33),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 33),
                             { 0, 0, height }, { 16, 32, 3 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 38),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 38),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6039,25 +6160,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 24),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 24),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         wooden_a_supports_paint_setup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 29),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 29),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         wooden_a_supports_paint_setup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 34),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 34),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         wooden_a_supports_paint_setup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 39),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 39),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         wooden_a_supports_paint_setup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6101,38 +6222,38 @@ namespace HybridRC
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_SMALL_CURVE + 0), { 0, 0, height },
-                    { 28, 28, 3 }, { 2, 2, height });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP_SMALL_CURVE + 0),
+                    { 0, 0, height }, { 28, 28, 3 }, { 2, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_SMALL_CURVE + 1), { 0, 0, height },
-                    { 28, 28, 1 }, { 2, 2, height + 99 });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP_SMALL_CURVE + 1),
+                    { 0, 0, height }, { 28, 28, 1 }, { 2, 2, height + 99 });
                 wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_SMALL_CURVE + 2), { 0, 0, height },
-                    { 28, 28, 3 }, { 2, 2, height });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP_SMALL_CURVE + 2),
+                    { 0, 0, height }, { 28, 28, 3 }, { 2, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_SMALL_CURVE + 3), { 0, 0, height },
-                    { 28, 28, 1 }, { 2, 2, height + 99 });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP_SMALL_CURVE + 3),
+                    { 0, 0, height }, { 28, 28, 1 }, { 2, 2, height + 99 });
                 wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_SMALL_CURVE + 4), { 0, 0, height },
-                    { 28, 3, 48 }, { 2, 28, height });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP_SMALL_CURVE + 4),
+                    { 0, 0, height }, { 28, 3, 48 }, { 2, 28, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_SMALL_CURVE + 5), { 0, 0, height },
-                    { 28, 28, 1 }, { 2, 2, height + 99 });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP_SMALL_CURVE + 5),
+                    { 0, 0, height }, { 28, 28, 1 }, { 2, 2, height + 99 });
                 wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_SMALL_CURVE + 6), { 0, 0, height },
-                    { 28, 28, 3 }, { 2, 2, height });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP_SMALL_CURVE + 6),
+                    { 0, 0, height }, { 28, 28, 3 }, { 2, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_SMALL_CURVE + 7), { 0, 0, height },
-                    { 28, 28, 1 }, { 2, 2, height + 99 });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP_SMALL_CURVE + 7),
+                    { 0, 0, height }, { 28, 28, 1 }, { 2, 2, height + 99 });
                 wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
@@ -6149,37 +6270,37 @@ namespace HybridRC
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_SMALL_CURVE + 8), { 0, 0, height },
-                    { 28, 28, 3 }, { 2, 2, height });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP_SMALL_CURVE + 8),
+                    { 0, 0, height }, { 28, 28, 3 }, { 2, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_SMALL_CURVE + 9), { 0, 0, height },
-                    { 28, 28, 1 }, { 2, 2, height + 99 });
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP_SMALL_CURVE + 9),
+                    { 0, 0, height }, { 28, 28, 1 }, { 2, 2, height + 99 });
                 wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_SMALL_CURVE + 10),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP_SMALL_CURVE + 10),
                     { 0, 0, height }, { 28, 3, 48 }, { 2, 28, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_SMALL_CURVE + 11),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP_SMALL_CURVE + 11),
                     { 0, 0, height }, { 28, 28, 1 }, { 2, 2, height + 99 });
                 wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_SMALL_CURVE + 12),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP_SMALL_CURVE + 12),
                     { 0, 0, height }, { 28, 28, 3 }, { 2, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_SMALL_CURVE + 13),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP_SMALL_CURVE + 13),
                     { 0, 0, height }, { 28, 28, 1 }, { 2, 2, height + 99 });
                 wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_SMALL_CURVE + 14),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP_SMALL_CURVE + 14),
                     { 0, 0, height }, { 28, 28, 3 }, { 2, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_SMALL_CURVE + 15),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_STEEP_SMALL_CURVE + 15),
                     { 0, 0, height }, { 28, 28, 1 }, { 2, 2, height + 99 });
                 wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -6215,28 +6336,28 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL_TWIST + 0),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_VERTICAL_TWIST + 0),
                             { 0, 0, height }, { 2, 20, 63 }, { 4, 6, height + 8 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL_TWIST + 1),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_VERTICAL_TWIST + 1),
                             { 0, 0, height }, { 2, 20, 63 }, { 4, 6, height + 8 });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL_TWIST + 2),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_VERTICAL_TWIST + 2),
                             { 0, 0, height }, { 2, 20, 63 }, { 24, 6, height + 8 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL_TWIST + 3),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_VERTICAL_TWIST + 3),
                             { 0, 0, height }, { 2, 20, 63 }, { 24, 6, height + 8 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL_TWIST + 4),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_VERTICAL_TWIST + 4),
                             { 0, 0, height }, { 2, 20, 63 }, { 4, 6, height + 8 });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL_TWIST + 5),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_VERTICAL_TWIST + 5),
                             { 0, 0, height }, { 2, 20, 63 }, { 24, 6, height + 8 });
                         break;
                 }
@@ -6260,28 +6381,28 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL_TWIST + 6),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_VERTICAL_TWIST + 6),
                             { 0, 0, height }, { 2, 20, 63 }, { 4, 6, height + 8 });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL_TWIST + 7),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_VERTICAL_TWIST + 7),
                             { 0, 0, height }, { 2, 20, 63 }, { 24, 6, height + 8 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL_TWIST + 8),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_VERTICAL_TWIST + 8),
                             { 0, 0, height }, { 2, 20, 63 }, { 24, 6, height + 8 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL_TWIST + 9),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_VERTICAL_TWIST + 9),
                             { 0, 0, height }, { 2, 20, 63 }, { 4, 6, height + 8 });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL_TWIST + 10),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_VERTICAL_TWIST + 10),
                             { 0, 0, height }, { 2, 20, 63 }, { 24, 6, height + 8 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL_TWIST + 11),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_VERTICAL_TWIST + 11),
                             { 0, 0, height }, { 2, 20, 63 }, { 4, 6, height + 8 });
                         break;
                 }
@@ -6316,25 +6437,25 @@ namespace HybridRC
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 0),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 0),
                     { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 1),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 1),
                     { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 2),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 2),
                     { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height + 3 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 3),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 3),
                     { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 4),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 4),
                     { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 break;
         }
@@ -6359,25 +6480,25 @@ namespace HybridRC
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 5),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 5),
                     { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 6),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 6),
                     { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 7),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 7),
                     { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 8),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 8),
                     { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 9),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 9),
                     { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 break;
         }
@@ -6402,25 +6523,25 @@ namespace HybridRC
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 10),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 10),
                     { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 11),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 11),
                     { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 12),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 12),
                     { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 13),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 13),
                     { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 14),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 14),
                     { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 break;
         }
@@ -6445,25 +6566,25 @@ namespace HybridRC
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 15),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 15),
                     { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 16),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 16),
                     { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 17),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 17),
                     { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 18),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 18),
                     { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 19),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 19),
                     { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 break;
         }
@@ -6516,28 +6637,28 @@ namespace HybridRC
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 20),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 20),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 21),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 21),
                     { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 22),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 22),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 23),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 23),
                     { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 24),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 24),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 25),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 25),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
         }
@@ -6562,28 +6683,28 @@ namespace HybridRC
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 26),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 26),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 27),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 27),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 28),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 28),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 29),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 29),
                     { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 30),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 30),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 31),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 31),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
         }
@@ -6608,28 +6729,28 @@ namespace HybridRC
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 32),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 32),
                     { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 33),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 33),
                     { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 34),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 34),
                     { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 35),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 35),
                     { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 36),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 36),
                     { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 37),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 37),
                     { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 break;
         }
@@ -6654,28 +6775,28 @@ namespace HybridRC
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 38),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 38),
                     { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 39),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 39),
                     { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 40),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 40),
                     { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 41),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 41),
                     { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 42),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 42),
                     { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 43),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 43),
                     { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
         }
@@ -6728,22 +6849,22 @@ namespace HybridRC
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 44),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 44),
                     { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 45),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 45),
                     { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 46),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 46),
                     { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 47),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 47),
                     { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 break;
         }
@@ -6768,22 +6889,22 @@ namespace HybridRC
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 48),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 48),
                     { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 49),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 49),
                     { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 50),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 50),
                     { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 51),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 51),
                     { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 break;
         }
@@ -6822,25 +6943,25 @@ namespace HybridRC
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 52),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 52),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 53),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 53),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 54),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 54),
                     { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 55),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 55),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 56),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 56),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
         }
@@ -6865,25 +6986,25 @@ namespace HybridRC
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 57),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 57),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 58),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 58),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 59),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 59),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 60),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 60),
                     { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 61),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 61),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
         }
@@ -6908,25 +7029,25 @@ namespace HybridRC
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 62),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 62),
                     { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 63),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 63),
                     { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 64),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 64),
                     { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 65),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 65),
                     { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 66),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 66),
                     { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 break;
         }
@@ -6951,25 +7072,25 @@ namespace HybridRC
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 67),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 67),
                     { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 68),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 68),
                     { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 69),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 69),
                     { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 70),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 70),
                     { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 71),
+                    session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SLOPE_BANK_TRANSITION + 71),
                     { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 3 });
                 break;
         }
@@ -7025,28 +7146,33 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 0),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 0),
                             { 0, 6, height }, { 32, 20, 3 });
                         wooden_a_supports_paint_setup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 2),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 2),
                             { 0, 6, height }, { 32, 20, 3 });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 3),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 3),
                             { 0, 6, height }, { 34, 1, 34 }, { 0, 27, height });
                         wooden_a_supports_paint_setup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 6),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 6),
                             { 0, 6, height }, { 32, 20, 3 });
                         wooden_a_supports_paint_setup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 9),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 9),
                             { 0, 6, height }, { 32, 20, 3 });
                         wooden_a_supports_paint_setup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7087,31 +7213,37 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 1),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 1),
                             { 6, 0, height }, { 20, 32, 3 });
                         wooden_a_supports_paint_setup(session, 0, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 4),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 4),
                             { 6, 0, height }, { 20, 32, 3 });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 5),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 5),
                             { 6, 0, height }, { 1, 34, 34 }, { 27, 0, height });
                         wooden_a_supports_paint_setup(session, 1, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 7),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 7),
                             { 6, 0, height }, { 20, 32, 3 });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 8),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 8),
                             { 6, 0, height }, { 1, 32, 34 }, { 27, 0, height });
                         wooden_a_supports_paint_setup(session, 0, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 10),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 10),
                             { 6, 0, height }, { 20, 32, 3 });
                         wooden_a_supports_paint_setup(session, 1, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7142,28 +7274,33 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 11),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 11),
                             { 0, 6, height }, { 32, 20, 3 });
                         wooden_a_supports_paint_setup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 13),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 13),
                             { 0, 6, height }, { 32, 20, 3 });
                         wooden_a_supports_paint_setup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 16),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 16),
                             { 0, 6, height }, { 32, 20, 3 });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 17),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 17),
                             { 0, 6, height }, { 34, 1, 34 }, { 0, 27, height });
                         wooden_a_supports_paint_setup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 20),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 20),
                             { 0, 6, height }, { 32, 20, 3 });
                         wooden_a_supports_paint_setup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7204,31 +7341,37 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 12),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 12),
                             { 6, 0, height }, { 20, 32, 3 });
                         wooden_a_supports_paint_setup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 14),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 14),
                             { 6, 0, height }, { 20, 32, 3 });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 15),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 15),
                             { 6, 0, height }, { 1, 32, 34 }, { 27, 0, height });
                         wooden_a_supports_paint_setup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 18),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 18),
                             { 6, 0, height }, { 20, 32, 3 });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 19),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 19),
                             { 6, 0, height }, { 1, 34, 34 }, { 27, 0, height });
                         wooden_a_supports_paint_setup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 21),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 21),
                             { 6, 0, height }, { 20, 32, 3 });
                         wooden_a_supports_paint_setup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7275,28 +7418,33 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 0),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 0),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 5),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 5),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 6),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 6),
                             { 0, 0, height }, { 34, 1, 34 }, { 0, 27, height });
                         wooden_a_supports_paint_setup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 15),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 15),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 21),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 21),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7318,28 +7466,33 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 1),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 1),
                             { 0, 0, height }, { 32, 16, 3 });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 7),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 7),
                             { 0, 0, height }, { 32, 16, 3 });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 8),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 8),
                             { 0, 0, height }, { 1, 1, 34 }, { 30, 30, height });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 16),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 16),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 22),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 22),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7356,28 +7509,33 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 2),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 2),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 9),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 9),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, -8, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 10),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 10),
                             { 0, 0, height }, { 1, 1, 34 }, { 30, 30, height });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 17),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 17),
                             { 0, 0, height }, { 1, 1, 3 }, { 64, 0, height });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 23),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 23),
                             { 0, 0, height }, { 16, 16, 3 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7400,28 +7558,33 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 3),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 3),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 11),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 11),
                             { 0, 0, height }, { 16, 32, 3 }, { -8, 0, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 12),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 12),
                             { 0, 0, height }, { 1, 1, 34 }, { 30, 30, height });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 18),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 18),
                             { 0, 0, height }, { 1, 32, 34 }, { 27, 0, height });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 24),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 24),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7438,31 +7601,37 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 4),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 4),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         wooden_a_supports_paint_setup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 13),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 13),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 14),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 14),
                             { 0, 0, height }, { 1, 32, 34 }, { 27, 0, height });
                         wooden_a_supports_paint_setup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 19),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 19),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 20),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 20),
                             { 0, 0, height }, { 1, 32, 34 }, { 27, 0, height });
                         wooden_a_supports_paint_setup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 25),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 25),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         wooden_a_supports_paint_setup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7493,28 +7662,33 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 26),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 26),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 31),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 31),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 37),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 37),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 38),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 38),
                             { 0, 0, height }, { 34, 1, 34 }, { 0, 27, height });
                         wooden_a_supports_paint_setup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 47),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 47),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7536,28 +7710,33 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 27),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 27),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 32),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 32),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 39),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 39),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 40),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 40),
                             { 0, 0, height }, { 1, 1, 34 }, { 30, 30, height });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 48),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 48),
                             { 0, 0, height }, { 32, 16, 3 });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7574,28 +7753,33 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 28),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 28),
                             { 0, 0, height }, { 16, 16, 3 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 33),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 33),
                             { 0, 0, height }, { 1, 1, 3 }, { 64, 0, height });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 41),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 41),
                             { 0, 0, height }, { 16, 16, 3 }, { -8, 0, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 42),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 42),
                             { 0, 0, height }, { 1, 1, 34 }, { 30, 30, height });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 49),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 49),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7618,28 +7802,33 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 29),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 29),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 34),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 34),
                             { 0, 0, height }, { 1, 32, 34 }, { 27, 0, height });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 43),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 43),
                             { 0, 0, height }, { 16, 32, 3 }, { -8, 0, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 44),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 44),
                             { 0, 0, height }, { 1, 1, 34 }, { 30, 30, height });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 50),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 50),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7656,31 +7845,37 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 30),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 30),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         wooden_a_supports_paint_setup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 35),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 35),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 36),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 36),
                             { 0, 0, height }, { 1, 32, 34 }, { 27, 0, height });
                         wooden_a_supports_paint_setup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 45),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 45),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 46),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 46),
                             { 0, 0, height }, { 1, 32, 34 }, { 27, 0, height });
                         wooden_a_supports_paint_setup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 51),
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 51),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         wooden_a_supports_paint_setup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7727,26 +7922,26 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 0), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_S_BEND + 0),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 4), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_S_BEND + 4),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 3), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_S_BEND + 3),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 7), { 0, 0, height },
-                            { 32, 32, 3 }, { 0, 6, height });
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_S_BEND + 7),
+                            { 0, 0, height }, { 32, 32, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
@@ -7762,26 +7957,26 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 1), { 0, 0, height },
-                            { 32, 26, 3 });
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_S_BEND + 1),
+                            { 0, 0, height }, { 32, 26, 3 });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 5), { 0, 0, height },
-                            { 34, 26, 3 });
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_S_BEND + 5),
+                            { 0, 0, height }, { 34, 26, 3 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 2), { 0, 0, height },
-                            { 32, 26, 3 }, { 0, 6, height });
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_S_BEND + 2),
+                            { 0, 0, height }, { 32, 26, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 6), { 0, 0, height },
-                            { 32, 26, 3 }, { 0, 6, height });
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_S_BEND + 6),
+                            { 0, 0, height }, { 32, 26, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
@@ -7797,26 +7992,26 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 2), { 0, 0, height },
-                            { 32, 26, 3 }, { 0, 6, height });
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_S_BEND + 2),
+                            { 0, 0, height }, { 32, 26, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 6), { 0, 0, height },
-                            { 32, 26, 3 }, { 0, 6, height });
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_S_BEND + 6),
+                            { 0, 0, height }, { 32, 26, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 1), { 0, 0, height },
-                            { 32, 26, 3 });
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_S_BEND + 1),
+                            { 0, 0, height }, { 32, 26, 3 });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 5), { 0, 0, height },
-                            { 34, 26, 3 });
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_S_BEND + 5),
+                            { 0, 0, height }, { 34, 26, 3 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
@@ -7832,26 +8027,26 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 3), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_S_BEND + 3),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 7), { 0, 0, height },
-                            { 32, 32, 3 }, { 0, 6, height });
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_S_BEND + 7),
+                            { 0, 0, height }, { 32, 32, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 0), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_S_BEND + 0),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 4), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_S_BEND + 4),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
@@ -7881,26 +8076,26 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 8), { 0, 0, height },
-                            { 32, 32, 3 }, { 0, 6, height });
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_S_BEND + 8),
+                            { 0, 0, height }, { 32, 32, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 12), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_S_BEND + 12),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 11), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_S_BEND + 11),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 15), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_S_BEND + 15),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
@@ -7916,26 +8111,26 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 9), { 0, 0, height },
-                            { 32, 26, 3 }, { 0, 6, height });
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_S_BEND + 9),
+                            { 0, 0, height }, { 32, 26, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 13), { 0, 0, height },
-                            { 32, 26, 3 }, { 0, 6, height });
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_S_BEND + 13),
+                            { 0, 0, height }, { 32, 26, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 10), { 0, 0, height },
-                            { 34, 26, 3 });
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_S_BEND + 10),
+                            { 0, 0, height }, { 34, 26, 3 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 14), { 0, 0, height },
-                            { 32, 26, 3 });
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_S_BEND + 14),
+                            { 0, 0, height }, { 32, 26, 3 });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
@@ -7951,26 +8146,26 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 10), { 0, 0, height },
-                            { 34, 26, 3 });
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_S_BEND + 10),
+                            { 0, 0, height }, { 34, 26, 3 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 14), { 0, 0, height },
-                            { 32, 26, 3 });
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_S_BEND + 14),
+                            { 0, 0, height }, { 32, 26, 3 });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 9), { 0, 0, height },
-                            { 32, 26, 3 }, { 0, 6, height });
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_S_BEND + 9),
+                            { 0, 0, height }, { 32, 26, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 13), { 0, 0, height },
-                            { 32, 26, 3 }, { 0, 6, height });
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_S_BEND + 13),
+                            { 0, 0, height }, { 32, 26, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
@@ -7986,26 +8181,26 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 11), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_S_BEND + 11),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 15), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_S_BEND + 15),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 8), { 0, 0, height },
-                            { 32, 32, 3 }, { 0, 6, height });
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_S_BEND + 8),
+                            { 0, 0, height }, { 32, 32, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 12), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_S_BEND + 12),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
@@ -8035,31 +8230,31 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 0),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 0),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 1),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 1),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 4),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 4),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 5),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 5),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 9),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 9),
                             { 0, 0, height }, { 32, 32, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 13),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 13),
                             { 0, 0, height }, { 32, 32, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -8094,25 +8289,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 2),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 2),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 6),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 6),
                             { 0, 0, height }, { 16, 16, 1 }, { 0, 0, height + 28 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 10),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 10),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 14),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 14),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 16, height });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -8127,31 +8322,31 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 3),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 3),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 7),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 7),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 8),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 8),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 11),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 11),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 12),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 12),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 15),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 15),
                             { 0, 0, height }, { 32, 32, 3 }, { 6, 0, height + 8 });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -8173,31 +8368,31 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 13),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 13),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 0),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 0),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 1),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 1),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 4),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 4),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 5),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 5),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 9),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 9),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -8237,25 +8432,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 14),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 14),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 16, height });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 2),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 2),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 6),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 6),
                             { 0, 0, height }, { 16, 16, 1 }, { 0, 0, height + 28 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 10),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 10),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -8270,31 +8465,31 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 15),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 15),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height + 8 });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 3),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 3),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 7),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 7),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 8),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 8),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 11),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 11),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 12),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 12),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -8320,31 +8515,31 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 16),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 16),
                             { 0, 0, height }, { 32, 32, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 19),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 19),
                             { 0, 0, height }, { 32, 32, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 23),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 23),
                             { 0, 0, height }, { 34, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 24),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 24),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 28),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 28),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 29),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 29),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -8379,25 +8574,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 17),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 17),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 16, height });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 20),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 20),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 25),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 25),
                             { 0, 0, height }, { 16, 16, 1 }, { 0, 0, height + 28 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 30),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 30),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -8412,31 +8607,31 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 18),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 18),
                             { 0, 0, height }, { 32, 32, 3 }, { 6, 0, height + 8 });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 21),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 21),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 22),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 22),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 26),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 26),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 27),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 27),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 31),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 31),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -8458,31 +8653,31 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 19),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 19),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 23),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 23),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 24),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 24),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 28),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 28),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 29),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 29),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 16),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 16),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -8522,25 +8717,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 20),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 20),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 25),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 25),
                             { 0, 0, height }, { 16, 16, 1 }, { 0, 0, height + 28 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 30),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 30),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 17),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 17),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 16, height });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -8555,31 +8750,31 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 21),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 21),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 22),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 22),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 26),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 26),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 27),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 27),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 31),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 31),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 18),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_SMALL_HELIX + 18),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height + 8 });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -8631,31 +8826,31 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 0),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 0),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 1),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 1),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 6),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 6),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 7),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 7),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 14),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 14),
                             { 0, 0, height }, { 32, 32, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 20),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 20),
                             { 0, 0, height }, { 32, 32, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -8677,25 +8872,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 2),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 2),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 0, height });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 8),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 8),
                             { 0, 0, height }, { 33, 16, 1 }, { 0, 0, height + 28 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 15),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 15),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 21),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 21),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -8712,28 +8907,28 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 3),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 3),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 9),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 9),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 10),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 10),
                             { 0, 0, height }, { 16, 16, 1 }, { 16, 16, height + 28 });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 16),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 16),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 22),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 22),
                             { 0, 0, height }, { 34, 34, 3 }, { 0, 0, height });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -8756,25 +8951,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 4),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 4),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 11),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 11),
                             { 0, 0, height }, { 16, 33, 1 }, { 0, 0, height + 28 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 17),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 17),
                             { 0, 0, height }, { 16, 32, 3 }, { 0, 0, height });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 23),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 23),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -8791,31 +8986,31 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 5),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 5),
                             { 0, 0, height }, { 32, 32, 3 }, { 6, 0, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 12),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 12),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 13),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 13),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 18),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 18),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 19),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 19),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 24),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 24),
                             { 0, 0, height }, { 28, 32, 3 }, { 6, 0, height + 8 });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -8837,31 +9032,31 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 20),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 20),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 0),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 0),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 1),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 1),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 6),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 6),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 7),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 7),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 14),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 14),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -8888,25 +9083,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 21),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 21),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 2),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 2),
                             { 0, 0, height }, { 16, 32, 3 }, { 0, 0, height });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 8),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 8),
                             { 0, 0, height }, { 16, 32, 1 }, { 0, 0, height + 28 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 15),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 15),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -8923,28 +9118,28 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 22),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 22),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 0, height });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 3),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 3),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 9),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 9),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 10),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 10),
                             { 0, 0, height }, { 16, 16, 1 }, { 16, 16, height + 28 });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 16),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 16),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -8967,25 +9162,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 23),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 23),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 4),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 4),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 11),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 11),
                             { 0, 0, height }, { 32, 16, 1 }, { 0, 0, height + 28 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 17),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 17),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 0, height });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9002,31 +9197,31 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 24),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 24),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height + 8 });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 5),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 5),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 12),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 12),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 13),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 13),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 18),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 18),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 19),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 19),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9052,31 +9247,31 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 25),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 25),
                             { 0, 0, height }, { 32, 32, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 30),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 30),
                             { 0, 0, height }, { 32, 32, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 36),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 36),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 37),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 37),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 44),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 44),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 45),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 45),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9098,25 +9293,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 26),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 26),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 31),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 31),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 38),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 38),
                             { 0, 0, height }, { 33, 16, 1 }, { 0, 0, height + 28 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 46),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 46),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 0, height });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9133,28 +9328,28 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 27),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 27),
                             { 0, 0, height }, { 34, 16, 3 }, { 0, 0, height });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 32),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 32),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 39),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 39),
                             { 0, 0, height }, { 16, 32, 3 }, { 0, 16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 40),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 40),
                             { 0, 0, height }, { 16, 16, 1 }, { 16, 16, height + 28 });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 47),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 47),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9177,25 +9372,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 28),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 28),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 33),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 33),
                             { 0, 0, height }, { 16, 32, 3 }, { 0, 0, height });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 41),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 41),
                             { 0, 0, height }, { 16, 33, 1 }, { 0, 0, height + 28 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 48),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 48),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9212,31 +9407,31 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 29),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 29),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height + 8 });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 34),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 34),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 35),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 35),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 42),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 42),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 43),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 43),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 49),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 49),
                             { 0, 0, height }, { 32, 32, 3 }, { 6, 0, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9258,31 +9453,31 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 30),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 30),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 36),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 36),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 37),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 37),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 44),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 44),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 45),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 45),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 25),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 25),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9309,25 +9504,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 31),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 31),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 38),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 38),
                             { 0, 0, height }, { 16, 32, 1 }, { 0, 0, height + 28 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 46),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 46),
                             { 0, 0, height }, { 16, 32, 3 }, { 0, 0, height });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 26),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 26),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9344,28 +9539,28 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 32),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 32),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 39),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 39),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 40),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 40),
                             { 0, 0, height }, { 16, 16, 1 }, { 16, 16, height + 28 });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 47),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 47),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 27),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 27),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 0, height });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9388,25 +9583,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 33),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 33),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 0, height });
                         wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 41),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 41),
                             { 0, 0, height }, { 32, 16, 1 }, { 0, 0, height + 28 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 48),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 48),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 28),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 28),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9423,31 +9618,31 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 34),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 34),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 35),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 35),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 42),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 42),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 43),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 43),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 49),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 49),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 29),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_HELIX + 29),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height + 8 });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9499,34 +9694,34 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 0),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 0),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 1),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 1),
                             { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 40 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 6),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 6),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 7),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 7),
                             { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 40 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 12),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 12),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 13),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 13),
                             { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 40 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 18),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 18),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 19),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 19),
                             { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 40 });
                         break;
                 }
@@ -9543,34 +9738,34 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 2),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 2),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 3),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 3),
                             { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 40 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 8),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 8),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 9),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 9),
                             { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 40 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 14),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 14),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 15),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 15),
                             { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 40 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 20),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 20),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 21),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 21),
                             { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 40 });
                         break;
                 }
@@ -9583,34 +9778,34 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 4),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 4),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 5),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 5),
                             { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 56 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 10),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 10),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 11),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 11),
                             { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 56 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 16),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 16),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 17),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 17),
                             { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 56 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 22),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 22),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 23),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 23),
                             { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 56 });
                         break;
                 }
@@ -9641,34 +9836,34 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 24),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 24),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 25),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 25),
                             { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 40 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 30),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 30),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 31),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 31),
                             { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 40 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 36),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 36),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 37),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 37),
                             { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 40 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 42),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 42),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 43),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 43),
                             { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 40 });
                         break;
                 }
@@ -9685,34 +9880,34 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 26),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 26),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 27),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 27),
                             { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 40 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 32),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 32),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 33),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 33),
                             { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 40 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 38),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 38),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 39),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 39),
                             { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 40 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 44),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 44),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 45),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 45),
                             { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 40 });
                         break;
                 }
@@ -9725,34 +9920,34 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 28),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 28),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 29),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 29),
                             { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 56 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 34),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 34),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 35),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 35),
                             { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 56 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 40),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 40),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 41),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 41),
                             { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 56 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 46),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 46),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BARREL_ROLL + 47),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BARREL_ROLL + 47),
                             { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 56 });
                         break;
                 }
@@ -9797,28 +9992,28 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 0),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 0),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 1),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 1),
                             { 0, 0, height }, { 32, 20, 1 }, { 0, 6, height + 40 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 6),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 6),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 7),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 7),
                             { 0, 0, height }, { 32, 1, 32 }, { 0, 31, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 12),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 12),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 16),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 16),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -9837,28 +10032,28 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 2),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 2),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 3),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 3),
                             { 0, 0, height }, { 32, 20, 1 }, { 0, 6, height + 40 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 8),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 8),
                             { 0, 0, height }, { 32, 20, 1 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 9),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 9),
                             { 0, 0, height }, { 32, 20, 1 }, { 0, 6, height + 40 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 13),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 13),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 17),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 17),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -9875,34 +10070,34 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 4),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 4),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 5),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 5),
                             { 0, 0, height }, { 32, 20, 1 }, { 0, 6, height + 48 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 10),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 10),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 11),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 11),
                             { 0, 0, height }, { 32, 20, 1 }, { 0, 6, height + 48 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 14),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 14),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 15),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 15),
                             { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 48 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 18),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 18),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 19),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 19),
                             { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 48 });
                         break;
                 }
@@ -9937,28 +10132,28 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 20),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 20),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 24),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 24),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 28),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 28),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 29),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 29),
                             { 0, 0, height }, { 32, 1, 32 }, { 0, 31, height + 40 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 34),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 34),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 35),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 35),
                             { 0, 0, height }, { 32, 20, 1 }, { 0, 6, height + 40 });
                         break;
                 }
@@ -9976,28 +10171,28 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 21),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 21),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 25),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 25),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 30),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 30),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 31),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 31),
                             { 0, 0, height }, { 32, 20, 1 }, { 0, 6, height + 40 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 36),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 36),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 37),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 37),
                             { 0, 0, height }, { 32, 20, 1 }, { 0, 6, height + 40 });
                         break;
                 }
@@ -10014,34 +10209,34 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 22),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 22),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 23),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 23),
                             { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 48 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 26),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 26),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 27),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 27),
                             { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 48 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 32),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 32),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 33),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 33),
                             { 0, 0, height }, { 32, 20, 1 }, { 0, 6, height + 48 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 38),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 38),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 39),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_ZERO_G_ROLL + 39),
                             { 0, 0, height }, { 32, 20, 1 }, { 0, 6, height + 48 });
                         break;
                 }
@@ -10090,28 +10285,28 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 0),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 0),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 7),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 7),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 8),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 8),
                             { 0, 0, height }, { 32, 0, 96 }, { 0, 30, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 15),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 15),
                             { 0, 0, height }, { 30, 20, 16 }, { 1, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 16),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 16),
                             { 0, 0, height }, { 32, 0, 40 }, { 0, 30, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 23),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 23),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -10129,31 +10324,31 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 1),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 1),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 2),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 2),
                             { 0, 0, height }, { 32, 0, 96 }, { 0, 30, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 9),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 9),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 10),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 10),
                             { 0, 0, height }, { 32, 0, 64 }, { 0, 30, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 17),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 17),
                             { 0, 0, height }, { 40, 8, 64 }, { -3, 0, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 18),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 18),
                             { 0, 0, height }, { 32, 0, 64 }, { 0, 30, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 24),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 24),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -10167,34 +10362,34 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 3),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 3),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 4),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 4),
                             { 0, 0, height }, { 32, 0, 64 }, { 0, 30, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 11),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 11),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 12),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 12),
                             { 0, 0, height }, { 32, 0, 48 }, { 0, 30, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 19),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 19),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 20),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 20),
                             { 0, 0, height }, { 32, 0, 48 }, { 0, 30, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 25),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 25),
                             { 0, 0, height }, { 32, 0, 32 }, { 0, 2, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 26),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 26),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height + 40 });
                         break;
                 }
@@ -10212,34 +10407,34 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 5),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 5),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 6),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 6),
                             { 0, 0, height }, { 32, 32, 1 }, { 0, 0, height + 40 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 13),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 13),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 14),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 14),
                             { 0, 0, height }, { 32, 0, 48 }, { 0, 30, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 21),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 21),
                             { 0, 0, height }, { 32, 0, 32 }, { 0, 2, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 22),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 22),
                             { 0, 0, height }, { 32, 0, 48 }, { 0, 30, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 27),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 27),
                             { 0, 0, height }, { 32, 0, 32 }, { 0, 2, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 28),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 28),
                             { 0, 0, height }, { 32, 32, 1 }, { 0, 0, height + 40 });
                         break;
                 }
@@ -10274,28 +10469,28 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 29),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 29),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 35),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 35),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 36),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 36),
                             { 0, 0, height }, { 32, 0, 96 }, { 0, 30, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 43),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 43),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 44),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 44),
                             { 0, 0, height }, { 32, 0, 96 }, { 0, 30, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 51),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 51),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -10313,31 +10508,31 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 30),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 30),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 37),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 37),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 38),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 38),
                             { 0, 0, height }, { 32, 0, 64 }, { 0, 30, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 45),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 45),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 46),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 46),
                             { 0, 0, height }, { 32, 0, 64 }, { 0, 30, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 52),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 52),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 53),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 53),
                             { 0, 0, height }, { 32, 0, 96 }, { 0, 30, height });
                         break;
                 }
@@ -10351,34 +10546,34 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 31),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 31),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 32),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 32),
                             { 0, 0, height }, { 32, 0, 32 }, { 0, 2, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 39),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 39),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 40),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 40),
                             { 0, 0, height }, { 32, 0, 48 }, { 0, 30, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 47),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 47),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 48),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 48),
                             { 0, 0, height }, { 32, 0, 48 }, { 0, 30, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 54),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 54),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 55),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 55),
                             { 0, 0, height }, { 32, 0, 64 }, { 0, 30, height });
                         break;
                 }
@@ -10396,34 +10591,34 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 33),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 33),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 34),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 34),
                             { 0, 0, height }, { 32, 32, 1 }, { 0, 0, height + 40 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 41),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 41),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 42),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 42),
                             { 0, 0, height }, { 32, 0, 48 }, { 0, 30, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 49),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 49),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 50),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 50),
                             { 0, 0, height }, { 32, 0, 48 }, { 0, 30, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 56),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 56),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 57),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_ZERO_G_ROLL + 57),
                             { 0, 0, height }, { 32, 32, 1 }, { 0, 0, height + 40 });
                         break;
                 }
@@ -10472,34 +10667,34 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 0),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 0),
                             { 0, 0, height }, { 2, 20, 31 }, { 4, 6, height + 8 });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 1),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 1),
                             { 0, 0, height }, { 32, 1, 48 }, { 0, 32, height + 8 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 6),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 6),
                             { 0, 0, height }, { 2, 20, 31 }, { 26, 4, height + 8 });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 7),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 7),
                             { 0, 0, height }, { 32, 1, 48 }, { 0, 32, height + 8 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 12),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 12),
                             { 0, 0, height }, { 2, 20, 31 }, { 26, 4, height + 8 });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 13),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 13),
                             { 0, 0, height }, { 32, 1, 48 }, { 0, 32, height + 8 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 18),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 18),
                             { 0, 0, height }, { 2, 20, 31 }, { 4, 6, height + 8 });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 19),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 19),
                             { 0, 0, height }, { 32, 1, 48 }, { 0, 32, height + 8 });
                         break;
                 }
@@ -10511,34 +10706,34 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 2),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 2),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 3),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 3),
                             { 0, 0, height }, { 32, 1, 64 }, { 0, 32, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 8),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 8),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 9),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 9),
                             { 0, 0, height }, { 32, 1, 64 }, { 0, 32, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 14),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 14),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 15),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 15),
                             { 0, 0, height }, { 32, 1, 64 }, { 0, 32, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 20),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 20),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 21),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 21),
                             { 0, 0, height }, { 32, 1, 64 }, { 0, 32, height });
                         break;
                 }
@@ -10551,34 +10746,34 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 4),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 4),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 5),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 5),
                             { 0, 0, height }, { 32, 1, 32 }, { 0, 32, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 10),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 10),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 11),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 11),
                             { 0, 0, height }, { 32, 1, 32 }, { 0, 32, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 16),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 16),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 17),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 17),
                             { 0, 0, height }, { 32, 1, 32 }, { 0, 32, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 22),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 22),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 23),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_QUARTER_LOOP + 23),
                             { 0, 0, height }, { 32, 1, 32 }, { 0, 32, height });
                         break;
                 }
@@ -10605,8 +10800,8 @@ namespace HybridRC
         const TrackElement& trackElement)
     {
         PaintAddImageAsParentRotated(
-            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BRAKE + (direction & 1)), { 0, 0, height },
-            { 32, 20, 3 }, { 0, 6, height });
+            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BRAKE + (direction & 1)),
+            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
         wooden_a_supports_paint_setup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
         paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
         paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -10618,9 +10813,9 @@ namespace HybridRC
         const TrackElement& trackElement)
     {
         PaintAddImageAsParentRotated(
-            session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+            session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
         PaintAddImageAsParentRotated(
-            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT + (direction & 1)), { 0, 0, height },
+            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_FLAT + (direction & 1)), { 0, 0, height },
             { 32, 20, 0 }, { 0, 6, height + 3 });
         track_paint_util_onride_photo_paint(session, direction, height + 3, trackElement);
         wooden_a_supports_paint_setup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -10640,22 +10835,22 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 0),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 0),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 4),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 4),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 8),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 8),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 12),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 12),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -10673,22 +10868,22 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 1),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 1),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 5),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 5),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 9),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 9),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 13),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 13),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -10702,22 +10897,22 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 2),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 2),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 6),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 6),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 10),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 10),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 14),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 14),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -10731,22 +10926,22 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 3),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 3),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 7),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 7),
                             { 0, 0, height }, { 2, 24, 56 }, { 28, 4, height - 16 });
                         break;
                     case 2:
                         session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 11),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 11),
                             { 0, 0, height }, { 2, 24, 56 }, { 28, 4, height - 16 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 15),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 15),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -10778,22 +10973,22 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 16),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 16),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 20),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 20),
                             { 0, 0, height }, { 2, 24, 56 }, { 28, 4, height - 16 });
                         break;
                     case 2:
                         session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 24),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 24),
                             { 0, 0, height }, { 2, 24, 56 }, { 28, 4, height - 16 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 28),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 28),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -10811,22 +11006,22 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 17),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 17),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 21),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 21),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 25),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 25),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 29),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 29),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -10840,22 +11035,22 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 18),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 18),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 22),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 22),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 26),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 26),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 30),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 30),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -10869,22 +11064,22 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 19),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 19),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 23),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 23),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 27),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 27),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 31),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_FLAT_TO_STEEP + 31),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -10924,8 +11119,8 @@ namespace HybridRC
         const TrackElement& trackElement)
     {
         PaintAddImageAsParentRotated(
-            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BLOCK_BRAKE + (direction & 1)), { 0, 0, height },
-            { 32, 20, 3 }, { 0, 6, height });
+            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BLOCK_BRAKE + (direction & 1)),
+            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
         wooden_a_supports_paint_setup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
         paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
         paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -10937,8 +11132,8 @@ namespace HybridRC
         const TrackElement& trackElement)
     {
         PaintAddImageAsParentRotated(
-            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BOOSTER + (direction & 1)), { 0, 0, height },
-            { 32, 20, 3 }, { 0, 6, height });
+            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_BOOSTER + (direction & 1)),
+            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
         wooden_a_supports_paint_setup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
         paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
         paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -10950,8 +11145,8 @@ namespace HybridRC
         const TrackElement& trackElement)
     {
         PaintAddImageAsParentRotated(
-            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_POWERED_LIFT + direction), { 0, 0, height },
-            { 32, 20, 3 }, { 0, 6, height });
+            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_POWERED_LIFT + direction),
+            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
         wooden_a_supports_paint_setup(session, direction & 1, 9 + direction, height, session.TrackColours[SCHEME_SUPPORTS]);
         if (direction == 0 || direction == 3)
         {
@@ -10976,28 +11171,28 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 0),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 0),
                             { 0, 6, height }, { 32, 20, 3 });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 2),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 2),
                             { 0, 6, height }, { 32, 20, 3 });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 3),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 3),
                             { 0, 6, height }, { 34, 1, 26 }, { 0, 27, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 5),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 5),
                             { 0, 6, height }, { 32, 20, 3 });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 7),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 7),
                             { 0, 6, height }, { 32, 32, 3 });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -11038,25 +11233,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 1),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 1),
                             { 6, 0, height }, { 20, 32, 3 });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 4),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 4),
                             { 6, 0, height }, { 20, 34, 3 });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 6),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 6),
                             { 6, 0, height }, { 20, 32, 3 });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 8),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 8),
                             { 6, 0, height }, { 20, 32, 3 });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -11087,29 +11282,33 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 9),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 9),
                             { 0, 6, height }, { 32, 32, 3 });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 11),
-                            { 0, 6, height }, { 32, 20, 3 });
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 11), { 0, 6, height },
+                            { 32, 20, 3 });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 13),
-                            { 0, 6, height }, { 32, 20, 3 });
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 13), { 0, 6, height },
+                            { 32, 20, 3 });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 14),
-                            { 0, 6, height }, { 34, 1, 26 }, { 0, 27, height });
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 14), { 0, 6, height },
+                            { 34, 1, 26 }, { 0, 27, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 16),
-                            { 0, 6, height }, { 32, 20, 3 });
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 16), { 0, 6, height },
+                            { 32, 20, 3 });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
@@ -11149,26 +11348,30 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 10),
-                            { 6, 0, height }, { 20, 32, 3 });
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 10), { 6, 0, height },
+                            { 20, 32, 3 });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 12),
-                            { 6, 0, height }, { 20, 32, 3 });
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 12), { 6, 0, height },
+                            { 20, 32, 3 });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 15),
-                            { 6, 0, height }, { 20, 34, 3 });
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 15), { 6, 0, height },
+                            { 20, 34, 3 });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 17),
-                            { 6, 0, height }, { 20, 32, 3 });
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 17), { 6, 0, height },
+                            { 20, 32, 3 });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
@@ -11198,26 +11401,30 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 12),
-                            { 0, 6, height }, { 32, 20, 3 });
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 12), { 0, 6, height },
+                            { 32, 20, 3 });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 15),
-                            { 0, 6, height }, { 34, 20, 3 });
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 15), { 0, 6, height },
+                            { 34, 20, 3 });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 17),
-                            { 0, 6, height }, { 32, 20, 3 });
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 17), { 0, 6, height },
+                            { 32, 20, 3 });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 10),
-                            { 0, 6, height }, { 32, 20, 3 });
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 10), { 0, 6, height },
+                            { 32, 20, 3 });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
@@ -11257,28 +11464,32 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 11),
-                            { 6, 0, height }, { 20, 32, 3 });
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 11), { 6, 0, height },
+                            { 20, 32, 3 });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 13),
-                            { 6, 0, height }, { 20, 32, 3 });
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 13), { 6, 0, height },
+                            { 20, 32, 3 });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 14),
-                            { 6, 0, height }, { 1, 34, 26 }, { 27, 0, height });
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 14), { 6, 0, height },
+                            { 1, 34, 26 }, { 27, 0, height });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 16),
-                            { 6, 0, height }, { 20, 32, 3 });
+                            session, direction,
+                            GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 16), { 6, 0, height },
+                            { 20, 32, 3 });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 9),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 9),
                             { 6, 0, height }, { 32, 32, 3 });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -11309,25 +11520,25 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 8),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 8),
                             { 0, 6, height }, { 32, 20, 3 });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 1),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 1),
                             { 0, 6, height }, { 32, 20, 3 });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 4),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 4),
                             { 0, 6, height }, { 34, 20, 3 });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 6),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 6),
                             { 0, 6, height }, { 32, 20, 3 });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -11368,28 +11579,28 @@ namespace HybridRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 7),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 7),
                             { 6, 0, height }, { 32, 32, 3 });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 0),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 0),
                             { 6, 0, height }, { 20, 32, 3 });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 2),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 2),
                             { 6, 0, height }, { 20, 32, 3 });
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 3),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 3),
                             { 6, 0, height }, { 1, 34, 26 }, { 27, 0, height });
                         wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 5),
+                            session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 5),
                             { 6, 0, height }, { 20, 32, 3 });
                         wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;

--- a/src/openrct2/ride/coaster/InvertedHairpinCoaster.cpp
+++ b/src/openrct2/ride/coaster/InvertedHairpinCoaster.cpp
@@ -29,23 +29,23 @@ static void inverted_hairpin_rc_track_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17030, { 0, 0, height + 24 }, { 32, 20, 1 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17030), { 0, 0, height + 24 },
+                    { 32, 20, 1 }, { 0, 6, height + 22 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17031, { 0, 0, height + 24 }, { 32, 20, 1 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17031), { 0, 0, height + 24 },
+                    { 32, 20, 1 }, { 0, 6, height + 22 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17032, { 0, 0, height + 24 }, { 32, 20, 1 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17032), { 0, 0, height + 24 },
+                    { 32, 20, 1 }, { 0, 6, height + 22 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17033, { 0, 0, height + 24 }, { 32, 20, 1 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17033), { 0, 0, height + 24 },
+                    { 32, 20, 1 }, { 0, 6, height + 22 });
                 break;
         }
     }
@@ -56,14 +56,14 @@ static void inverted_hairpin_rc_track_flat(
             case 0:
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17026, { 0, 0, height + 24 }, { 32, 20, 1 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17026), { 0, 0, height + 24 },
+                    { 32, 20, 1 }, { 0, 6, height + 22 });
                 break;
             case 1:
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17027, { 0, 0, height + 24 }, { 32, 20, 1 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17027), { 0, 0, height + 24 },
+                    { 32, 20, 1 }, { 0, 6, height + 22 });
                 break;
         }
     }
@@ -93,13 +93,13 @@ static void inverted_hairpin_rc_track_station(
     };
 
     PaintAddImageAsParentRotated(
-        session, direction, imageIds[direction][0] | session.TrackColours[SCHEME_MISC], { 0, 0, height }, { 32, 28, 1 },
-        { 0, 2, height });
+        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][0]), { 0, 0, height },
+        { 32, 28, 1 }, { 0, 2, height });
     PaintAddImageAsParentRotated(
-        session, direction, imageIds[direction][1] | session.TrackColours[SCHEME_TRACK], { 0, 0, height + 24 }, { 32, 20, 3 },
-        { 0, 6, height + 24 });
+        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][1]), { 0, 0, height + 24 },
+        { 32, 20, 3 }, { 0, 6, height + 24 });
     PaintAddImageAsChildRotated(
-        session, direction, imageIds[direction][2] | session.TrackColours[SCHEME_SUPPORTS], { 0, 6, height + 24 },
+        session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(imageIds[direction][2]), { 0, 6, height + 24 },
         { 32, 20, 1 }, { 0, 6, height + 24 });
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], 11);
     track_paint_util_draw_station_inverted(session, ride, direction, height, trackElement, STATION_VARIANT_1);
@@ -119,23 +119,23 @@ static void inverted_hairpin_rc_track_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17070, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17070), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 40 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17071, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17071), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 40 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17072, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17072), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 40 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17073, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17073), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 40 });
                 break;
         }
     }
@@ -145,23 +145,23 @@ static void inverted_hairpin_rc_track_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17042, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17042), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 40 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17043, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17043), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 40 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17044, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17044), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 40 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17045, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17045), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 40 });
                 break;
         }
     }
@@ -213,23 +213,23 @@ static void inverted_hairpin_rc_track_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17086, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 88 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17086), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 88 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17087, { 0, 0, height + 24 }, { 32, 2, 81 },
-                    { 0, 4, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17087), { 0, 0, height + 24 },
+                    { 32, 2, 81 }, { 0, 4, height + 6 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17088, { 0, 0, height + 24 }, { 32, 2, 81 },
-                    { 0, 4, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17088), { 0, 0, height + 24 },
+                    { 32, 2, 81 }, { 0, 4, height + 6 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17089, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 88 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17089), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 88 });
                 break;
         }
     }
@@ -239,23 +239,23 @@ static void inverted_hairpin_rc_track_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17058, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 88 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17058), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 88 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17059, { 0, 0, height + 24 }, { 32, 2, 81 },
-                    { 0, 4, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17059), { 0, 0, height + 24 },
+                    { 32, 2, 81 }, { 0, 4, height + 6 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17060, { 0, 0, height + 24 }, { 32, 2, 81 },
-                    { 0, 4, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17060), { 0, 0, height + 24 },
+                    { 32, 2, 81 }, { 0, 4, height + 6 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17061, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 88 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17061), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 88 });
                 break;
         }
     }
@@ -283,23 +283,23 @@ static void inverted_hairpin_rc_track_flat_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17062, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17062), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17063, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17063), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17064, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17064), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17065, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17065), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
         }
     }
@@ -309,23 +309,23 @@ static void inverted_hairpin_rc_track_flat_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17034, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17034), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17035, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17035), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17036, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17036), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17037, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17037), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
         }
     }
@@ -377,29 +377,29 @@ static void inverted_hairpin_rc_track_25_deg_up_to_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17074, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 56 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17074), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 56 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17078, { 0, 0, height + 24 }, { 32, 10, 49 },
-                    { 0, 10, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17078), { 0, 0, height + 24 },
+                    { 32, 10, 49 }, { 0, 10, height + 6 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17075, { 0, 0, height + 24 }, { 32, 2, 49 },
-                    { 0, 4, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17075), { 0, 0, height + 24 },
+                    { 32, 2, 49 }, { 0, 4, height + 6 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17079, { 0, 0, height + 24 }, { 32, 10, 49 },
-                    { 0, 10, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17079), { 0, 0, height + 24 },
+                    { 32, 10, 49 }, { 0, 10, height + 6 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17076, { 0, 0, height + 24 }, { 32, 2, 49 },
-                    { 0, 4, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17076), { 0, 0, height + 24 },
+                    { 32, 2, 49 }, { 0, 4, height + 6 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17077, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 56 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17077), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 56 });
                 break;
         }
     }
@@ -409,29 +409,29 @@ static void inverted_hairpin_rc_track_25_deg_up_to_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17046, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 56 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17046), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 56 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17050, { 0, 0, height + 24 }, { 32, 10, 49 },
-                    { 0, 10, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17050), { 0, 0, height + 24 },
+                    { 32, 10, 49 }, { 0, 10, height + 6 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17047, { 0, 0, height + 24 }, { 32, 2, 49 },
-                    { 0, 4, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17047), { 0, 0, height + 24 },
+                    { 32, 2, 49 }, { 0, 4, height + 6 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17051, { 0, 0, height + 24 }, { 32, 10, 49 },
-                    { 0, 10, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17051), { 0, 0, height + 24 },
+                    { 32, 10, 49 }, { 0, 10, height + 6 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17048, { 0, 0, height + 24 }, { 32, 2, 49 },
-                    { 0, 4, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17048), { 0, 0, height + 24 },
+                    { 32, 2, 49 }, { 0, 4, height + 6 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17049, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 56 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17049), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 56 });
                 break;
         }
     }
@@ -459,29 +459,29 @@ static void inverted_hairpin_rc_track_60_deg_up_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17080, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 56 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17080), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 56 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17084, { 0, 0, height + 24 }, { 32, 10, 49 },
-                    { 0, 10, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17084), { 0, 0, height + 24 },
+                    { 32, 10, 49 }, { 0, 10, height + 6 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17081, { 0, 0, height + 24 }, { 32, 2, 49 },
-                    { 0, 4, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17081), { 0, 0, height + 24 },
+                    { 32, 2, 49 }, { 0, 4, height + 6 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17085, { 0, 0, height + 24 }, { 32, 10, 49 },
-                    { 0, 10, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17085), { 0, 0, height + 24 },
+                    { 32, 10, 49 }, { 0, 10, height + 6 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17082, { 0, 0, height + 24 }, { 32, 2, 49 },
-                    { 0, 4, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17082), { 0, 0, height + 24 },
+                    { 32, 2, 49 }, { 0, 4, height + 6 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17083, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 56 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17083), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 56 });
                 break;
         }
     }
@@ -491,29 +491,29 @@ static void inverted_hairpin_rc_track_60_deg_up_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17052, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 56 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17052), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 56 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17056, { 0, 0, height + 24 }, { 32, 10, 49 },
-                    { 0, 10, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17056), { 0, 0, height + 24 },
+                    { 32, 10, 49 }, { 0, 10, height + 6 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17053, { 0, 0, height + 24 }, { 32, 2, 49 },
-                    { 0, 4, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17053), { 0, 0, height + 24 },
+                    { 32, 2, 49 }, { 0, 4, height + 6 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17057, { 0, 0, height + 24 }, { 32, 10, 49 },
-                    { 0, 10, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17057), { 0, 0, height + 24 },
+                    { 32, 10, 49 }, { 0, 10, height + 6 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17054, { 0, 0, height + 24 }, { 32, 2, 49 },
-                    { 0, 4, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17054), { 0, 0, height + 24 },
+                    { 32, 2, 49 }, { 0, 4, height + 6 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17055, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 56 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17055), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 56 });
                 break;
         }
     }
@@ -565,23 +565,23 @@ static void inverted_hairpin_rc_track_25_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17066, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17066), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17067, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17067), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17068, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17068), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17069, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17069), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
         }
     }
@@ -591,23 +591,23 @@ static void inverted_hairpin_rc_track_25_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17038, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17038), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17039, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17039), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17040, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17040), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17041, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17041), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
         }
     }
@@ -708,23 +708,23 @@ static void inverted_hairpin_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17123, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 22 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17123), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 22 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17126, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 22 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17126), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 22 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17129, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 22 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17129), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 22 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17120, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 22 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17120), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 22 });
                     break;
             }
 
@@ -748,23 +748,23 @@ static void inverted_hairpin_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17122, { 0, 0, height + 24 }, { 16, 16, 3 },
-                        { 16, 0, height + 22 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17122), { 0, 0, height + 24 },
+                        { 16, 16, 3 }, { 16, 0, height + 22 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17125, { 0, 0, height + 24 }, { 16, 16, 3 },
-                        { 0, 0, height + 22 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17125), { 0, 0, height + 24 },
+                        { 16, 16, 3 }, { 0, 0, height + 22 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17128, { 0, 0, height + 24 }, { 16, 16, 3 },
-                        { 0, 16, height + 22 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17128), { 0, 0, height + 24 },
+                        { 16, 16, 3 }, { 0, 16, height + 22 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17119, { 0, 0, height + 24 }, { 16, 16, 3 },
-                        { 16, 16, height + 22 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17119), { 0, 0, height + 24 },
+                        { 16, 16, 3 }, { 16, 16, height + 22 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -776,23 +776,23 @@ static void inverted_hairpin_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17121, { 0, 0, height + 24 }, { 20, 32, 3 },
-                        { 6, 0, height + 22 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17121), { 0, 0, height + 24 },
+                        { 20, 32, 3 }, { 6, 0, height + 22 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17124, { 0, 0, height + 24 }, { 20, 32, 3 },
-                        { 6, 0, height + 22 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17124), { 0, 0, height + 24 },
+                        { 20, 32, 3 }, { 6, 0, height + 22 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17127, { 0, 0, height + 24 }, { 20, 32, 3 },
-                        { 6, 0, height + 22 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17127), { 0, 0, height + 24 },
+                        { 20, 32, 3 }, { 6, 0, height + 22 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17118, { 0, 0, height + 24 }, { 20, 32, 3 },
-                        { 6, 0, height + 22 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17118), { 0, 0, height + 24 },
+                        { 20, 32, 3 }, { 6, 0, height + 22 });
                     break;
             }
 
@@ -837,19 +837,23 @@ static void inverted_hairpin_rc_track_left_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17141, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17141), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17143, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17143), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17145, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17145), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17139, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17139), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
             }
 
@@ -876,19 +880,23 @@ static void inverted_hairpin_rc_track_left_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17140, { 6, 0, height + 24 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17140), { 6, 0, height + 24 },
+                        { 20, 32, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17142, { 6, 0, height + 24 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17142), { 6, 0, height + 24 },
+                        { 20, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17144, { 6, 0, height + 24 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17144), { 6, 0, height + 24 },
+                        { 20, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17138, { 6, 0, height + 24 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17138), { 6, 0, height + 24 },
+                        { 20, 32, 3 });
                     break;
             }
 
@@ -924,19 +932,23 @@ static void inverted_hairpin_rc_track_right_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17130, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17130), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17132, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17132), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17134, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17134), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17136, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17136), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
             }
 
@@ -963,19 +975,23 @@ static void inverted_hairpin_rc_track_right_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17131, { 6, 0, height + 24 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17131), { 6, 0, height + 24 },
+                        { 20, 32, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17133, { 6, 0, height + 24 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17133), { 6, 0, height + 24 },
+                        { 20, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17135, { 6, 0, height + 24 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17135), { 6, 0, height + 24 },
+                        { 20, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 17137, { 6, 0, height + 24 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17137), { 6, 0, height + 24 },
+                        { 20, 32, 3 });
                     break;
             }
 
@@ -1028,22 +1044,22 @@ static void inverted_hairpin_rc_track_left_quarter_turn_1(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17114, { 0, 0, height + 24 }, { 26, 24, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17114), { 0, 0, height + 24 }, { 26, 24, 3 },
                 { 6, 2, height + 24 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17115, { 0, 0, height + 24 }, { 26, 26, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17115), { 0, 0, height + 24 }, { 26, 26, 3 },
                 { 0, 0, height + 24 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17116, { 0, 0, height + 24 }, { 24, 26, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17116), { 0, 0, height + 24 }, { 24, 26, 3 },
                 { 2, 6, height + 24 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17117, { 0, 0, height + 24 }, { 24, 24, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17117), { 0, 0, height + 24 }, { 24, 24, 3 },
                 { 6, 6, height + 24 });
             break;
     }
@@ -1088,29 +1104,29 @@ static void inverted_hairpin_rc_track_flat_to_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17102, { 0, 0, height + 24 }, { 30, 20, 3 },
-                    { 0, 6, height + 56 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17102), { 0, 0, height + 24 },
+                    { 30, 20, 3 }, { 0, 6, height + 56 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17106, { 0, 0, height + 24 }, { 32, 10, 49 },
-                    { 0, 10, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17106), { 0, 0, height + 24 },
+                    { 32, 10, 49 }, { 0, 10, height + 6 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17103, { 0, 0, height + 24 }, { 32, 2, 49 },
-                    { 0, 4, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17103), { 0, 0, height + 24 },
+                    { 32, 2, 49 }, { 0, 4, height + 6 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17107, { 0, 0, height + 24 }, { 32, 10, 49 },
-                    { 0, 10, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17107), { 0, 0, height + 24 },
+                    { 32, 10, 49 }, { 0, 10, height + 6 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17104, { 0, 0, height + 24 }, { 32, 2, 49 },
-                    { 0, 4, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17104), { 0, 0, height + 24 },
+                    { 32, 2, 49 }, { 0, 4, height + 6 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17105, { 0, 0, height + 24 }, { 30, 20, 3 },
-                    { 0, 6, height + 56 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17105), { 0, 0, height + 24 },
+                    { 30, 20, 3 }, { 0, 6, height + 56 });
                 break;
         }
     }
@@ -1120,29 +1136,29 @@ static void inverted_hairpin_rc_track_flat_to_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17090, { 0, 0, height + 24 }, { 30, 20, 3 },
-                    { 0, 6, height + 56 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17090), { 0, 0, height + 24 },
+                    { 30, 20, 3 }, { 0, 6, height + 56 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17094, { 0, 0, height + 24 }, { 32, 10, 49 },
-                    { 0, 10, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17094), { 0, 0, height + 24 },
+                    { 32, 10, 49 }, { 0, 10, height + 6 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17091, { 0, 0, height + 24 }, { 32, 2, 49 },
-                    { 0, 4, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17091), { 0, 0, height + 24 },
+                    { 32, 2, 49 }, { 0, 4, height + 6 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17095, { 0, 0, height + 24 }, { 32, 10, 49 },
-                    { 0, 10, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17095), { 0, 0, height + 24 },
+                    { 32, 10, 49 }, { 0, 10, height + 6 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17092, { 0, 0, height + 24 }, { 32, 2, 49 },
-                    { 0, 4, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17092), { 0, 0, height + 24 },
+                    { 32, 2, 49 }, { 0, 4, height + 6 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17093, { 0, 0, height + 24 }, { 30, 20, 3 },
-                    { 0, 6, height + 56 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17093), { 0, 0, height + 24 },
+                    { 30, 20, 3 }, { 0, 6, height + 56 });
                 break;
         }
     }
@@ -1170,29 +1186,29 @@ static void inverted_hairpin_rc_track_60_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17108, { 0, 0, height + 24 }, { 30, 20, 3 },
-                    { 0, 6, height + 48 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17108), { 0, 0, height + 24 },
+                    { 30, 20, 3 }, { 0, 6, height + 48 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17112, { 0, 0, height + 24 }, { 32, 10, 41 },
-                    { 0, 10, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17112), { 0, 0, height + 24 },
+                    { 32, 10, 41 }, { 0, 10, height + 6 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17109, { 0, 0, height + 24 }, { 32, 2, 41 },
-                    { 0, 4, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17109), { 0, 0, height + 24 },
+                    { 32, 2, 41 }, { 0, 4, height + 6 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17113, { 0, 0, height + 24 }, { 32, 10, 41 },
-                    { 0, 10, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17113), { 0, 0, height + 24 },
+                    { 32, 10, 41 }, { 0, 10, height + 6 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17110, { 0, 0, height + 24 }, { 32, 2, 41 },
-                    { 0, 4, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17110), { 0, 0, height + 24 },
+                    { 32, 2, 41 }, { 0, 4, height + 6 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17111, { 0, 0, height + 24 }, { 30, 20, 3 },
-                    { 0, 6, height + 48 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17111), { 0, 0, height + 24 },
+                    { 30, 20, 3 }, { 0, 6, height + 48 });
                 break;
         }
     }
@@ -1202,29 +1218,29 @@ static void inverted_hairpin_rc_track_60_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17096, { 0, 0, height + 24 }, { 30, 20, 3 },
-                    { 0, 6, height + 48 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17096), { 0, 0, height + 24 },
+                    { 30, 20, 3 }, { 0, 6, height + 48 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17100, { 0, 0, height + 24 }, { 32, 10, 41 },
-                    { 0, 10, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17100), { 0, 0, height + 24 },
+                    { 32, 10, 41 }, { 0, 10, height + 6 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17097, { 0, 0, height + 24 }, { 32, 2, 41 },
-                    { 0, 4, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17097), { 0, 0, height + 24 },
+                    { 32, 2, 41 }, { 0, 4, height + 6 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17101, { 0, 0, height + 24 }, { 32, 10, 41 },
-                    { 0, 10, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17101), { 0, 0, height + 24 },
+                    { 32, 10, 41 }, { 0, 10, height + 6 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17098, { 0, 0, height + 24 }, { 32, 2, 41 },
-                    { 0, 4, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17098), { 0, 0, height + 24 },
+                    { 32, 2, 41 }, { 0, 4, height + 6 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 17099, { 0, 0, height + 24 }, { 30, 20, 3 },
-                    { 0, 6, height + 48 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17099), { 0, 0, height + 24 },
+                    { 30, 20, 3 }, { 0, 6, height + 48 });
                 break;
         }
     }
@@ -1288,13 +1304,13 @@ static void inverted_hairpin_rc_track_brakes(
         case 0:
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17028, { 0, 0, height + 24 }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17028), { 0, 0, height + 24 }, { 32, 20, 1 },
                 { 0, 6, height + 22 });
             break;
         case 1:
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17029, { 0, 0, height + 24 }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17029), { 0, 0, height + 24 }, { 32, 20, 1 },
                 { 0, 6, height + 22 });
             break;
     }
@@ -1321,13 +1337,13 @@ static void inverted_hairpin_rc_track_block_brakes(
         case 0:
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17028, { 0, 0, height + 24 }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17028), { 0, 0, height + 24 }, { 32, 20, 1 },
                 { 0, 6, height + 22 });
             break;
         case 1:
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 17029, { 0, 0, height + 24 }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(17029), { 0, 0, height + 24 }, { 32, 20, 1 },
                 { 0, 6, height + 22 });
             break;
     }

--- a/src/openrct2/ride/coaster/InvertedImpulseCoaster.cpp
+++ b/src/openrct2/ride/coaster/InvertedImpulseCoaster.cpp
@@ -28,13 +28,13 @@ static void inverted_impulse_rc_track_flat(
         case 0:
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19662, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19662), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
         case 1:
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19663, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19663), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
     }
@@ -64,13 +64,13 @@ static void inverted_impulse_rc_track_station(
     };
 
     PaintAddImageAsParentRotated(
-        session, direction, imageIds[direction][0] | session.TrackColours[SCHEME_MISC], { 0, 0, height }, { 32, 28, 1 },
-        { 0, 2, height });
+        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][0]), { 0, 0, height },
+        { 32, 28, 1 }, { 0, 2, height });
     PaintAddImageAsParentRotated(
-        session, direction, imageIds[direction][1] | session.TrackColours[SCHEME_TRACK], { 0, 0, height + 29 }, { 32, 20, 3 },
-        { 0, 6, height + 29 });
+        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][1]), { 0, 0, height + 29 },
+        { 32, 20, 3 }, { 0, 6, height + 29 });
     PaintAddImageAsChildRotated(
-        session, direction, imageIds[direction][2] | session.TrackColours[SCHEME_SUPPORTS], { 0, 6, height + 29 },
+        session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(imageIds[direction][2]), { 0, 6, height + 29 },
         { 32, 20, 3 }, { 0, 6, height + 29 });
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], 11);
     track_paint_util_draw_station_inverted(session, ride, direction, height, trackElement, STATION_VARIANT_TALL);
@@ -88,22 +88,22 @@ static void inverted_impulse_rc_track_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19672, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19672), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 45 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19673, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19673), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 45 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19674, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19674), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 45 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19675, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19675), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 45 });
             break;
     }
@@ -153,22 +153,22 @@ static void inverted_impulse_rc_track_60_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19688, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19688), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 93 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19689, { 0, 0, height + 29 }, { 32, 2, 81 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19689), { 0, 0, height + 29 }, { 32, 2, 81 },
                 { 0, 4, height + 11 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19690, { 0, 0, height + 29 }, { 32, 2, 81 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19690), { 0, 0, height + 29 }, { 32, 2, 81 },
                 { 0, 4, height + 11 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19691, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19691), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 93 });
             break;
     }
@@ -194,22 +194,22 @@ static void inverted_impulse_rc_track_flat_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19664, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19664), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19665, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19665), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19666, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19666), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19667, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19667), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
     }
@@ -256,28 +256,28 @@ static void inverted_impulse_rc_track_25_deg_up_to_60_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19676, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19676), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 61 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19680, { 0, 0, height + 29 }, { 32, 10, 49 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19680), { 0, 0, height + 29 }, { 32, 10, 49 },
                 { 0, 10, height + 11 });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19677, { 0, 0, height + 29 }, { 32, 2, 49 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19677), { 0, 0, height + 29 }, { 32, 2, 49 },
                 { 0, 4, height + 11 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19681, { 0, 0, height + 29 }, { 32, 10, 49 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19681), { 0, 0, height + 29 }, { 32, 10, 49 },
                 { 0, 10, height + 11 });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19678, { 0, 0, height + 29 }, { 32, 2, 49 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19678), { 0, 0, height + 29 }, { 32, 2, 49 },
                 { 0, 4, height + 11 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19679, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19679), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 61 });
             break;
     }
@@ -303,28 +303,28 @@ static void inverted_impulse_rc_track_60_deg_up_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19682, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19682), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 61 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19686, { 0, 0, height + 29 }, { 32, 10, 49 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19686), { 0, 0, height + 29 }, { 32, 10, 49 },
                 { 0, 10, height + 11 });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19683, { 0, 0, height + 29 }, { 32, 2, 49 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19683), { 0, 0, height + 29 }, { 32, 2, 49 },
                 { 0, 4, height + 11 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19687, { 0, 0, height + 29 }, { 32, 10, 49 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19687), { 0, 0, height + 29 }, { 32, 10, 49 },
                 { 0, 10, height + 11 });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19684, { 0, 0, height + 29 }, { 32, 2, 49 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19684), { 0, 0, height + 29 }, { 32, 2, 49 },
                 { 0, 4, height + 11 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19685, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19685), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 61 });
             break;
     }
@@ -350,22 +350,22 @@ static void inverted_impulse_rc_track_25_deg_up_to_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19668, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19668), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19669, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19669), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19670, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19670), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19671, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19671), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
     }
@@ -463,23 +463,23 @@ static void inverted_impulse_rc_track_90_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19700, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 61 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19700), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 61 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19701, { 0, 0, height + 29 }, { 32, 2, 31 },
-                        { 0, 4, height + 11 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19701), { 0, 0, height + 29 },
+                        { 32, 2, 31 }, { 0, 4, height + 11 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19702, { 0, 0, height + 29 }, { 32, 2, 31 },
-                        { 0, 4, height + 11 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19702), { 0, 0, height + 29 },
+                        { 32, 2, 31 }, { 0, 4, height + 11 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19703, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 61 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19703), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 61 });
                     break;
             }
             paint_util_set_vertical_tunnel(session, height + 32);
@@ -512,23 +512,23 @@ static void inverted_impulse_rc_track_60_deg_up_to_90_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19692, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 85 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19692), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 85 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19693, { 0, 0, height + 29 }, { 32, 2, 55 },
-                        { 0, 4, height + 11 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19693), { 0, 0, height + 29 },
+                        { 32, 2, 55 }, { 0, 4, height + 11 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19694, { 0, 0, height + 29 }, { 32, 2, 55 },
-                        { 0, 4, height + 11 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19694), { 0, 0, height + 29 },
+                        { 32, 2, 55 }, { 0, 4, height + 11 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19695, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 85 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19695), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 85 });
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -562,22 +562,22 @@ static void inverted_impulse_rc_track_90_deg_up_to_60_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19696, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19696), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 85 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19697, { 0, 0, height + 29 }, { 32, 2, 55 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19697), { 0, 0, height + 29 }, { 32, 2, 55 },
                 { 0, 4, height + 11 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19698, { 0, 0, height + 29 }, { 32, 2, 55 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19698), { 0, 0, height + 29 }, { 32, 2, 55 },
                 { 0, 4, height + 11 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19699, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19699), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 85 });
             break;
     }
@@ -607,23 +607,23 @@ static void inverted_impulse_rc_track_60_deg_down_to_90_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19698, { 0, 0, height + 29 }, { 32, 2, 55 },
-                        { 0, 4, height + 11 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19698), { 0, 0, height + 29 },
+                        { 32, 2, 55 }, { 0, 4, height + 11 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19699, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 85 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19699), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 85 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19696, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 85 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19696), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 85 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19697, { 0, 0, height + 29 }, { 32, 2, 55 },
-                        { 0, 4, height + 11 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19697), { 0, 0, height + 29 },
+                        { 32, 2, 55 }, { 0, 4, height + 11 });
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -651,32 +651,32 @@ static void inverted_impulse_rc_track_left_quarter_turn_1_90_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19708, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 125 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19708), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 125 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19709, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 125 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19709), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 125 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19717, { 0, 0, height + 29 }, { 2, 32, 31 },
-                        { 4, 0, height + 11 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19717), { 0, 0, height + 29 },
+                        { 2, 32, 31 }, { 4, 0, height + 11 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19710, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 125 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19710), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 125 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19718, { 0, 0, height + 29 }, { 32, 2, 31 },
-                        { 0, 4, height + 11 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19718), { 0, 0, height + 29 },
+                        { 32, 2, 31 }, { 0, 4, height + 11 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19711, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 125 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19711), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 125 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19719, { 0, 0, height + 29 }, { 32, 2, 31 },
-                        { 0, 4, height + 11 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19719), { 0, 0, height + 29 },
+                        { 32, 2, 31 }, { 0, 4, height + 11 });
                     break;
             }
             paint_util_set_vertical_tunnel(session, height + 96);
@@ -701,32 +701,32 @@ static void inverted_impulse_rc_track_right_quarter_turn_1_90_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19704, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 125 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19704), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 125 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19712, { 0, 0, height + 29 }, { 32, 2, 31 },
-                        { 0, 4, height + 11 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19712), { 0, 0, height + 29 },
+                        { 32, 2, 31 }, { 0, 4, height + 11 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19705, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 125 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19705), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 125 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19713, { 0, 0, height + 29 }, { 32, 2, 31 },
-                        { 0, 4, height + 11 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19713), { 0, 0, height + 29 },
+                        { 32, 2, 31 }, { 0, 4, height + 11 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19706, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 125 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19706), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 125 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19714, { 0, 0, height + 29 }, { 32, 2, 31 },
-                        { 0, 4, height + 11 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19714), { 0, 0, height + 29 },
+                        { 32, 2, 31 }, { 0, 4, height + 11 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19707, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 125 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19707), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 125 });
                     break;
             }
             paint_util_set_vertical_tunnel(session, height + 96);

--- a/src/openrct2/ride/coaster/InvertedRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/InvertedRollerCoaster.cpp
@@ -30,14 +30,14 @@ static void inverted_rc_track_flat(
             case 0:
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27131, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 29 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27131), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 29 });
                 break;
             case 1:
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27132, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 29 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27132), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 29 });
                 break;
         }
     }
@@ -48,14 +48,14 @@ static void inverted_rc_track_flat(
             case 0:
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27129, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 29 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27129), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 29 });
                 break;
             case 1:
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27130, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 29 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27130), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 29 });
                 break;
         }
     }
@@ -84,13 +84,13 @@ static void inverted_rc_track_station(
     };
 
     PaintAddImageAsParentRotated(
-        session, direction, imageIds[direction][0] | session.TrackColours[SCHEME_MISC], { 0, 0, height }, { 32, 28, 1 },
-        { 0, 2, height });
+        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][0]), { 0, 0, height },
+        { 32, 28, 1 }, { 0, 2, height });
     PaintAddImageAsParentRotated(
-        session, direction, imageIds[direction][1] | session.TrackColours[SCHEME_TRACK], { 0, 0, height + 29 }, { 32, 20, 3 },
-        { 0, 6, height + 29 });
+        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][1]), { 0, 0, height + 29 },
+        { 32, 20, 3 }, { 0, 6, height + 29 });
     PaintAddImageAsChildRotated(
-        session, direction, imageIds[direction][2] | session.TrackColours[SCHEME_SUPPORTS], { 0, 6, height + 29 },
+        session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(imageIds[direction][2]), { 0, 6, height + 29 },
         { 32, 20, 3 }, { 0, 6, height + 29 });
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], 3);
     track_paint_util_draw_station_inverted(session, ride, direction, height, trackElement, STATION_VARIANT_TALL);
@@ -110,23 +110,23 @@ static void inverted_rc_track_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27249, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 45 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27249), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 45 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27250, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 45 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27250), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 45 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27251, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 45 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27251), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 45 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27252, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 45 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27252), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 45 });
                 break;
         }
     }
@@ -136,23 +136,23 @@ static void inverted_rc_track_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27221, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 45 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27221), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 45 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27222, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 45 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27222), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 45 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27223, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 45 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27223), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 45 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27224, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 45 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27224), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 45 });
                 break;
         }
     }
@@ -202,22 +202,22 @@ static void inverted_rc_track_60_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27237, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27237), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 93 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27238, { 0, 0, height + 29 }, { 32, 2, 81 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27238), { 0, 0, height + 29 }, { 32, 2, 81 },
                 { 0, 4, height + 11 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27239, { 0, 0, height + 29 }, { 32, 2, 81 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27239), { 0, 0, height + 29 }, { 32, 2, 81 },
                 { 0, 4, height + 11 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27240, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27240), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 93 });
             break;
     }
@@ -245,23 +245,23 @@ static void inverted_rc_track_flat_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27241, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27241), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27242, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27242), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27243, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27243), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27244, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27244), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
         }
     }
@@ -271,23 +271,23 @@ static void inverted_rc_track_flat_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27213, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27213), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27214, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27214), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27215, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27215), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27216, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27216), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
         }
     }
@@ -337,28 +337,28 @@ static void inverted_rc_track_25_deg_up_to_60_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27225, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27225), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 61 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27229, { 0, 0, height + 29 }, { 32, 10, 49 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27229), { 0, 0, height + 29 }, { 32, 10, 49 },
                 { 0, 10, height + 11 });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27226, { 0, 0, height + 29 }, { 32, 2, 49 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27226), { 0, 0, height + 29 }, { 32, 2, 49 },
                 { 0, 4, height + 11 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27230, { 0, 0, height + 29 }, { 32, 10, 49 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27230), { 0, 0, height + 29 }, { 32, 10, 49 },
                 { 0, 10, height + 11 });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27227, { 0, 0, height + 29 }, { 32, 2, 49 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27227), { 0, 0, height + 29 }, { 32, 2, 49 },
                 { 0, 4, height + 11 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27228, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27228), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 61 });
             break;
     }
@@ -384,28 +384,28 @@ static void inverted_rc_track_60_deg_up_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27231, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27231), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 61 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27235, { 0, 0, height + 29 }, { 32, 10, 49 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27235), { 0, 0, height + 29 }, { 32, 10, 49 },
                 { 0, 10, height + 11 });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27232, { 0, 0, height + 29 }, { 32, 2, 49 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27232), { 0, 0, height + 29 }, { 32, 2, 49 },
                 { 0, 4, height + 11 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27236, { 0, 0, height + 29 }, { 32, 10, 49 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27236), { 0, 0, height + 29 }, { 32, 10, 49 },
                 { 0, 10, height + 11 });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27233, { 0, 0, height + 29 }, { 32, 2, 49 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27233), { 0, 0, height + 29 }, { 32, 2, 49 },
                 { 0, 4, height + 11 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27234, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27234), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 61 });
             break;
     }
@@ -457,23 +457,23 @@ static void inverted_rc_track_25_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27245, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27245), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27246, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27246), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27247, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27247), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27248, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27248), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
         }
     }
@@ -483,23 +483,23 @@ static void inverted_rc_track_25_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27217, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27217), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27218, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27218), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27219, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27219), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 27220, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27220), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
         }
     }
@@ -600,23 +600,23 @@ static void inverted_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27142, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27142), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27147, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27147), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27152, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27152), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27137, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27137), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
             }
 
@@ -640,21 +640,23 @@ static void inverted_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27141, { 0, 0, height + 29 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27141), { 0, 0, height + 29 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27146, { 0, 0, height + 29 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27146), { 0, 0, height + 29 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27151, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27151), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27136, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27136), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -669,22 +671,23 @@ static void inverted_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27140, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27140), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 16, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27145, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27145), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 16, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27150, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27150), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 0, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27135, { 0, 0, height + 29 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27135), { 0, 0, height + 29 },
+                        { 16, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -699,21 +702,23 @@ static void inverted_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27139, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 16, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27139), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 16, 0, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27144, { 0, 0, height + 29 }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27144), { 0, 0, height + 29 },
+                        { 16, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27149, { 0, 0, height + 29 }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27149), { 0, 0, height + 29 },
+                        { 16, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27134, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 16, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27134), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 16, 0, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -728,23 +733,23 @@ static void inverted_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27138, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27138), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27143, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27143), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27148, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27148), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27133, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27133), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 29 });
                     break;
             }
 
@@ -786,22 +791,22 @@ static void inverted_rc_track_flat_to_left_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27269, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27269), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27270, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27270), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27271, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27271), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27272, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27272), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
     }
@@ -828,22 +833,22 @@ static void inverted_rc_track_flat_to_right_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27273, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27273), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27274, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27274), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27275, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27275), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27276, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27276), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
     }
@@ -870,22 +875,22 @@ static void inverted_rc_track_left_bank_to_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27275, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27275), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27276, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27276), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27273, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27273), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27274, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27274), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
     }
@@ -912,22 +917,22 @@ static void inverted_rc_track_right_bank_to_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27271, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27271), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27272, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27272), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27269, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27269), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27270, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27270), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
     }
@@ -957,23 +962,23 @@ static void inverted_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27162, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27162), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27167, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27167), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27172, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27172), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27157, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27157), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
             }
 
@@ -997,21 +1002,23 @@ static void inverted_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27161, { 0, 0, height + 29 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27161), { 0, 0, height + 29 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27166, { 0, 0, height + 29 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27166), { 0, 0, height + 29 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27171, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27171), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27156, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27156), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1026,22 +1033,23 @@ static void inverted_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27160, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27160), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 16, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27165, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27165), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 16, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27170, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27170), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 0, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27155, { 0, 0, height + 29 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27155), { 0, 0, height + 29 },
+                        { 16, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1056,21 +1064,23 @@ static void inverted_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27159, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 16, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27159), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 16, 0, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27164, { 0, 0, height + 29 }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27164), { 0, 0, height + 29 },
+                        { 16, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27169, { 0, 0, height + 29 }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27169), { 0, 0, height + 29 },
+                        { 16, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27154, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 16, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27154), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 16, 0, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1085,23 +1095,23 @@ static void inverted_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27158, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27158), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27163, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27163), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27168, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27168), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27153, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27153), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 29 });
                     break;
             }
 
@@ -1143,22 +1153,22 @@ static void inverted_rc_track_left_bank_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27277, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27277), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27278, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27278), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27279, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27279), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27280, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27280), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
     }
@@ -1210,22 +1220,22 @@ static void inverted_rc_track_right_bank_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27281, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27281), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27282, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27282), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27283, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27283), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27284, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27284), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
     }
@@ -1277,22 +1287,22 @@ static void inverted_rc_track_25_deg_up_to_left_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27285, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27285), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27286, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27286), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27287, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27287), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27288, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27288), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
     }
@@ -1344,22 +1354,22 @@ static void inverted_rc_track_25_deg_up_to_right_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27289, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27289), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27290, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27290), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27291, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27291), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27292, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27292), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
     }
@@ -1443,22 +1453,22 @@ static void inverted_rc_track_left_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27293, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27293), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27294, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27294), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27295, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27295), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27296, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27296), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
     }
@@ -1496,19 +1506,23 @@ static void inverted_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27317, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27317), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27322, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27322), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27327, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27327), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27332, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27332), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
             }
 
@@ -1532,19 +1546,23 @@ static void inverted_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27318, { 0, 0, height + 29 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27318), { 0, 0, height + 29 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27323, { 0, 0, height + 29 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27323), { 0, 0, height + 29 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27328, { 0, 16, height + 29 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27328), { 0, 16, height + 29 },
+                        { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27333, { 0, 16, height + 29 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27333), { 0, 16, height + 29 },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1559,19 +1577,23 @@ static void inverted_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27319, { 0, 16, height + 29 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27319), { 0, 16, height + 29 },
+                        { 16, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27324, { 16, 16, height + 29 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27324), { 16, 16, height + 29 },
+                        { 16, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27329, { 16, 0, height + 29 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27329), { 16, 0, height + 29 },
+                        { 16, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27334, { 0, 0, height + 29 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27334), { 0, 0, height + 29 },
+                        { 16, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1586,19 +1608,23 @@ static void inverted_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27320, { 16, 0, height + 29 }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27320), { 16, 0, height + 29 },
+                        { 16, 32, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27325, { 0, 0, height + 29 }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27325), { 0, 0, height + 29 },
+                        { 16, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27330, { 0, 0, height + 29 }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27330), { 0, 0, height + 29 },
+                        { 16, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27335, { 16, 0, height + 29 }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27335), { 16, 0, height + 29 },
+                        { 16, 32, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1613,19 +1639,23 @@ static void inverted_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27321, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27321), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27326, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27326), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27331, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27331), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27336, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27336), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
             }
 
@@ -1661,19 +1691,23 @@ static void inverted_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27297, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27297), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27302, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27302), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27307, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27307), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27312, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27312), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
             }
 
@@ -1697,19 +1731,23 @@ static void inverted_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27298, { 0, 16, height + 29 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27298), { 0, 16, height + 29 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27303, { 0, 16, height + 29 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27303), { 0, 16, height + 29 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27308, { 0, 0, height + 29 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27308), { 0, 0, height + 29 },
+                        { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27313, { 0, 0, height + 29 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27313), { 0, 0, height + 29 },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1724,19 +1762,23 @@ static void inverted_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27299, { 0, 0, height + 29 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27299), { 0, 0, height + 29 },
+                        { 16, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27304, { 16, 0, height + 29 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27304), { 16, 0, height + 29 },
+                        { 16, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27309, { 16, 16, height + 29 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27309), { 16, 16, height + 29 },
+                        { 16, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27314, { 0, 16, height + 29 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27314), { 0, 16, height + 29 },
+                        { 16, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1751,19 +1793,23 @@ static void inverted_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27300, { 16, 0, height + 29 }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27300), { 16, 0, height + 29 },
+                        { 16, 32, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27305, { 0, 0, height + 29 }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27305), { 0, 0, height + 29 },
+                        { 16, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27310, { 0, 0, height + 29 }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27310), { 0, 0, height + 29 },
+                        { 16, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27315, { 16, 0, height + 29 }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27315), { 16, 0, height + 29 },
+                        { 16, 32, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1778,19 +1824,23 @@ static void inverted_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27301, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27301), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27306, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27306), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27311, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27311), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27316, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27316), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
             }
 
@@ -1844,23 +1894,23 @@ static void inverted_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27253, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27253), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27257, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27257), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27256, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27256), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27260, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27260), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
             }
 
@@ -1880,21 +1930,23 @@ static void inverted_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27254, { 0, 0, height + 29 }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27254), { 0, 0, height + 29 },
+                        { 32, 26, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27258, { 0, 0, height + 29 }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27258), { 0, 0, height + 29 },
+                        { 32, 26, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27255, { 0, 0, height + 29 }, { 32, 26, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27255), { 0, 0, height + 29 },
+                        { 32, 26, 3 }, { 0, 6, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27259, { 0, 0, height + 29 }, { 32, 26, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27259), { 0, 0, height + 29 },
+                        { 32, 26, 3 }, { 0, 6, height + 29 });
                     break;
             }
 
@@ -1922,21 +1974,23 @@ static void inverted_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27255, { 0, 0, height + 29 }, { 32, 26, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27255), { 0, 0, height + 29 },
+                        { 32, 26, 3 }, { 0, 6, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27259, { 0, 0, height + 29 }, { 32, 26, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27259), { 0, 0, height + 29 },
+                        { 32, 26, 3 }, { 0, 6, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27254, { 0, 0, height + 29 }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27254), { 0, 0, height + 29 },
+                        { 32, 26, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27258, { 0, 0, height + 29 }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27258), { 0, 0, height + 29 },
+                        { 32, 26, 3 });
                     break;
             }
 
@@ -1964,23 +2018,23 @@ static void inverted_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27256, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27256), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27260, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27260), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27253, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27253), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27257, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27257), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
             }
 
@@ -2015,23 +2069,23 @@ static void inverted_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27261, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27261), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27265, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27265), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27264, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27264), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27268, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27268), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
             }
 
@@ -2051,21 +2105,23 @@ static void inverted_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27262, { 0, 0, height + 29 }, { 32, 26, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27262), { 0, 0, height + 29 },
+                        { 32, 26, 3 }, { 0, 6, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27266, { 0, 0, height + 29 }, { 32, 26, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27266), { 0, 0, height + 29 },
+                        { 32, 26, 3 }, { 0, 6, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27263, { 0, 0, height + 29 }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27263), { 0, 0, height + 29 },
+                        { 32, 26, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27267, { 0, 0, height + 29 }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27267), { 0, 0, height + 29 },
+                        { 32, 26, 3 });
                     break;
             }
 
@@ -2093,21 +2149,23 @@ static void inverted_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27263, { 0, 0, height + 29 }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27263), { 0, 0, height + 29 },
+                        { 32, 26, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27267, { 0, 0, height + 29 }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27267), { 0, 0, height + 29 },
+                        { 32, 26, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27262, { 0, 0, height + 29 }, { 32, 26, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27262), { 0, 0, height + 29 },
+                        { 32, 26, 3 }, { 0, 6, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27266, { 0, 0, height + 29 }, { 32, 26, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27266), { 0, 0, height + 29 },
+                        { 32, 26, 3 }, { 0, 6, height + 29 });
                     break;
             }
 
@@ -2135,23 +2193,23 @@ static void inverted_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27264, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27264), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27268, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27268), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27261, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27261), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27265, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27265), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
             }
 
@@ -2186,23 +2244,23 @@ static void inverted_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27355, { 0, 6, height + 29 }, { 32, 2, 3 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27355), { 0, 6, height + 29 },
+                        { 32, 2, 3 }, { 0, 29, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27363, { 0, 6, height + 29 }, { 32, 2, 3 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27363), { 0, 6, height + 29 },
+                        { 32, 2, 3 }, { 0, 29, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27362, { 0, 6, height + 29 }, { 32, 2, 3 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27362), { 0, 6, height + 29 },
+                        { 32, 2, 3 }, { 0, 29, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27370, { 0, 6, height + 29 }, { 32, 10, 7 },
-                        { 0, 6, height + 45 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27370), { 0, 6, height + 29 },
+                        { 32, 10, 7 }, { 0, 6, height + 45 });
                     break;
             }
 
@@ -2243,23 +2301,23 @@ static void inverted_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27356, { 0, 0, height + 29 }, { 32, 2, 3 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27356), { 0, 0, height + 29 },
+                        { 32, 2, 3 }, { 0, 29, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27364, { 0, 14, height + 29 }, { 32, 2, 63 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27364), { 0, 14, height + 29 },
+                        { 32, 2, 63 }, { 0, 29, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27361, { 0, 6, height + 29 }, { 32, 2, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27361), { 0, 6, height + 29 },
+                        { 32, 2, 3 }, { 0, 0, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27369, { 0, 6, height + 29 }, { 2, 2, 3 },
-                        { 29, 20, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27369), { 0, 6, height + 29 },
+                        { 2, 2, 3 }, { 29, 20, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -2270,23 +2328,23 @@ static void inverted_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27357, { 16, 0, height + 2 }, { 5, 2, 119 },
-                        { 16, 29, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27357), { 16, 0, height + 2 },
+                        { 5, 2, 119 }, { 16, 29, height + 2 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27365, { 12, 0, height + 2 }, { 32, 2, 119 },
-                        { 0, -6, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27365), { 12, 0, height + 2 },
+                        { 32, 2, 119 }, { 0, -6, height + 2 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27360, { 10, 16, height + 2 }, { 4, 2, 119 },
-                        { 10, 0, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27360), { 10, 16, height + 2 },
+                        { 4, 2, 119 }, { 10, 0, height + 2 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27368, { 16, 16, height + 2 }, { 2, 2, 119 },
-                        { 29, 29, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27368), { 16, 16, height + 2 },
+                        { 2, 2, 119 }, { 29, 29, height + 2 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2298,23 +2356,23 @@ static void inverted_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27358, { 0, 0, height + 34 }, { 32, 2, 3 },
-                        { 0, 0, height - 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27358), { 0, 0, height + 34 },
+                        { 32, 2, 3 }, { 0, 0, height - 6 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27366, { 0, 0, height + 34 }, { 2, 2, 3 },
-                        { 0, 0, height - 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27366), { 0, 0, height + 34 },
+                        { 2, 2, 3 }, { 0, 0, height - 6 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27359, { 0, 16, height + 34 }, { 32, 2, 3 },
-                        { 0, 0, height - 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27359), { 0, 16, height + 34 },
+                        { 32, 2, 3 }, { 0, 0, height - 6 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27367, { 0, 16, height + 34 }, { 2, 2, 3 },
-                        { 0, 0, height - 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27367), { 0, 16, height + 34 },
+                        { 2, 2, 3 }, { 0, 0, height - 6 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2335,23 +2393,23 @@ static void inverted_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27359, { 0, 16, height + 34 }, { 32, 2, 3 },
-                        { 0, 0, height - 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27359), { 0, 16, height + 34 },
+                        { 32, 2, 3 }, { 0, 0, height - 6 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27367, { 0, 16, height + 34 }, { 2, 2, 3 },
-                        { 0, 0, height - 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27367), { 0, 16, height + 34 },
+                        { 2, 2, 3 }, { 0, 0, height - 6 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27358, { 0, 0, height + 34 }, { 32, 2, 3 },
-                        { 0, 0, height - 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27358), { 0, 0, height + 34 },
+                        { 32, 2, 3 }, { 0, 0, height - 6 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27366, { 0, 0, height + 34 }, { 2, 2, 3 },
-                        { 0, 0, height - 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27366), { 0, 0, height + 34 },
+                        { 2, 2, 3 }, { 0, 0, height - 6 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2366,23 +2424,23 @@ static void inverted_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27360, { 10, 16, height + 2 }, { 4, 2, 119 },
-                        { 10, 0, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27360), { 10, 16, height + 2 },
+                        { 4, 2, 119 }, { 10, 0, height + 2 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27368, { 16, 16, height + 2 }, { 2, 2, 119 },
-                        { 29, 29, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27368), { 16, 16, height + 2 },
+                        { 2, 2, 119 }, { 29, 29, height + 2 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27357, { 16, 0, height + 2 }, { 5, 2, 119 },
-                        { 16, 29, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27357), { 16, 0, height + 2 },
+                        { 5, 2, 119 }, { 16, 29, height + 2 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27365, { 12, 0, height + 2 }, { 32, 2, 119 },
-                        { 0, -6, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27365), { 12, 0, height + 2 },
+                        { 32, 2, 119 }, { 0, -6, height + 2 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2394,23 +2452,23 @@ static void inverted_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27361, { 0, 6, height + 29 }, { 32, 2, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27361), { 0, 6, height + 29 },
+                        { 32, 2, 3 }, { 0, 0, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27369, { 0, 6, height + 29 }, { 2, 2, 3 },
-                        { 29, 20, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27369), { 0, 6, height + 29 },
+                        { 2, 2, 3 }, { 29, 20, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27356, { 0, 0, height + 29 }, { 32, 2, 3 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27356), { 0, 0, height + 29 },
+                        { 32, 2, 3 }, { 0, 29, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27364, { 0, 14, height + 29 }, { 32, 2, 63 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27364), { 0, 14, height + 29 },
+                        { 32, 2, 63 }, { 0, 29, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -2421,23 +2479,23 @@ static void inverted_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27362, { 0, 6, height + 29 }, { 32, 2, 3 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27362), { 0, 6, height + 29 },
+                        { 32, 2, 3 }, { 0, 29, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27370, { 0, 6, height + 29 }, { 32, 10, 7 },
-                        { 0, 6, height + 45 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27370), { 0, 6, height + 29 },
+                        { 32, 10, 7 }, { 0, 6, height + 45 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27355, { 0, 6, height + 29 }, { 32, 2, 3 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27355), { 0, 6, height + 29 },
+                        { 32, 2, 3 }, { 0, 29, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27363, { 0, 6, height + 29 }, { 32, 2, 3 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27363), { 0, 6, height + 29 },
+                        { 32, 2, 3 }, { 0, 29, height + 29 });
                     break;
             }
 
@@ -2493,23 +2551,23 @@ static void inverted_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27386, { 0, 6, height + 29 }, { 32, 10, 7 },
-                        { 0, 6, height + 45 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27386), { 0, 6, height + 29 },
+                        { 32, 10, 7 }, { 0, 6, height + 45 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27378, { 0, 6, height + 29 }, { 32, 2, 3 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27378), { 0, 6, height + 29 },
+                        { 32, 2, 3 }, { 0, 29, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27379, { 0, 6, height + 29 }, { 32, 2, 3 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27379), { 0, 6, height + 29 },
+                        { 32, 2, 3 }, { 0, 29, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27371, { 0, 6, height + 29 }, { 32, 2, 3 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27371), { 0, 6, height + 29 },
+                        { 32, 2, 3 }, { 0, 29, height + 29 });
                     break;
             }
 
@@ -2550,23 +2608,23 @@ static void inverted_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27385, { 0, 6, height + 29 }, { 2, 2, 3 },
-                        { 29, 20, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27385), { 0, 6, height + 29 },
+                        { 2, 2, 3 }, { 29, 20, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27377, { 0, 6, height + 29 }, { 32, 2, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27377), { 0, 6, height + 29 },
+                        { 32, 2, 3 }, { 0, 0, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27380, { 0, 14, height + 29 }, { 32, 2, 63 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27380), { 0, 14, height + 29 },
+                        { 32, 2, 63 }, { 0, 29, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27372, { 0, 0, height + 29 }, { 32, 2, 3 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27372), { 0, 0, height + 29 },
+                        { 32, 2, 3 }, { 0, 29, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -2577,23 +2635,23 @@ static void inverted_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27384, { 16, 16, height + 2 }, { 2, 2, 119 },
-                        { 29, 29, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27384), { 16, 16, height + 2 },
+                        { 2, 2, 119 }, { 29, 29, height + 2 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27376, { 10, 16, height + 2 }, { 4, 2, 119 },
-                        { 10, 0, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27376), { 10, 16, height + 2 },
+                        { 4, 2, 119 }, { 10, 0, height + 2 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27381, { 12, 0, height + 2 }, { 32, 2, 119 },
-                        { 0, -6, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27381), { 12, 0, height + 2 },
+                        { 32, 2, 119 }, { 0, -6, height + 2 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27373, { 16, 0, height + 2 }, { 5, 2, 119 },
-                        { 16, 29, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27373), { 16, 0, height + 2 },
+                        { 5, 2, 119 }, { 16, 29, height + 2 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2605,23 +2663,23 @@ static void inverted_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27383, { 0, 16, height + 34 }, { 2, 2, 3 },
-                        { 0, 0, height - 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27383), { 0, 16, height + 34 },
+                        { 2, 2, 3 }, { 0, 0, height - 6 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27375, { 0, 16, height + 34 }, { 32, 2, 3 },
-                        { 0, 0, height - 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27375), { 0, 16, height + 34 },
+                        { 32, 2, 3 }, { 0, 0, height - 6 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27382, { 0, 0, height + 34 }, { 2, 2, 3 },
-                        { 0, 0, height - 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27382), { 0, 0, height + 34 },
+                        { 2, 2, 3 }, { 0, 0, height - 6 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27374, { 0, 0, height + 34 }, { 32, 2, 3 },
-                        { 0, 0, height - 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27374), { 0, 0, height + 34 },
+                        { 32, 2, 3 }, { 0, 0, height - 6 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2642,23 +2700,23 @@ static void inverted_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27382, { 0, 0, height + 34 }, { 2, 2, 3 },
-                        { 0, 0, height - 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27382), { 0, 0, height + 34 },
+                        { 2, 2, 3 }, { 0, 0, height - 6 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27374, { 0, 0, height + 34 }, { 32, 2, 3 },
-                        { 0, 0, height - 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27374), { 0, 0, height + 34 },
+                        { 32, 2, 3 }, { 0, 0, height - 6 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27383, { 0, 16, height + 34 }, { 2, 2, 3 },
-                        { 0, 0, height - 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27383), { 0, 16, height + 34 },
+                        { 2, 2, 3 }, { 0, 0, height - 6 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27375, { 0, 16, height + 34 }, { 32, 2, 3 },
-                        { 0, 0, height - 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27375), { 0, 16, height + 34 },
+                        { 32, 2, 3 }, { 0, 0, height - 6 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2673,23 +2731,23 @@ static void inverted_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27381, { 12, 0, height + 2 }, { 32, 2, 119 },
-                        { 0, -6, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27381), { 12, 0, height + 2 },
+                        { 32, 2, 119 }, { 0, -6, height + 2 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27373, { 16, 0, height + 2 }, { 5, 2, 119 },
-                        { 16, 29, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27373), { 16, 0, height + 2 },
+                        { 5, 2, 119 }, { 16, 29, height + 2 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27384, { 16, 16, height + 2 }, { 2, 2, 119 },
-                        { 29, 29, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27384), { 16, 16, height + 2 },
+                        { 2, 2, 119 }, { 29, 29, height + 2 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27376, { 10, 16, height + 2 }, { 4, 2, 119 },
-                        { 10, 0, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27376), { 10, 16, height + 2 },
+                        { 4, 2, 119 }, { 10, 0, height + 2 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2701,23 +2759,23 @@ static void inverted_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27380, { 0, 14, height + 29 }, { 32, 2, 63 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27380), { 0, 14, height + 29 },
+                        { 32, 2, 63 }, { 0, 29, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27372, { 0, 0, height + 29 }, { 32, 2, 3 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27372), { 0, 0, height + 29 },
+                        { 32, 2, 3 }, { 0, 29, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27385, { 0, 6, height + 29 }, { 2, 2, 3 },
-                        { 29, 20, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27385), { 0, 6, height + 29 },
+                        { 2, 2, 3 }, { 29, 20, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27377, { 0, 6, height + 29 }, { 32, 2, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27377), { 0, 6, height + 29 },
+                        { 32, 2, 3 }, { 0, 0, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -2728,23 +2786,23 @@ static void inverted_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27379, { 0, 6, height + 29 }, { 32, 2, 3 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27379), { 0, 6, height + 29 },
+                        { 32, 2, 3 }, { 0, 29, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27371, { 0, 6, height + 29 }, { 32, 2, 3 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27371), { 0, 6, height + 29 },
+                        { 32, 2, 3 }, { 0, 29, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27386, { 0, 6, height + 29 }, { 32, 10, 7 },
-                        { 0, 6, height + 45 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27386), { 0, 6, height + 29 },
+                        { 32, 10, 7 }, { 0, 6, height + 45 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27378, { 0, 6, height + 29 }, { 32, 2, 3 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27378), { 0, 6, height + 29 },
+                        { 32, 2, 3 }, { 0, 29, height + 29 });
                     break;
             }
 
@@ -2800,23 +2858,23 @@ static void inverted_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27392, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27392), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27395, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27395), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27398, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27398), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27389, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27389), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
             }
 
@@ -2840,22 +2898,23 @@ static void inverted_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27391, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27391), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 0, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27394, { 0, 0, height + 29 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27394), { 0, 0, height + 29 },
+                        { 16, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27397, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27397), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 16, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27388, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27388), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 16, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2867,23 +2926,23 @@ static void inverted_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27390, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27390), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27393, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27393), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27396, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27396), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27387, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27387), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 29 });
                     break;
             }
 
@@ -2928,23 +2987,23 @@ static void inverted_rc_track_left_quarter_turn_3_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27404, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27404), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27407, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27407), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27410, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27410), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27401, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27401), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
             }
 
@@ -2968,23 +3027,23 @@ static void inverted_rc_track_left_quarter_turn_3_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27403, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27403), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 0, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27406, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27406), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 0, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27409, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27409), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 16, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27400, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27400), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 16, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2996,23 +3055,23 @@ static void inverted_rc_track_left_quarter_turn_3_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27402, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27402), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27405, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27405), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27408, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27408), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27399, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27399), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 29 });
                     break;
             }
 
@@ -3057,19 +3116,23 @@ static void inverted_rc_track_left_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27422, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27422), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27424, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27424), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27426, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27426), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27420, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27420), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
             }
 
@@ -3096,19 +3159,23 @@ static void inverted_rc_track_left_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27421, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27421), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27423, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27423), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27425, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27425), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27419, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27419), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
             }
 
@@ -3144,19 +3211,23 @@ static void inverted_rc_track_right_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27411, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27411), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27413, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27413), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27415, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27415), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27417, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27417), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
             }
 
@@ -3183,19 +3254,23 @@ static void inverted_rc_track_right_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27412, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27412), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27414, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27414), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27416, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27416), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27418, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27418), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
             }
 
@@ -3249,19 +3324,23 @@ static void inverted_rc_track_left_twist_down_to_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27427, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27427), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27433, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27433), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27432, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27432), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27438, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27438), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
             }
 
@@ -3284,19 +3363,23 @@ static void inverted_rc_track_left_twist_down_to_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27428, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27428), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27434, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27434), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27431, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27431), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27437, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27437), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3311,19 +3394,23 @@ static void inverted_rc_track_left_twist_down_to_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27429, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27429), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27435, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27435), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27430, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27430), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27436, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27436), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3358,19 +3445,23 @@ static void inverted_rc_track_right_twist_down_to_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27439, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27439), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27445, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27445), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27444, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27444), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27450, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27450), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
             }
 
@@ -3393,19 +3484,23 @@ static void inverted_rc_track_right_twist_down_to_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27440, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27440), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27446, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27446), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27443, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27443), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27449, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27449), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3420,19 +3515,23 @@ static void inverted_rc_track_right_twist_down_to_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27441, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27441), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27447, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27447), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27442, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27442), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27448, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27448), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3467,19 +3566,23 @@ static void inverted_rc_track_left_twist_up_to_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27430, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27430), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27436, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27436), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27429, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27429), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27435, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27435), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3499,19 +3602,23 @@ static void inverted_rc_track_left_twist_up_to_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27431, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27431), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27437, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27437), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27428, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27428), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27434, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27434), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3526,19 +3633,23 @@ static void inverted_rc_track_left_twist_up_to_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27432, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27432), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27438, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27438), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27427, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27427), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27433, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27433), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
             }
 
@@ -3576,19 +3687,23 @@ static void inverted_rc_track_right_twist_up_to_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27442, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27442), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27448, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27448), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27441, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27441), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27447, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27447), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3608,19 +3723,23 @@ static void inverted_rc_track_right_twist_up_to_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27443, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27443), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27449, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27449), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27440, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27440), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27446, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27446), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3635,19 +3754,23 @@ static void inverted_rc_track_right_twist_up_to_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27444, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27444), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27450, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27450), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27439, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27439), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27445, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27445), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
             }
 
@@ -3685,23 +3808,23 @@ static void inverted_rc_track_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27451, { 0, 6, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 45 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27451), { 0, 6, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 45 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27459, { 0, 6, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 45 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27459), { 0, 6, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 45 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27458, { 0, 6, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 45 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27458), { 0, 6, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 45 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27466, { 0, 6, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 45 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27466), { 0, 6, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 45 });
                     break;
             }
 
@@ -3738,23 +3861,23 @@ static void inverted_rc_track_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27452, { 0, 0, height + 29 }, { 32, 2, 3 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27452), { 0, 0, height + 29 },
+                        { 32, 2, 3 }, { 0, 29, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27460, { 0, 14, height + 29 }, { 32, 2, 63 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27460), { 0, 14, height + 29 },
+                        { 32, 2, 63 }, { 0, 29, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27457, { 0, 6, height + 29 }, { 32, 2, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27457), { 0, 6, height + 29 },
+                        { 32, 2, 3 }, { 0, 0, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27465, { 0, 6, height + 29 }, { 2, 2, 3 },
-                        { 29, 20, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27465), { 0, 6, height + 29 },
+                        { 2, 2, 3 }, { 29, 20, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -3765,23 +3888,23 @@ static void inverted_rc_track_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27453, { 16, 0, height + 2 }, { 5, 2, 119 },
-                        { 16, 29, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27453), { 16, 0, height + 2 },
+                        { 5, 2, 119 }, { 16, 29, height + 2 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27461, { 12, 0, height + 2 }, { 32, 2, 119 },
-                        { 0, -6, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27461), { 12, 0, height + 2 },
+                        { 32, 2, 119 }, { 0, -6, height + 2 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27456, { 10, 16, height + 2 }, { 4, 2, 119 },
-                        { 10, 0, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27456), { 10, 16, height + 2 },
+                        { 4, 2, 119 }, { 10, 0, height + 2 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27464, { 16, 16, height + 2 }, { 2, 2, 119 },
-                        { 29, 29, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27464), { 16, 16, height + 2 },
+                        { 2, 2, 119 }, { 29, 29, height + 2 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3796,23 +3919,23 @@ static void inverted_rc_track_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27454, { 0, 0, height + 34 }, { 32, 20, 3 },
-                        { 0, 6, height + 34 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27454), { 0, 0, height + 34 },
+                        { 32, 20, 3 }, { 0, 6, height + 34 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27462, { 0, 0, height + 34 }, { 2, 2, 3 },
-                        { 0, 0, height - 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27462), { 0, 0, height + 34 },
+                        { 2, 2, 3 }, { 0, 0, height - 6 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27455, { 0, 16, height + 34 }, { 32, 2, 3 },
-                        { 0, 0, height - 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27455), { 0, 16, height + 34 },
+                        { 32, 2, 3 }, { 0, 0, height - 6 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27463, { 0, 16, height + 34 }, { 32, 20, 3 },
-                        { 0, 6, height + 34 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27463), { 0, 16, height + 34 },
+                        { 32, 20, 3 }, { 0, 6, height + 34 });
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -3846,23 +3969,23 @@ static void inverted_rc_track_left_corkscrew_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27467, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 33 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27467), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 33 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27470, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 33 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27470), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 33 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27473, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 33 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27473), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 33 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27476, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 33 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27476), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 33 });
                     break;
             }
 
@@ -3885,23 +4008,23 @@ static void inverted_rc_track_left_corkscrew_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27468, { 0, 0, height + 14 }, { 20, 20, 3 },
-                        { 6, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27468), { 0, 0, height + 14 },
+                        { 20, 20, 3 }, { 6, 6, height + 24 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27471, { 0, 0, height + 14 }, { 20, 20, 3 },
-                        { 6, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27471), { 0, 0, height + 14 },
+                        { 20, 20, 3 }, { 6, 6, height + 24 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27474, { 0, 0, height + 14 }, { 20, 20, 3 },
-                        { 6, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27474), { 0, 0, height + 14 },
+                        { 20, 20, 3 }, { 6, 6, height + 24 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27477, { 0, 0, height + 14 }, { 20, 20, 3 },
-                        { 6, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27477), { 0, 0, height + 14 },
+                        { 20, 20, 3 }, { 6, 6, height + 24 });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -3912,23 +4035,23 @@ static void inverted_rc_track_left_corkscrew_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27469, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 39 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27469), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 39 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27472, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 39 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27472), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 39 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27475, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 39 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27475), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 39 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27478, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 39 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27478), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 39 });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -3964,23 +4087,23 @@ static void inverted_rc_track_right_corkscrew_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27479, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 33 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27479), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 33 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27482, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 33 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27482), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 33 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27485, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 33 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27485), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 33 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27488, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 33 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27488), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 33 });
                     break;
             }
 
@@ -4003,23 +4126,23 @@ static void inverted_rc_track_right_corkscrew_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27480, { 0, 0, height + 14 }, { 20, 20, 3 },
-                        { 6, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27480), { 0, 0, height + 14 },
+                        { 20, 20, 3 }, { 6, 6, height + 24 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27483, { 0, 0, height + 14 }, { 20, 20, 3 },
-                        { 6, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27483), { 0, 0, height + 14 },
+                        { 20, 20, 3 }, { 6, 6, height + 24 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27486, { 0, 0, height + 14 }, { 20, 20, 3 },
-                        { 6, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27486), { 0, 0, height + 14 },
+                        { 20, 20, 3 }, { 6, 6, height + 24 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27489, { 0, 0, height + 14 }, { 20, 20, 3 },
-                        { 6, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27489), { 0, 0, height + 14 },
+                        { 20, 20, 3 }, { 6, 6, height + 24 });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -4030,23 +4153,23 @@ static void inverted_rc_track_right_corkscrew_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27481, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 39 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27481), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 39 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27484, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 39 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27484), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 39 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27487, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 39 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27487), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 39 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27490, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 39 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27490), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 39 });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -4095,34 +4218,34 @@ static void inverted_rc_track_left_quarter_turn_1_60_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27352, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27352), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27348, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27348), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27353, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27353), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27349, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27349), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27354, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27354), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27350, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27350), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27351, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27351), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27347, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27347), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
     }
@@ -4140,34 +4263,34 @@ static void inverted_rc_track_right_quarter_turn_1_60_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27343, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27343), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27339, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27339), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27344, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27344), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27340, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27340), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27345, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27345), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27341, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27341), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27346, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27346), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27342, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27342), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
     }
@@ -4203,13 +4326,13 @@ static void inverted_rc_track_brakes(
         case 0:
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27337, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27337), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
         case 1:
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27338, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27338), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
     }
@@ -4237,23 +4360,23 @@ static void inverted_rc_track_left_quarter_banked_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27202, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27202), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 35 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27207, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27207), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 35 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27212, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27212), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 35 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27197, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27197), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 35 });
                     break;
             }
 
@@ -4277,23 +4400,23 @@ static void inverted_rc_track_left_quarter_banked_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27201, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27201), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 0, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27206, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27206), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 0, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27211, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27211), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27196, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27196), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 43 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4308,23 +4431,23 @@ static void inverted_rc_track_left_quarter_banked_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27200, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27200), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 16, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27205, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27205), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 16, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27210, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27210), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 0, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27195, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27195), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 0, height + 43 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4339,23 +4462,23 @@ static void inverted_rc_track_left_quarter_banked_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27199, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 16, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27199), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 16, 0, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27204, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27204), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 0, 0, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27209, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27209), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 0, 0, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27194, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 16, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27194), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 16, 0, height + 43 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4370,23 +4493,23 @@ static void inverted_rc_track_left_quarter_banked_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27198, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27198), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27203, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27203), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27208, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27208), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27193, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27193), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 43 });
                     break;
             }
 
@@ -4422,23 +4545,23 @@ static void inverted_rc_track_right_quarter_banked_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27173, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27173), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 35 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27178, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27178), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 35 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27183, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27183), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 35 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27188, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27188), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 35 });
                     break;
             }
 
@@ -4462,23 +4585,23 @@ static void inverted_rc_track_right_quarter_banked_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27174, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27174), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27179, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27179), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27184, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27184), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 0, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27189, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27189), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 0, height + 43 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4493,23 +4616,23 @@ static void inverted_rc_track_right_quarter_banked_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27175, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27175), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 0, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27180, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27180), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 0, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27185, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27185), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 16, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27190, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27190), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 16, height + 43 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4524,23 +4647,23 @@ static void inverted_rc_track_right_quarter_banked_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27176, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 16, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27176), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 16, 0, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27181, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27181), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 0, 0, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27186, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27186), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 0, 0, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27191, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 16, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27191), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 16, 0, height + 43 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4555,23 +4678,23 @@ static void inverted_rc_track_right_quarter_banked_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27177, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27177), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27182, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27182), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27187, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27187), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27192, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27192), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 43 });
                     break;
             }
 
@@ -4607,23 +4730,23 @@ static void inverted_rc_track_left_quarter_banked_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27182, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27182), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27187, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27187), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27192, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27192), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27177, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27177), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 43 });
                     break;
             }
 
@@ -4647,23 +4770,23 @@ static void inverted_rc_track_left_quarter_banked_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27181, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27181), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 0, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27186, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27186), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 0, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27191, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27191), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27176, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27176), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 43 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4678,23 +4801,23 @@ static void inverted_rc_track_left_quarter_banked_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27180, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27180), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 16, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27185, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27185), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 16, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27190, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27190), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 0, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27175, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27175), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 0, height + 43 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4709,23 +4832,23 @@ static void inverted_rc_track_left_quarter_banked_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27179, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 16, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27179), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 16, 0, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27184, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27184), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 0, 0, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27189, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27189), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 0, 0, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27174, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 16, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27174), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 16, 0, height + 43 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4740,23 +4863,23 @@ static void inverted_rc_track_left_quarter_banked_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27178, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27178), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 35 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27183, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27183), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 35 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27188, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27188), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 35 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27173, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27173), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 35 });
                     break;
             }
 
@@ -4792,23 +4915,23 @@ static void inverted_rc_track_right_quarter_banked_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27193, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27193), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27198, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27198), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27203, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27203), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27208, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27208), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 43 });
                     break;
             }
 
@@ -4832,23 +4955,23 @@ static void inverted_rc_track_right_quarter_banked_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27194, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27194), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27199, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27199), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27204, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27204), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 0, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27209, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27209), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 0, height + 43 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4863,23 +4986,23 @@ static void inverted_rc_track_right_quarter_banked_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27195, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27195), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 0, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27200, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27200), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 0, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27205, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27205), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 16, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27210, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27210), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 16, height + 43 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4894,23 +5017,23 @@ static void inverted_rc_track_right_quarter_banked_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27196, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 16, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27196), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 16, 0, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27201, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27201), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 0, 0, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27206, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27206), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 0, 0, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27211, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 16, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27211), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 16, 0, height + 43 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4925,23 +5048,23 @@ static void inverted_rc_track_right_quarter_banked_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27197, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27197), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 35 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27202, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27202), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 35 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27207, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27207), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 35 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27212, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27212), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 35 });
                     break;
             }
 
@@ -4974,22 +5097,22 @@ static void inverted_rc_track_25_deg_up_left_banked(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27711, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27711), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 45 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27712, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27712), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 45 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27713, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27713), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 45 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27714, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27714), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 45 });
             break;
     }
@@ -5039,22 +5162,22 @@ static void inverted_rc_track_25_deg_up_right_banked(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27715, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27715), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 45 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27716, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27716), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 45 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27717, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27717), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 45 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27718, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27718), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 45 });
             break;
     }
@@ -5104,38 +5227,38 @@ static void inverted_rc_track_on_ride_photo(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27129, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27129), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27130, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27130), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27129, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27129), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27130, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27130), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
     }
@@ -5173,23 +5296,23 @@ static void inverted_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27507, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27507), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27511, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27511), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27515, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27515), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27519, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27519), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
             }
 
@@ -5209,23 +5332,23 @@ static void inverted_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27508, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27508), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 0, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27512, { 0, 0, height + 29 }, { 34, 16, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27512), { 0, 0, height + 29 },
+                        { 34, 16, 3 }, { 0, 0, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27516, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27516), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27520, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27520), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5240,23 +5363,23 @@ static void inverted_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27509, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27509), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 16, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27513, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27513), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 16, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27517, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27517), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 0, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27521, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27521), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 0, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5274,23 +5397,23 @@ static void inverted_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27510, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27510), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 16, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27514, { 0, 0, height + 29 }, { 16, 18, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27514), { 0, 0, height + 29 },
+                        { 16, 18, 3 }, { 0, 16, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27518, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27518), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 0, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27522, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27522), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 0, height + 29 });
                     break;
             }
 
@@ -5336,23 +5459,23 @@ static void inverted_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27491, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27491), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27495, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27495), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27499, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27499), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27503, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27503), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
             }
 
@@ -5372,23 +5495,23 @@ static void inverted_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27492, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27492), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27496, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27496), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27500, { 0, 0, height + 29 }, { 34, 16, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27500), { 0, 0, height + 29 },
+                        { 34, 16, 3 }, { 0, 0, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27504, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27504), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 0, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5403,23 +5526,23 @@ static void inverted_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27493, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27493), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 0, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27497, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27497), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 0, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27501, { 0, 0, height + 29 }, { 28, 28, 3 },
-                        { 4, 4, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27501), { 0, 0, height + 29 },
+                        { 28, 28, 3 }, { 4, 4, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27505, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27505), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 16, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5437,23 +5560,23 @@ static void inverted_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27494, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27494), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 0, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27498, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27498), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 0, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27502, { 0, 0, height + 29 }, { 16, 18, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27502), { 0, 0, height + 29 },
+                        { 16, 18, 3 }, { 0, 16, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27506, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27506), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 16, height + 29 });
                     break;
             }
 
@@ -5517,23 +5640,23 @@ static void inverted_rc_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27539, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27539), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27543, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27543), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27547, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27547), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27551, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27551), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
             }
 
@@ -5553,23 +5676,23 @@ static void inverted_rc_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27540, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27540), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 0, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27544, { 0, 0, height + 29 }, { 34, 16, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27544), { 0, 0, height + 29 },
+                        { 34, 16, 3 }, { 0, 0, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27548, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27548), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27552, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27552), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5584,23 +5707,23 @@ static void inverted_rc_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27541, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27541), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 16, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27545, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27545), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 16, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27549, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27549), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 0, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27553, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27553), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 0, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5618,23 +5741,23 @@ static void inverted_rc_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27542, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27542), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 16, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27546, { 0, 0, height + 29 }, { 16, 18, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27546), { 0, 0, height + 29 },
+                        { 16, 18, 3 }, { 0, 16, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27550, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27550), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 0, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27554, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27554), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 0, height + 29 });
                     break;
             }
 
@@ -5680,23 +5803,23 @@ static void inverted_rc_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27523, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27523), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27527, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27527), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27531, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27531), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27535, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27535), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
             }
 
@@ -5716,23 +5839,23 @@ static void inverted_rc_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27524, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27524), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27528, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27528), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27532, { 0, 0, height + 29 }, { 34, 16, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27532), { 0, 0, height + 29 },
+                        { 34, 16, 3 }, { 0, 0, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27536, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27536), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 0, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5747,23 +5870,23 @@ static void inverted_rc_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27525, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27525), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 0, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27529, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27529), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 0, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27533, { 0, 0, height + 29 }, { 28, 28, 3 },
-                        { 4, 4, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27533), { 0, 0, height + 29 },
+                        { 28, 28, 3 }, { 4, 4, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27537, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27537), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 16, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5781,23 +5904,23 @@ static void inverted_rc_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27526, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27526), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 0, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27530, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27530), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 0, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27534, { 0, 0, height + 29 }, { 16, 18, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27534), { 0, 0, height + 29 },
+                        { 16, 18, 3 }, { 0, 16, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27538, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27538), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 16, height + 29 });
                     break;
             }
 
@@ -5863,7 +5986,7 @@ static void inverted_rc_track_diag_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27614, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27614), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 29 });
                         break;
                 }
@@ -5874,7 +5997,7 @@ static void inverted_rc_track_diag_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27558, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27558), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 29 });
                         break;
                 }
@@ -5890,7 +6013,7 @@ static void inverted_rc_track_diag_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27611, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27611), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 29 });
                         break;
                 }
@@ -5901,7 +6024,7 @@ static void inverted_rc_track_diag_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27555, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27555), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 29 });
                         break;
                 }
@@ -5917,7 +6040,7 @@ static void inverted_rc_track_diag_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27613, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27613), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 29 });
                         break;
                 }
@@ -5928,7 +6051,7 @@ static void inverted_rc_track_diag_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27557, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27557), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 29 });
                         break;
                 }
@@ -5944,7 +6067,7 @@ static void inverted_rc_track_diag_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27612, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27612), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 29 });
                         break;
                 }
@@ -5955,7 +6078,7 @@ static void inverted_rc_track_diag_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27556, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27556), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 29 });
                         break;
                 }
@@ -6002,7 +6125,7 @@ static void inverted_rc_track_diag_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27626, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27626), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -6013,7 +6136,7 @@ static void inverted_rc_track_diag_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27570, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27570), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -6029,7 +6152,7 @@ static void inverted_rc_track_diag_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27623, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27623), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -6040,7 +6163,7 @@ static void inverted_rc_track_diag_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27567, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27567), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -6056,7 +6179,7 @@ static void inverted_rc_track_diag_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27625, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27625), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -6067,7 +6190,7 @@ static void inverted_rc_track_diag_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27569, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27569), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -6083,7 +6206,7 @@ static void inverted_rc_track_diag_25_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27624, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27624), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -6094,7 +6217,7 @@ static void inverted_rc_track_diag_25_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27568, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27568), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -6139,7 +6262,7 @@ static void inverted_rc_track_diag_60_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27582, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27582), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 93 });
                     break;
             }
@@ -6152,7 +6275,7 @@ static void inverted_rc_track_diag_60_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27579, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27579), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 93 });
                     break;
             }
@@ -6165,7 +6288,7 @@ static void inverted_rc_track_diag_60_deg_up(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27581, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27581), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 93 });
                     break;
             }
@@ -6178,7 +6301,7 @@ static void inverted_rc_track_diag_60_deg_up(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27580, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27580), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -6224,7 +6347,7 @@ static void inverted_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27618, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27618), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -6235,7 +6358,7 @@ static void inverted_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27562, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27562), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -6251,7 +6374,7 @@ static void inverted_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27615, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27615), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -6262,7 +6385,7 @@ static void inverted_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27559, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27559), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -6278,7 +6401,7 @@ static void inverted_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27617, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27617), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -6289,7 +6412,7 @@ static void inverted_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27561, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27561), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -6305,7 +6428,7 @@ static void inverted_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27616, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27616), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -6316,7 +6439,7 @@ static void inverted_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27560, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27560), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -6361,7 +6484,7 @@ static void inverted_rc_track_diag_25_deg_up_to_60_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27574, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27574), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 61 });
                     break;
             }
@@ -6374,7 +6497,7 @@ static void inverted_rc_track_diag_25_deg_up_to_60_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27571, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27571), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 61 });
                     break;
             }
@@ -6387,7 +6510,7 @@ static void inverted_rc_track_diag_25_deg_up_to_60_deg_up(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27573, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27573), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 61 });
                     break;
             }
@@ -6400,7 +6523,7 @@ static void inverted_rc_track_diag_25_deg_up_to_60_deg_up(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27572, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27572), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 61 });
                     break;
             }
@@ -6444,7 +6567,7 @@ static void inverted_rc_track_diag_60_deg_up_to_25_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27578, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27578), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 61 });
                     break;
             }
@@ -6457,7 +6580,7 @@ static void inverted_rc_track_diag_60_deg_up_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27575, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27575), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 61 });
                     break;
             }
@@ -6470,7 +6593,7 @@ static void inverted_rc_track_diag_60_deg_up_to_25_deg_up(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27577, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27577), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 61 });
                     break;
             }
@@ -6483,7 +6606,7 @@ static void inverted_rc_track_diag_60_deg_up_to_25_deg_up(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27576, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27576), { -16, -16, height + 29 },
                         { 16, 16, 3 }, { 0, 0, height + 61 });
                     break;
             }
@@ -6529,7 +6652,7 @@ static void inverted_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27622, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27622), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -6540,7 +6663,7 @@ static void inverted_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27566, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27566), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -6556,7 +6679,7 @@ static void inverted_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27619, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27619), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -6567,7 +6690,7 @@ static void inverted_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27563, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27563), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -6583,7 +6706,7 @@ static void inverted_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27621, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27621), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -6594,7 +6717,7 @@ static void inverted_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27565, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27565), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -6610,7 +6733,7 @@ static void inverted_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27620, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27620), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -6621,7 +6744,7 @@ static void inverted_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27564, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27564), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -6668,7 +6791,7 @@ static void inverted_rc_track_diag_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27624, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27624), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -6679,7 +6802,7 @@ static void inverted_rc_track_diag_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27568, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27568), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -6695,7 +6818,7 @@ static void inverted_rc_track_diag_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27625, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27625), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -6706,7 +6829,7 @@ static void inverted_rc_track_diag_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27569, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27569), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -6722,7 +6845,7 @@ static void inverted_rc_track_diag_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27623, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27623), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -6733,7 +6856,7 @@ static void inverted_rc_track_diag_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27567, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27567), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -6749,7 +6872,7 @@ static void inverted_rc_track_diag_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27626, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27626), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -6760,7 +6883,7 @@ static void inverted_rc_track_diag_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27570, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27570), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -6805,7 +6928,7 @@ static void inverted_rc_track_diag_60_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27580, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27580), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -6818,7 +6941,7 @@ static void inverted_rc_track_diag_60_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27581, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27581), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 93 });
                     break;
             }
@@ -6831,7 +6954,7 @@ static void inverted_rc_track_diag_60_deg_down(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27579, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27579), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 93 });
                     break;
             }
@@ -6844,7 +6967,7 @@ static void inverted_rc_track_diag_60_deg_down(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27582, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27582), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 93 });
                     break;
             }
@@ -6890,7 +7013,7 @@ static void inverted_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27620, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27620), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -6901,7 +7024,7 @@ static void inverted_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27564, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27564), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -6916,7 +7039,7 @@ static void inverted_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27621, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27621), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -6927,7 +7050,7 @@ static void inverted_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27565, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27565), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -6942,7 +7065,7 @@ static void inverted_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27619, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27619), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -6953,7 +7076,7 @@ static void inverted_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27563, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27563), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -6968,7 +7091,7 @@ static void inverted_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27622, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27622), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -6979,7 +7102,7 @@ static void inverted_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27566, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27566), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -7024,7 +7147,7 @@ static void inverted_rc_track_diag_25_deg_down_to_60_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27576, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27576), { -16, -16, height + 29 },
                         { 16, 16, 3 }, { 0, 0, height + 61 });
                     break;
             }
@@ -7037,7 +7160,7 @@ static void inverted_rc_track_diag_25_deg_down_to_60_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27577, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27577), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 61 });
                     break;
             }
@@ -7050,7 +7173,7 @@ static void inverted_rc_track_diag_25_deg_down_to_60_deg_down(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27575, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27575), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 61 });
                     break;
             }
@@ -7063,7 +7186,7 @@ static void inverted_rc_track_diag_25_deg_down_to_60_deg_down(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27578, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27578), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 61 });
                     break;
             }
@@ -7107,7 +7230,7 @@ static void inverted_rc_track_diag_60_deg_down_to_25_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27572, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27572), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 61 });
                     break;
             }
@@ -7120,7 +7243,7 @@ static void inverted_rc_track_diag_60_deg_down_to_25_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27573, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27573), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 61 });
                     break;
             }
@@ -7133,7 +7256,7 @@ static void inverted_rc_track_diag_60_deg_down_to_25_deg_down(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27571, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27571), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 61 });
                     break;
             }
@@ -7146,7 +7269,7 @@ static void inverted_rc_track_diag_60_deg_down_to_25_deg_down(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27574, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27574), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 61 });
                     break;
             }
@@ -7192,7 +7315,7 @@ static void inverted_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27616, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27616), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -7203,7 +7326,7 @@ static void inverted_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27560, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27560), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -7219,7 +7342,7 @@ static void inverted_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27617, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27617), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -7230,7 +7353,7 @@ static void inverted_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27561, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27561), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -7246,7 +7369,7 @@ static void inverted_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27615, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27615), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -7257,7 +7380,7 @@ static void inverted_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27559, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27559), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -7273,7 +7396,7 @@ static void inverted_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27618, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27618), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -7284,7 +7407,7 @@ static void inverted_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 27562, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27562), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -7329,7 +7452,7 @@ static void inverted_rc_track_diag_flat_to_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27590, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27590), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -7342,7 +7465,7 @@ static void inverted_rc_track_diag_flat_to_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27587, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27587), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -7355,7 +7478,7 @@ static void inverted_rc_track_diag_flat_to_left_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27589, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27589), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -7368,7 +7491,7 @@ static void inverted_rc_track_diag_flat_to_left_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27588, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27588), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -7413,7 +7536,7 @@ static void inverted_rc_track_diag_flat_to_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27594, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27594), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -7426,7 +7549,7 @@ static void inverted_rc_track_diag_flat_to_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27591, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27591), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -7439,7 +7562,7 @@ static void inverted_rc_track_diag_flat_to_right_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27593, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27593), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -7452,7 +7575,7 @@ static void inverted_rc_track_diag_flat_to_right_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27592, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27592), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -7497,7 +7620,7 @@ static void inverted_rc_track_diag_left_bank_to_flat(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27592, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27592), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -7510,7 +7633,7 @@ static void inverted_rc_track_diag_left_bank_to_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27593, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27593), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -7523,7 +7646,7 @@ static void inverted_rc_track_diag_left_bank_to_flat(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27591, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27591), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -7536,7 +7659,7 @@ static void inverted_rc_track_diag_left_bank_to_flat(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27594, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27594), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -7581,7 +7704,7 @@ static void inverted_rc_track_diag_right_bank_to_flat(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27588, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27588), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -7594,7 +7717,7 @@ static void inverted_rc_track_diag_right_bank_to_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27589, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27589), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -7607,7 +7730,7 @@ static void inverted_rc_track_diag_right_bank_to_flat(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27587, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27587), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -7620,7 +7743,7 @@ static void inverted_rc_track_diag_right_bank_to_flat(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27590, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27590), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -7665,7 +7788,7 @@ static void inverted_rc_track_diag_left_bank_to_25_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27606, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27606), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -7678,7 +7801,7 @@ static void inverted_rc_track_diag_left_bank_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27603, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27603), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -7691,7 +7814,7 @@ static void inverted_rc_track_diag_left_bank_to_25_deg_up(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27605, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27605), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -7704,7 +7827,7 @@ static void inverted_rc_track_diag_left_bank_to_25_deg_up(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27604, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27604), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -7748,7 +7871,7 @@ static void inverted_rc_track_diag_right_bank_to_25_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27610, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27610), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -7761,7 +7884,7 @@ static void inverted_rc_track_diag_right_bank_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27607, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27607), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -7774,7 +7897,7 @@ static void inverted_rc_track_diag_right_bank_to_25_deg_up(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27609, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27609), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -7787,7 +7910,7 @@ static void inverted_rc_track_diag_right_bank_to_25_deg_up(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27608, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27608), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -7831,7 +7954,7 @@ static void inverted_rc_track_diag_25_deg_up_to_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27598, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27598), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -7844,7 +7967,7 @@ static void inverted_rc_track_diag_25_deg_up_to_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27595, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27595), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -7857,7 +7980,7 @@ static void inverted_rc_track_diag_25_deg_up_to_left_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27597, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27597), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -7870,7 +7993,7 @@ static void inverted_rc_track_diag_25_deg_up_to_left_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27596, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27596), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -7914,7 +8037,7 @@ static void inverted_rc_track_diag_25_deg_up_to_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27602, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27602), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -7927,7 +8050,7 @@ static void inverted_rc_track_diag_25_deg_up_to_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27599, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27599), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -7940,7 +8063,7 @@ static void inverted_rc_track_diag_25_deg_up_to_right_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27601, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27601), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -7953,7 +8076,7 @@ static void inverted_rc_track_diag_25_deg_up_to_right_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27600, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27600), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -7997,7 +8120,7 @@ static void inverted_rc_track_diag_left_bank_to_25_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27600, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27600), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8009,7 +8132,7 @@ static void inverted_rc_track_diag_left_bank_to_25_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27601, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27601), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8021,7 +8144,7 @@ static void inverted_rc_track_diag_left_bank_to_25_deg_down(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27599, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27599), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8033,7 +8156,7 @@ static void inverted_rc_track_diag_left_bank_to_25_deg_down(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27602, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27602), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8077,7 +8200,7 @@ static void inverted_rc_track_diag_right_bank_to_25_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27596, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27596), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8089,7 +8212,7 @@ static void inverted_rc_track_diag_right_bank_to_25_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27597, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27597), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8101,7 +8224,7 @@ static void inverted_rc_track_diag_right_bank_to_25_deg_down(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27595, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27595), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8113,7 +8236,7 @@ static void inverted_rc_track_diag_right_bank_to_25_deg_down(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27598, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27598), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8157,7 +8280,7 @@ static void inverted_rc_track_diag_25_deg_down_to_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27608, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27608), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8170,7 +8293,7 @@ static void inverted_rc_track_diag_25_deg_down_to_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27609, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27609), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8183,7 +8306,7 @@ static void inverted_rc_track_diag_25_deg_down_to_left_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27607, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27607), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8196,7 +8319,7 @@ static void inverted_rc_track_diag_25_deg_down_to_left_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27610, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27610), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8240,7 +8363,7 @@ static void inverted_rc_track_diag_25_deg_down_to_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27604, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27604), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8253,7 +8376,7 @@ static void inverted_rc_track_diag_25_deg_down_to_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27605, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27605), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8266,7 +8389,7 @@ static void inverted_rc_track_diag_25_deg_down_to_right_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27603, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27603), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8279,7 +8402,7 @@ static void inverted_rc_track_diag_25_deg_down_to_right_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27606, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27606), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 37 });
                     break;
             }
@@ -8323,7 +8446,7 @@ static void inverted_rc_track_diag_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27586, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27586), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -8336,7 +8459,7 @@ static void inverted_rc_track_diag_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27583, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27583), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -8349,7 +8472,7 @@ static void inverted_rc_track_diag_left_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27585, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27585), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -8362,7 +8485,7 @@ static void inverted_rc_track_diag_left_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27584, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27584), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -8407,7 +8530,7 @@ static void inverted_rc_track_diag_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27584, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27584), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -8420,7 +8543,7 @@ static void inverted_rc_track_diag_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27585, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27585), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -8433,7 +8556,7 @@ static void inverted_rc_track_diag_right_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27583, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27583), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -8446,7 +8569,7 @@ static void inverted_rc_track_diag_right_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27586, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27586), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -8491,23 +8614,23 @@ static void inverted_rc_track_left_large_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27639, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27639), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27646, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27646), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27653, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27653), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27660, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27660), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -8523,23 +8646,23 @@ static void inverted_rc_track_left_large_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27640, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27640), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27647, { 0, 0, height }, { 32, 20, 9 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27647), { 0, 0, height },
+                        { 32, 20, 9 }, { 0, 6, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27654, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27654), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27661, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27661), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8551,22 +8674,22 @@ static void inverted_rc_track_left_large_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27641, { 0, 0, height }, { 24, 16, 3 },
-                        { 8, 0, height + 40 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27641), { 0, 0, height },
+                        { 24, 16, 3 }, { 8, 0, height + 40 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27648, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27648), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27655, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27655), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27662, { 0, 0, height }, { 2, 16, 3 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27662), { 0, 0, height }, { 2, 16, 3 },
                         { 30, 16, height + 70 });
                     break;
             }
@@ -8582,22 +8705,22 @@ static void inverted_rc_track_left_large_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27642, { 0, 0, height }, { 8, 16, 3 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27642), { 0, 0, height }, { 8, 16, 3 },
                         { 24, 0, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27649, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27649), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27656, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27656), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27663, { 0, 0, height }, { 2, 16, 3 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27663), { 0, 0, height }, { 2, 16, 3 },
                         { 30, 16, height + 100 });
                     break;
             }
@@ -8613,22 +8736,22 @@ static void inverted_rc_track_left_large_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27643, { 0, 0, height }, { 2, 2, 3 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27643), { 0, 0, height }, { 2, 2, 3 },
                         { 30, 30, height + 80 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27650, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27650), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27657, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27657), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27664, { 0, 0, height }, { 2, 16, 3 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27664), { 0, 0, height }, { 2, 16, 3 },
                         { 30, 0, height + 90 });
                     break;
             }
@@ -8641,22 +8764,22 @@ static void inverted_rc_track_left_large_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27644, { 0, 0, height }, { 2, 16, 3 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27644), { 0, 0, height }, { 2, 16, 3 },
                         { 30, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27651, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27651), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27658, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27658), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27665, { 0, 0, height }, { 2, 16, 3 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27665), { 0, 0, height }, { 2, 16, 3 },
                         { 30, 0, height + 140 });
                     break;
             }
@@ -8672,29 +8795,29 @@ static void inverted_rc_track_left_large_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27645, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27645), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height + 32 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_BOXED, 4, 27, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27652, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27652), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_BOXED, 4, 27, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27659, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27659), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_BOXED, 4, 25, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27666, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27666), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height + 32 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_BOXED, 4, 27, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8725,23 +8848,23 @@ static void inverted_rc_track_right_large_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27688, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27688), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27681, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27681), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27674, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27674), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27667, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27667), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -8757,23 +8880,23 @@ static void inverted_rc_track_right_large_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27689, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27689), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27682, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27682), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27675, { 0, 0, height }, { 32, 20, 19 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27675), { 0, 0, height },
+                        { 32, 20, 19 }, { 0, 6, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27668, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27668), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8785,23 +8908,23 @@ static void inverted_rc_track_right_large_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27690, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height + 70 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27690), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height + 70 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27683, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27683), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27676, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27676), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27669, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height + 70 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27669), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height + 70 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8816,23 +8939,23 @@ static void inverted_rc_track_right_large_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27691, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height + 100 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27691), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height + 100 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27684, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27684), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27677, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27677), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27670, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height + 100 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27670), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height + 100 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8847,22 +8970,22 @@ static void inverted_rc_track_right_large_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27692, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height + 90 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27692), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height + 90 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27685, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27685), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27678, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27678), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27671, { 0, 0, height }, { 2, 16, 3 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27671), { 0, 0, height }, { 2, 16, 3 },
                         { 30, 16, height + 110 });
                     break;
             }
@@ -8875,22 +8998,22 @@ static void inverted_rc_track_right_large_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27693, { 0, 0, height }, { 2, 16, 3 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27693), { 0, 0, height }, { 2, 16, 3 },
                         { 30, 0, height + 140 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27686, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27686), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27679, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27679), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27672, { 0, 0, height }, { 2, 16, 3 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27672), { 0, 0, height }, { 2, 16, 3 },
                         { 30, 16, height + 140 });
                     break;
             }
@@ -8906,29 +9029,29 @@ static void inverted_rc_track_right_large_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27694, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27694), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height + 32 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_BOXED, 4, 27, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27687, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27687), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_BOXED, 4, 25, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27680, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27680), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_BOXED, 4, 27, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27673, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27673), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height + 32 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_BOXED, 4, 27, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8973,13 +9096,13 @@ static void inverted_rc_track_block_brakes(
         case 0:
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27337, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27337), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
         case 1:
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27338, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27338), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
     }
@@ -9007,19 +9130,23 @@ static void inverted_rc_track_left_banked_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27762, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27762), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27764, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27764), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27766, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27766), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27760, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27760), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
             }
 
@@ -9046,19 +9173,23 @@ static void inverted_rc_track_left_banked_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27761, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27761), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27763, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27763), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27765, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27765), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27759, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27759), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
             }
 
@@ -9094,19 +9225,23 @@ static void inverted_rc_track_right_banked_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27751, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27751), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27753, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27753), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27755, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27755), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27757, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27757), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
             }
 
@@ -9133,19 +9268,23 @@ static void inverted_rc_track_right_banked_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27752, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27752), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27754, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27754), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27756, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27756), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27758, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27758), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
             }
 
@@ -9201,19 +9340,23 @@ static void inverted_rc_track_left_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27787, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27787), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27792, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27792), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27797, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27797), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27802, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27802), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
             }
 
@@ -9237,19 +9380,23 @@ static void inverted_rc_track_left_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27788, { 0, 0, height + 29 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27788), { 0, 0, height + 29 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27793, { 0, 0, height + 29 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27793), { 0, 0, height + 29 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27798, { 0, 16, height + 29 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27798), { 0, 16, height + 29 },
+                        { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27803, { 0, 16, height + 29 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27803), { 0, 16, height + 29 },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -9264,19 +9411,23 @@ static void inverted_rc_track_left_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27789, { 0, 16, height + 29 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27789), { 0, 16, height + 29 },
+                        { 16, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27794, { 16, 16, height + 29 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27794), { 16, 16, height + 29 },
+                        { 16, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27799, { 16, 0, height + 29 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27799), { 16, 0, height + 29 },
+                        { 16, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27804, { 0, 0, height + 29 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27804), { 0, 0, height + 29 },
+                        { 16, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -9291,19 +9442,23 @@ static void inverted_rc_track_left_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27790, { 16, 0, height + 29 }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27790), { 16, 0, height + 29 },
+                        { 16, 32, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27795, { 0, 0, height + 29 }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27795), { 0, 0, height + 29 },
+                        { 16, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27800, { 0, 0, height + 29 }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27800), { 0, 0, height + 29 },
+                        { 16, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27805, { 16, 0, height + 29 }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27805), { 16, 0, height + 29 },
+                        { 16, 32, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -9318,19 +9473,23 @@ static void inverted_rc_track_left_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27791, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27791), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27796, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27796), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27801, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27801), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27806, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27806), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
             }
 
@@ -9366,19 +9525,23 @@ static void inverted_rc_track_right_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27767, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27767), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27772, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27772), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27777, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27777), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27782, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27782), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
             }
 
@@ -9402,19 +9565,23 @@ static void inverted_rc_track_right_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27768, { 0, 16, height + 29 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27768), { 0, 16, height + 29 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27773, { 0, 16, height + 29 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27773), { 0, 16, height + 29 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27778, { 0, 0, height + 29 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27778), { 0, 0, height + 29 },
+                        { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27783, { 0, 0, height + 29 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27783), { 0, 0, height + 29 },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -9429,19 +9596,23 @@ static void inverted_rc_track_right_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27769, { 0, 0, height + 29 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27769), { 0, 0, height + 29 },
+                        { 16, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27774, { 16, 0, height + 29 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27774), { 16, 0, height + 29 },
+                        { 16, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27779, { 16, 16, height + 29 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27779), { 16, 16, height + 29 },
+                        { 16, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27784, { 0, 16, height + 29 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27784), { 0, 16, height + 29 },
+                        { 16, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -9456,19 +9627,23 @@ static void inverted_rc_track_right_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27770, { 16, 0, height + 29 }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27770), { 16, 0, height + 29 },
+                        { 16, 32, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27775, { 0, 0, height + 29 }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27775), { 0, 0, height + 29 },
+                        { 16, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27780, { 0, 0, height + 29 }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27780), { 0, 0, height + 29 },
+                        { 16, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27785, { 16, 0, height + 29 }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27785), { 16, 0, height + 29 },
+                        { 16, 32, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -9483,19 +9658,23 @@ static void inverted_rc_track_right_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27771, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27771), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27776, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27776), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27781, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27781), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27786, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27786), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
             }
 
@@ -9548,22 +9727,22 @@ static void inverted_rc_track_25_deg_up_to_left_banked_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27719, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27719), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 45 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27720, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27720), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 45 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27721, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27721), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 45 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27722, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27722), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 45 });
             break;
     }
@@ -9613,22 +9792,22 @@ static void inverted_rc_track_25_deg_up_to_right_banked_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27723, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27723), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 45 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27724, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27724), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 45 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27725, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27725), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 45 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27726, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27726), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 45 });
             break;
     }
@@ -9678,22 +9857,22 @@ static void inverted_rc_track_left_banked_25_deg_up_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27727, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27727), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 45 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27728, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27728), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 45 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27729, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27729), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 45 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27730, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27730), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 45 });
             break;
     }
@@ -9743,22 +9922,22 @@ static void inverted_rc_track_right_banked_25_deg_up_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27731, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27731), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 45 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27732, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27732), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 45 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27733, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27733), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 45 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27734, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27734), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 45 });
             break;
     }
@@ -9844,22 +10023,22 @@ static void inverted_rc_track_left_banked_flat_to_left_banked_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27735, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27735), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27736, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27736), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27737, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27737), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27738, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27738), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
     }
@@ -9909,22 +10088,22 @@ static void inverted_rc_track_right_banked_flat_to_right_banked_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27739, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27739), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27740, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27740), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27741, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27741), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27742, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27742), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
     }
@@ -9974,22 +10153,22 @@ static void inverted_rc_track_left_banked_25_deg_up_to_left_banked_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27743, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27743), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27744, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27744), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27745, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27745), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27746, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27746), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
     }
@@ -10039,22 +10218,22 @@ static void inverted_rc_track_right_banked_25_deg_up_to_right_banked_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27747, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27747), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27748, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27748), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27749, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27749), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27750, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27750), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
     }
@@ -10140,22 +10319,22 @@ static void inverted_rc_track_flat_to_left_banked_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27695, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27695), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27696, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27696), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27697, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27697), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27698, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27698), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
     }
@@ -10205,22 +10384,22 @@ static void inverted_rc_track_flat_to_right_banked_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27699, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27699), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27700, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27700), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27701, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27701), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27702, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27702), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
     }
@@ -10270,22 +10449,22 @@ static void inverted_rc_track_left_banked_25_deg_up_to_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27703, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27703), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27704, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27704), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27705, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27705), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27706, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27706), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
     }
@@ -10335,22 +10514,22 @@ static void inverted_rc_track_right_banked_25_deg_up_to_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27707, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27707), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27708, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27708), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27709, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27709), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 27710, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27710), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 37 });
             break;
     }

--- a/src/openrct2/ride/coaster/JuniorRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/JuniorRollerCoaster.cpp
@@ -1847,7 +1847,7 @@ void junior_rc_paint_track_flat(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
-    uint32_t imageId = junior_rc_track_pieces_flat[EnumValue(chainType)][direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(junior_rc_track_pieces_flat[EnumValue(chainType)][direction]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 6, height }, { 32, 20, 1 });
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
 
@@ -1867,24 +1867,24 @@ void junior_rc_paint_station(
     paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, bool drawBlockBrake)
 {
-    uint32_t imageId;
+    ImageId imageId;
 
     bool isBraked = trackElement.BlockBrakeClosed();
 
     if (direction == 0 || direction == 2)
     {
         // height -= 2 (height - 2)
-        imageId = SPR_STATION_BASE_B_SW_NE | session.TrackColours[SCHEME_MISC];
+        imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_STATION_BASE_B_SW_NE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height - 2 }, { 32, 28, 1 }, { 0, 2, height });
 
         // height += 2 (height)
         if (trackElement.GetTrackType() == TrackElemType::EndStation && drawBlockBrake)
         {
-            imageId = junior_rc_track_pieces_block_brake[isBraked][direction] | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(junior_rc_track_pieces_block_brake[isBraked][direction]);
         }
         else
         {
-            imageId = junior_rc_track_pieces_station[false][direction] | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(junior_rc_track_pieces_station[false][direction]);
         }
         PaintAddImageAsChild(session, imageId, { 0, 6, height }, { 32, 20, 1 }, { 0, 0, height });
 
@@ -1896,17 +1896,17 @@ void junior_rc_paint_station(
     else if (direction == 1 || direction == 3)
     {
         // height -= 2 (height - 2)
-        imageId = SPR_STATION_BASE_B_NW_SE | session.TrackColours[SCHEME_MISC];
+        imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_STATION_BASE_B_NW_SE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height - 2 }, { 28, 32, 1 }, { 2, 0, height });
 
         // height += 2 (height)
         if (trackElement.GetTrackType() == TrackElemType::EndStation && drawBlockBrake)
         {
-            imageId = junior_rc_track_pieces_block_brake[isBraked][direction] | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(junior_rc_track_pieces_block_brake[isBraked][direction]);
         }
         else
         {
-            imageId = junior_rc_track_pieces_station[false][direction] | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(junior_rc_track_pieces_station[false][direction]);
         }
         PaintAddImageAsChild(session, imageId, { 6, 0, height }, { 20, 32, 1 }, { 0, 0, height });
 
@@ -1925,7 +1925,8 @@ void junior_rc_paint_track_25_deg_up(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
-    uint32_t imageId = junior_rc_track_pieces_25_deg_up[EnumValue(chainType)][direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+        junior_rc_track_pieces_25_deg_up[EnumValue(chainType)][direction]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 6, height }, { 32, 20, 1 });
 
     int8_t tunnelHeights[4] = { -8, 8, 8, -8 };
@@ -1947,8 +1948,8 @@ void junior_rc_paint_track_flat_to_25_deg_up(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
-    uint32_t imageId = junior_rc_track_pieces_flat_to_25_deg_up[EnumValue(chainType)][direction]
-        | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+        junior_rc_track_pieces_flat_to_25_deg_up[EnumValue(chainType)][direction]);
 
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 6, height }, { 32, 20, 1 });
     if (direction == 0 || direction == 3)
@@ -1976,8 +1977,8 @@ void junior_rc_paint_track_25_deg_up_to_flat(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
-    uint32_t imageId = junior_rc_track_pieces_25_deg_up_to_flat[EnumValue(chainType)][direction]
-        | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+        junior_rc_track_pieces_25_deg_up_to_flat[EnumValue(chainType)][direction]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 6, height }, { 32, 20, 1 });
 
     uint8_t tunnelType;
@@ -2117,9 +2118,9 @@ static void junior_rc_flat_to_left_bank_paint_setup(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t image_id;
+    ImageId image_id;
 
-    image_id = junior_rc_track_pieces_flat_to_left_bank[direction][0] | session.TrackColours[SCHEME_TRACK];
+    image_id = session.TrackColours[SCHEME_TRACK].WithIndex(junior_rc_track_pieces_flat_to_left_bank[direction][0]);
     if (direction & 1)
     {
         PaintAddImageAsParent(session, image_id, { 0, 0, height }, { 20, 32, 1 }, { 6, 0, height });
@@ -2135,7 +2136,7 @@ static void junior_rc_flat_to_left_bank_paint_setup(
 
     if (junior_rc_track_pieces_flat_to_left_bank[direction][1] != 0)
     {
-        image_id = junior_rc_track_pieces_flat_to_left_bank[direction][1] | session.TrackColours[SCHEME_TRACK];
+        image_id = session.TrackColours[SCHEME_TRACK].WithIndex(junior_rc_track_pieces_flat_to_left_bank[direction][1]);
 
         if (direction & 1)
         {
@@ -2165,9 +2166,9 @@ static void junior_rc_flat_to_right_bank_paint_setup(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t image_id;
+    ImageId image_id;
 
-    image_id = junior_rc_track_pieces_flat_to_right_bank[direction][0] | session.TrackColours[SCHEME_TRACK];
+    image_id = session.TrackColours[SCHEME_TRACK].WithIndex(junior_rc_track_pieces_flat_to_right_bank[direction][0]);
     if (direction & 1)
     {
         PaintAddImageAsParent(session, image_id, { 0, 0, height }, { 20, 32, 1 }, { 6, 0, height });
@@ -2183,7 +2184,7 @@ static void junior_rc_flat_to_right_bank_paint_setup(
 
     if (junior_rc_track_pieces_flat_to_right_bank[direction][1] != 0)
     {
-        image_id = junior_rc_track_pieces_flat_to_right_bank[direction][1] | session.TrackColours[SCHEME_TRACK];
+        image_id = session.TrackColours[SCHEME_TRACK].WithIndex(junior_rc_track_pieces_flat_to_right_bank[direction][1]);
 
         if (direction & 1)
         {
@@ -2299,12 +2300,12 @@ static void junior_rc_banked_right_quarter_turn_5_tiles_paint_setup(
 
     if (direction == 1 && trackSequence == 6)
     {
-        uint32_t imageId = SPR_JUNIOR_RC_BANKED_QUARTER_TURN_5_TILES_NW_SW_PART_4_2 | session.TrackColours[SCHEME_TRACK];
+        auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_JUNIOR_RC_BANKED_QUARTER_TURN_5_TILES_NW_SW_PART_4_2);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
     }
     else if (direction == 3 && trackSequence == 0)
     {
-        uint32_t imageId = SPR_JUNIOR_RC_BANKED_QUARTER_TURN_5_TILES_SE_NE_PART_0_2 | session.TrackColours[SCHEME_TRACK];
+        auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_JUNIOR_RC_BANKED_QUARTER_TURN_5_TILES_SE_NE_PART_0_2);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
     }
 
@@ -2393,9 +2394,9 @@ static void junior_rc_left_bank_to_25_deg_up_paint_setup(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t image_id;
+    ImageId image_id;
 
-    image_id = junior_rc_track_pieces_left_banked_to_25_deg_up[direction][0] | session.TrackColours[SCHEME_TRACK];
+    image_id = session.TrackColours[SCHEME_TRACK].WithIndex(junior_rc_track_pieces_left_banked_to_25_deg_up[direction][0]);
     if (direction & 1)
     {
         PaintAddImageAsParent(session, image_id, { 0, 0, height }, { 20, 32, 1 }, { 6, 0, height });
@@ -2407,7 +2408,7 @@ static void junior_rc_left_bank_to_25_deg_up_paint_setup(
 
     if (junior_rc_track_pieces_left_banked_to_25_deg_up[direction][1] != 0)
     {
-        image_id = junior_rc_track_pieces_left_banked_to_25_deg_up[direction][1] | session.TrackColours[SCHEME_TRACK];
+        image_id = session.TrackColours[SCHEME_TRACK].WithIndex(junior_rc_track_pieces_left_banked_to_25_deg_up[direction][1]);
 
         if (direction & 1)
         {
@@ -2453,9 +2454,9 @@ static void junior_rc_right_bank_to_25_deg_up_paint_setup(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t image_id;
+    ImageId image_id;
 
-    image_id = junior_rc_track_pieces_right_banked_to_25_deg_up[direction][0] | session.TrackColours[SCHEME_TRACK];
+    image_id = session.TrackColours[SCHEME_TRACK].WithIndex(junior_rc_track_pieces_right_banked_to_25_deg_up[direction][0]);
     if (direction & 1)
     {
         PaintAddImageAsParent(session, image_id, { 0, 0, height }, { 20, 32, 1 }, { 6, 0, height });
@@ -2467,7 +2468,7 @@ static void junior_rc_right_bank_to_25_deg_up_paint_setup(
 
     if (junior_rc_track_pieces_right_banked_to_25_deg_up[direction][1] != 0)
     {
-        image_id = junior_rc_track_pieces_right_banked_to_25_deg_up[direction][1] | session.TrackColours[SCHEME_TRACK];
+        image_id = session.TrackColours[SCHEME_TRACK].WithIndex(junior_rc_track_pieces_right_banked_to_25_deg_up[direction][1]);
 
         if (direction & 1)
         {
@@ -2513,7 +2514,7 @@ static void junior_rc_25_deg_up_to_left_bank_paint_setup(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t image_id;
+    ImageId image_id;
 
     uint8_t tunnelType;
     int16_t tunnelHeight;
@@ -2528,7 +2529,7 @@ static void junior_rc_25_deg_up_to_left_bank_paint_setup(
         tunnelHeight = height - 8;
     }
 
-    image_id = junior_rc_track_pieces_25_deg_up_to_left_bank[direction][0] | session.TrackColours[SCHEME_TRACK];
+    image_id = session.TrackColours[SCHEME_TRACK].WithIndex(junior_rc_track_pieces_25_deg_up_to_left_bank[direction][0]);
     if (direction & 1)
     {
         PaintAddImageAsParent(session, image_id, { 0, 0, height }, { 20, 32, 1 }, { 6, 0, height });
@@ -2544,7 +2545,7 @@ static void junior_rc_25_deg_up_to_left_bank_paint_setup(
 
     if (junior_rc_track_pieces_25_deg_up_to_left_bank[direction][1] != 0)
     {
-        image_id = junior_rc_track_pieces_25_deg_up_to_left_bank[direction][1] | session.TrackColours[SCHEME_TRACK];
+        image_id = session.TrackColours[SCHEME_TRACK].WithIndex(junior_rc_track_pieces_25_deg_up_to_left_bank[direction][1]);
 
         if (direction & 1)
         {
@@ -2574,7 +2575,7 @@ static void junior_rc_25_deg_up_to_right_bank_paint_setup(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t image_id;
+    ImageId image_id;
 
     uint8_t tunnelType;
     int16_t tunnelHeight;
@@ -2589,7 +2590,7 @@ static void junior_rc_25_deg_up_to_right_bank_paint_setup(
         tunnelHeight = height - 8;
     }
 
-    image_id = junior_rc_track_pieces_25_deg_up_to_right_bank[direction][0] | session.TrackColours[SCHEME_TRACK];
+    image_id = session.TrackColours[SCHEME_TRACK].WithIndex(junior_rc_track_pieces_25_deg_up_to_right_bank[direction][0]);
     if (direction & 1)
     {
         PaintAddImageAsParent(session, image_id, { 0, 0, height }, { 20, 32, 1 }, { 6, 0, height });
@@ -2605,7 +2606,7 @@ static void junior_rc_25_deg_up_to_right_bank_paint_setup(
 
     if (junior_rc_track_pieces_25_deg_up_to_right_bank[direction][1] != 0)
     {
-        image_id = junior_rc_track_pieces_25_deg_up_to_right_bank[direction][1] | session.TrackColours[SCHEME_TRACK];
+        image_id = session.TrackColours[SCHEME_TRACK].WithIndex(junior_rc_track_pieces_25_deg_up_to_right_bank[direction][1]);
 
         if (direction & 1)
         {
@@ -2689,9 +2690,9 @@ static void junior_rc_left_bank_paint_setup(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t image_id;
+    ImageId image_id;
 
-    image_id = junior_rc_track_pieces_left_bank[direction] | session.TrackColours[SCHEME_TRACK];
+    image_id = session.TrackColours[SCHEME_TRACK].WithIndex(junior_rc_track_pieces_left_bank[direction]);
     PaintAddImageAsParent(
         session, image_id, { 0, 0, height }, junior_rc_left_bank_bound_lengths[direction],
         { junior_rc_left_bank_bound_offsets[direction], height });
@@ -2952,7 +2953,8 @@ static void junior_rc_s_bend_left_paint_setup(
         { 32, 20 },
     };
 
-    uint32_t imageId = junior_rc_track_pieces_s_bend_left[(direction & 1)][trackSequence] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+        junior_rc_track_pieces_s_bend_left[(direction & 1)][trackSequence]);
     CoordsXY offset = offsetList[trackSequence];
     CoordsXY bounds = boundsList[trackSequence];
     if (direction == 0 || direction == 2)
@@ -3053,7 +3055,8 @@ static void junior_rc_s_bend_right_paint_setup(
         { 32, 20 },
     };
 
-    uint32_t imageId = junior_rc_track_pieces_s_bend_right[direction & 1][trackSequence] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+        junior_rc_track_pieces_s_bend_right[direction & 1][trackSequence]);
     CoordsXY offset = offsetList[trackSequence];
     CoordsXY bounds = boundsList[trackSequence];
     if (direction == 0 || direction == 2)
@@ -3247,12 +3250,12 @@ static void junior_rc_right_quarter_turn_3_tiles_bank_paint_setup(
 
     if (direction == 1 && trackSequence == 3)
     {
-        uint32_t imageId = SPR_JUNIOR_RC_BANKED_QUARTER_TURN_3_TILES_NW_SW_PART_2_2 | session.TrackColours[SCHEME_TRACK];
+        auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_JUNIOR_RC_BANKED_QUARTER_TURN_3_TILES_NW_SW_PART_2_2);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
     }
     else if (direction == 3 && trackSequence == 0)
     {
-        uint32_t imageId = SPR_JUNIOR_RC_BANKED_QUARTER_TURN_3_TILES_SE_NE_PART_0_2 | session.TrackColours[SCHEME_TRACK];
+        auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_JUNIOR_RC_BANKED_QUARTER_TURN_3_TILES_SE_NE_PART_0_2);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
     }
 
@@ -3291,7 +3294,7 @@ void junior_rc_paint_track_right_quarter_turn_3_tiles_25_deg_up(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
-    uint32_t imageId = 0;
+    auto imageId = ImageId(0);
     CoordsXY offset;
     CoordsXY boundsLength;
     CoordsXY boundsOffset;
@@ -3299,21 +3302,21 @@ void junior_rc_paint_track_right_quarter_turn_3_tiles_25_deg_up(
     switch (trackSequence)
     {
         case 0:
-            imageId = junior_rc_track_pieces_right_quarter_turn_3_tiles_25_deg_up[EnumValue(chainType)][direction][0]
-                | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+                junior_rc_track_pieces_right_quarter_turn_3_tiles_25_deg_up[EnumValue(chainType)][direction][0]);
             offset = defaultRightQuarterTurn3TilesOffsets[direction][0];
             boundsLength = defaultRightQuarterTurn3TilesBoundLengths[direction][0];
             boundsOffset = offset;
             break;
         case 3:
-            imageId = junior_rc_track_pieces_right_quarter_turn_3_tiles_25_deg_up[EnumValue(chainType)][direction][1]
-                | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+                junior_rc_track_pieces_right_quarter_turn_3_tiles_25_deg_up[EnumValue(chainType)][direction][1]);
             offset = defaultRightQuarterTurn3TilesOffsets[direction][2];
             boundsLength = defaultRightQuarterTurn3TilesBoundLengths[direction][2];
             boundsOffset = offset;
             break;
     }
-    if (imageId != 0)
+    if (imageId.GetIndex() != 0)
     {
         PaintAddImageAsParent(session, imageId, { offset, height }, { boundsLength, 1 }, { boundsOffset, height });
     }
@@ -3373,7 +3376,7 @@ void junior_rc_paint_track_right_quarter_turn_3_tiles_25_deg_down(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
-    uint32_t imageId = 0;
+    auto imageId = ImageId(0);
     CoordsXY offset;
     CoordsXY boundsLength;
     CoordsXY boundsOffset;
@@ -3381,21 +3384,21 @@ void junior_rc_paint_track_right_quarter_turn_3_tiles_25_deg_down(
     switch (trackSequence)
     {
         case 0:
-            imageId = junior_rc_track_pieces_right_quarter_turn_3_tiles_25_deg_down[EnumValue(chainType)][direction][0]
-                | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+                junior_rc_track_pieces_right_quarter_turn_3_tiles_25_deg_down[EnumValue(chainType)][direction][0]);
             offset = defaultRightQuarterTurn3TilesOffsets[direction][0];
             boundsLength = defaultRightQuarterTurn3TilesBoundLengths[direction][0];
             boundsOffset = offset;
             break;
         case 3:
-            imageId = junior_rc_track_pieces_right_quarter_turn_3_tiles_25_deg_down[EnumValue(chainType)][direction][1]
-                | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+                junior_rc_track_pieces_right_quarter_turn_3_tiles_25_deg_down[EnumValue(chainType)][direction][1]);
             offset = defaultRightQuarterTurn3TilesOffsets[direction][2];
             boundsLength = defaultRightQuarterTurn3TilesBoundLengths[direction][2];
             boundsOffset = offset;
             break;
     }
-    if (imageId != 0)
+    if (imageId.GetIndex() != 0)
     {
         PaintAddImageAsParent(
             session, imageId, { offset, height }, { boundsLength.x, boundsLength.y, 1 }, { boundsOffset, height });
@@ -3890,9 +3893,9 @@ static void junior_rc_brake_paint_setup(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t image_id;
+    ImageId image_id;
 
-    image_id = junior_rc_track_pieces_brake[direction] | session.TrackColours[SCHEME_TRACK];
+    image_id = session.TrackColours[SCHEME_TRACK].WithIndex(junior_rc_track_pieces_brake[direction]);
     if (direction & 1)
     {
         PaintAddImageAsParent(session, image_id, { 6, 0, height }, { 20, 32, 1 });
@@ -3924,11 +3927,11 @@ static void junior_rc_block_brake_paint_setup(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t image_id;
+    ImageId image_id;
 
     bool isBraked = trackElement.BlockBrakeClosed();
 
-    image_id = junior_rc_track_pieces_block_brake[isBraked][direction] | session.TrackColours[SCHEME_TRACK];
+    image_id = session.TrackColours[SCHEME_TRACK].WithIndex(junior_rc_track_pieces_block_brake[isBraked][direction]);
     if (direction & 1)
     {
         PaintAddImageAsParent(session, image_id, { 6, 0, height }, { 20, 32, 1 });
@@ -4794,7 +4797,7 @@ static void junior_rc_diag_flat_to_left_bank_paint_setup(
 
     if (direction == 0 && trackSequence == 1)
     {
-        uint32_t imageId = SPR_JUNIOR_RC_DIAG_FLAT_TO_LEFT_BANK_W_E_PART_0_2 | session.TrackColours[SCHEME_TRACK];
+        auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_JUNIOR_RC_DIAG_FLAT_TO_LEFT_BANK_W_E_PART_0_2);
 
         PaintAddImageAsParent(session, imageId, { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
     }
@@ -4821,7 +4824,7 @@ static void junior_rc_diag_flat_to_right_bank_paint_setup(
 
     if (direction == 2 && trackSequence == 2)
     {
-        uint32_t imageId = SPR_JUNIOR_RC_DIAG_FLAT_TO_RIGHT_BANK_E_W_PART_0_2 | session.TrackColours[SCHEME_TRACK];
+        auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_JUNIOR_RC_DIAG_FLAT_TO_RIGHT_BANK_E_W_PART_0_2);
 
         PaintAddImageAsParent(session, imageId, { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
     }
@@ -4848,7 +4851,7 @@ static void junior_rc_diag_left_bank_to_flat_paint_setup(
 
     if (direction == 0 && trackSequence == 1)
     {
-        uint32_t imageId = SPR_JUNIOR_RC_DIAG_FLAT_TO_RIGHT_BANK_E_W_PART_0_2 | session.TrackColours[SCHEME_TRACK];
+        auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_JUNIOR_RC_DIAG_FLAT_TO_RIGHT_BANK_E_W_PART_0_2);
 
         PaintAddImageAsParent(session, imageId, { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
     }
@@ -4875,7 +4878,7 @@ static void junior_rc_diag_right_bank_to_flat_paint_setup(
 
     if (direction == 2 && trackSequence == 2)
     {
-        uint32_t imageId = SPR_JUNIOR_RC_DIAG_FLAT_TO_LEFT_BANK_W_E_PART_0_2 | session.TrackColours[SCHEME_TRACK];
+        auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_JUNIOR_RC_DIAG_FLAT_TO_LEFT_BANK_W_E_PART_0_2);
 
         PaintAddImageAsParent(session, imageId, { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
     }
@@ -4902,7 +4905,7 @@ static void junior_rc_diag_left_bank_to_25_deg_up_paint_setup(
 
     if (direction == 0 && trackSequence == 1)
     {
-        uint32_t imageId = SPR_JUNIOR_RC_DIAG_LEFT_BANK_TO_25_DEG_UP_W_E_PART_0_2 | session.TrackColours[SCHEME_TRACK];
+        auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_JUNIOR_RC_DIAG_LEFT_BANK_TO_25_DEG_UP_W_E_PART_0_2);
 
         PaintAddImageAsParent(session, imageId, { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
     }
@@ -4929,7 +4932,7 @@ static void junior_rc_diag_right_bank_to_25_deg_up_paint_setup(
 
     if (direction == 2 && trackSequence == 2)
     {
-        uint32_t imageId = SPR_JUNIOR_RC_DIAG_RIGHT_BANK_TO_25_DEG_UP_E_W_PART_0_2 | session.TrackColours[SCHEME_TRACK];
+        auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_JUNIOR_RC_DIAG_RIGHT_BANK_TO_25_DEG_UP_E_W_PART_0_2);
 
         PaintAddImageAsParent(session, imageId, { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
     }
@@ -4956,7 +4959,7 @@ static void junior_rc_diag_25_deg_up_to_left_bank_paint_setup(
 
     if (direction == 0 && trackSequence == 1)
     {
-        uint32_t imageId = SPR_JUNIOR_RC_DIAG_25_DEG_UP_TO_LEFT_BANK_W_E_PART_0_2 | session.TrackColours[SCHEME_TRACK];
+        auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_JUNIOR_RC_DIAG_25_DEG_UP_TO_LEFT_BANK_W_E_PART_0_2);
 
         PaintAddImageAsParent(session, imageId, { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
     }
@@ -4983,7 +4986,7 @@ static void junior_rc_diag_25_deg_up_to_right_bank_paint_setup(
 
     if (direction == 2 && trackSequence == 2)
     {
-        uint32_t imageId = SPR_JUNIOR_RC_DIAG_25_DEG_UP_TO_RIGHT_BANK_E_W_PART_0_2 | session.TrackColours[SCHEME_TRACK];
+        auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_JUNIOR_RC_DIAG_25_DEG_UP_TO_RIGHT_BANK_E_W_PART_0_2);
 
         PaintAddImageAsParent(session, imageId, { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
     }
@@ -5010,7 +5013,7 @@ static void junior_rc_diag_left_bank_to_25_deg_down_paint_setup(
 
     if (direction == 0 && trackSequence == 1)
     {
-        uint32_t imageId = SPR_JUNIOR_RC_DIAG_25_DEG_UP_TO_RIGHT_BANK_E_W_PART_0_2 | session.TrackColours[SCHEME_TRACK];
+        auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_JUNIOR_RC_DIAG_25_DEG_UP_TO_RIGHT_BANK_E_W_PART_0_2);
 
         PaintAddImageAsParent(session, imageId, { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
     }
@@ -5037,7 +5040,7 @@ static void junior_rc_diag_right_bank_to_25_deg_down_paint_setup(
 
     if (direction == 2 && trackSequence == 2)
     {
-        uint32_t imageId = SPR_JUNIOR_RC_DIAG_25_DEG_UP_TO_LEFT_BANK_W_E_PART_0_2 | session.TrackColours[SCHEME_TRACK];
+        auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_JUNIOR_RC_DIAG_25_DEG_UP_TO_LEFT_BANK_W_E_PART_0_2);
 
         PaintAddImageAsParent(session, imageId, { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
     }
@@ -5064,7 +5067,7 @@ static void junior_rc_diag_25_deg_down_to_left_bank_paint_setup(
 
     if (direction == 0 && trackSequence == 1)
     {
-        uint32_t imageId = SPR_JUNIOR_RC_DIAG_RIGHT_BANK_TO_25_DEG_UP_E_W_PART_0_2 | session.TrackColours[SCHEME_TRACK];
+        auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_JUNIOR_RC_DIAG_RIGHT_BANK_TO_25_DEG_UP_E_W_PART_0_2);
 
         PaintAddImageAsParent(session, imageId, { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
     }
@@ -5091,7 +5094,7 @@ static void junior_rc_diag_25_deg_down_to_right_bank_paint_setup(
 
     if (direction == 2 && trackSequence == 2)
     {
-        uint32_t imageId = SPR_JUNIOR_RC_DIAG_LEFT_BANK_TO_25_DEG_UP_W_E_PART_0_2 | session.TrackColours[SCHEME_TRACK];
+        auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_JUNIOR_RC_DIAG_LEFT_BANK_TO_25_DEG_UP_W_E_PART_0_2);
 
         PaintAddImageAsParent(session, imageId, { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
     }
@@ -5199,9 +5202,8 @@ void junior_rc_paint_track_60_deg_up(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
-    uint32_t image_id = session.TrackColours[SCHEME_TRACK];
-
-    image_id |= junior_rc_track_pieces_60_deg_up[EnumValue(chainType)][direction];
+    auto image_id = session.TrackColours[SCHEME_TRACK].WithIndex(
+        junior_rc_track_pieces_60_deg_up[EnumValue(chainType)][direction]);
 
     PaintAddImageAsParent(
         session, image_id, { junior_rc_60_deg_up_tile_offsets[direction], height },
@@ -5279,9 +5281,8 @@ void junior_rc_paint_track_25_deg_up_to_60_deg_up(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
-    uint32_t image_id = session.TrackColours[SCHEME_TRACK];
-
-    image_id |= junior_rc_track_pieces_25_deg_up_to_60_deg_up[EnumValue(chainType)][direction][0];
+    auto image_id = session.TrackColours[SCHEME_TRACK].WithIndex(
+        junior_rc_track_pieces_25_deg_up_to_60_deg_up[EnumValue(chainType)][direction][0]);
 
     PaintAddImageAsParent(
         session, image_id, { junior_rc_60_deg_up_tile_offsets[direction], height },
@@ -5291,9 +5292,8 @@ void junior_rc_paint_track_25_deg_up_to_60_deg_up(
 
     if (junior_rc_track_pieces_25_deg_up_to_60_deg_up[EnumValue(chainType)][direction][1] != 0)
     {
-        image_id = session.TrackColours[SCHEME_TRACK];
-
-        image_id |= junior_rc_track_pieces_25_deg_up_to_60_deg_up[EnumValue(chainType)][direction][1];
+        image_id = session.TrackColours[SCHEME_TRACK].WithIndex(
+            junior_rc_track_pieces_25_deg_up_to_60_deg_up[EnumValue(chainType)][direction][1]);
 
         PaintAddImageAsParent(
             session, image_id, { junior_rc_60_deg_up_tile_offsets[direction], height },
@@ -5352,9 +5352,8 @@ void junior_rc_paint_track_60_deg_up_to_25_deg_up(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
-    uint32_t image_id = session.TrackColours[SCHEME_TRACK];
-
-    image_id |= junior_rc_track_pieces_60_deg_up_to_25_deg_up[EnumValue(chainType)][direction][0];
+    auto image_id = session.TrackColours[SCHEME_TRACK].WithIndex(
+        junior_rc_track_pieces_60_deg_up_to_25_deg_up[EnumValue(chainType)][direction][0]);
 
     PaintAddImageAsParent(
         session, image_id, { junior_rc_60_deg_up_tile_offsets[direction], height },
@@ -5364,9 +5363,8 @@ void junior_rc_paint_track_60_deg_up_to_25_deg_up(
 
     if (junior_rc_track_pieces_60_deg_up_to_25_deg_up[EnumValue(chainType)][direction][1] != 0)
     {
-        image_id = session.TrackColours[SCHEME_TRACK];
-
-        image_id |= junior_rc_track_pieces_60_deg_up_to_25_deg_up[EnumValue(chainType)][direction][1];
+        image_id = session.TrackColours[SCHEME_TRACK].WithIndex(
+            junior_rc_track_pieces_60_deg_up_to_25_deg_up[EnumValue(chainType)][direction][1]);
 
         PaintAddImageAsParent(
             session, image_id, { junior_rc_60_deg_up_tile_offsets[direction], height },
@@ -5490,8 +5488,8 @@ void junior_rc_paint_track_diag_60_deg_up_to_25_deg_up(
     {
         PaintAddImageAsParent(
             session,
-            junior_rc_track_pieces_diag_60_deg_up_to_25_deg_up[EnumValue(chainType)][direction]
-                | session.TrackColours[SCHEME_TRACK],
+            session.TrackColours[SCHEME_TRACK].WithIndex(
+                junior_rc_track_pieces_diag_60_deg_up_to_25_deg_up[EnumValue(chainType)][direction]),
             { -16, -16, height }, { 16, 16, 1 }, { 0, 0, height });
     }
     else
@@ -5522,8 +5520,8 @@ void junior_rc_paint_track_diag_25_deg_down_to_60_deg_down(
     {
         PaintAddImageAsParent(
             session,
-            junior_rc_track_pieces_diag_25_deg_down_to_60_deg_down[EnumValue(chainType)][direction]
-                | session.TrackColours[SCHEME_TRACK],
+            session.TrackColours[SCHEME_TRACK].WithIndex(
+                junior_rc_track_pieces_diag_25_deg_down_to_60_deg_down[EnumValue(chainType)][direction]),
             { -16, -16, height }, { 16, 16, 1 }, { 0, 0, height });
     }
     else
@@ -5666,11 +5664,9 @@ static void junior_rc_flat_to_60_deg_up_paint_setup(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t image_id = session.TrackColours[SCHEME_TRACK];
-
     bool isChained = trackElement.HasChain();
-
-    image_id |= junior_rc_track_pieces_flat_to_60_deg_up[isChained][direction][0];
+    auto image_id = session.TrackColours[SCHEME_TRACK].WithIndex(
+        junior_rc_track_pieces_flat_to_60_deg_up[isChained][direction][0]);
 
     PaintAddImageAsParent(
         session, image_id, { junior_rc_flat_to_60_deg_up_tile_offsets[direction][0], height + 24 },
@@ -5679,9 +5675,8 @@ static void junior_rc_flat_to_60_deg_up_paint_setup(
 
     if (junior_rc_track_pieces_flat_to_60_deg_up[isChained][direction][1] != 0)
     {
-        image_id = session.TrackColours[SCHEME_TRACK];
-
-        image_id |= junior_rc_track_pieces_flat_to_60_deg_up[isChained][direction][1];
+        image_id = session.TrackColours[SCHEME_TRACK].WithIndex(
+            junior_rc_track_pieces_flat_to_60_deg_up[isChained][direction][1]);
 
         PaintAddImageAsParent(
             session, image_id, { junior_rc_flat_to_60_deg_up_tile_offsets[direction][1], height },
@@ -5729,11 +5724,9 @@ static void junior_rc_60_deg_up_to_flat_paint_setup(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t image_id = session.TrackColours[SCHEME_TRACK];
-
     bool isChained = trackElement.HasChain();
-
-    image_id |= junior_rc_track_pieces_60_deg_up_to_flat[isChained][direction][0];
+    auto image_id = session.TrackColours[SCHEME_TRACK].WithIndex(
+        junior_rc_track_pieces_60_deg_up_to_flat[isChained][direction][0]);
 
     PaintAddImageAsParent(
         session, image_id, { junior_rc_60_deg_up_to_flat_tile_offsets[direction][0], height + 24 },
@@ -5742,9 +5735,8 @@ static void junior_rc_60_deg_up_to_flat_paint_setup(
 
     if (junior_rc_track_pieces_60_deg_up_to_flat[isChained][direction][1] != 0)
     {
-        image_id = session.TrackColours[SCHEME_TRACK];
-
-        image_id |= junior_rc_track_pieces_60_deg_up_to_flat[isChained][direction][1];
+        image_id = session.TrackColours[SCHEME_TRACK].WithIndex(
+            junior_rc_track_pieces_60_deg_up_to_flat[isChained][direction][1]);
 
         PaintAddImageAsParent(
             session, image_id, { junior_rc_60_deg_up_to_flat_tile_offsets[direction][1], height },
@@ -5870,14 +5862,16 @@ static void junior_rc_booster_paint_setup(
     if (direction & 1)
     {
         PaintAddImageAsParent(
-            session, SPR_JUNIOR_RC_BOOSTER_NE_SW | session.TrackColours[SCHEME_TRACK], { 0, 0, height }, { 20, 32, 1 });
+            session, session.TrackColours[SCHEME_TRACK].WithIndex(SPR_JUNIOR_RC_BOOSTER_NE_SW), { 0, 0, height },
+            { 20, 32, 1 });
 
         paint_util_push_tunnel_right(session, height, TUNNEL_0);
     }
     else
     {
         PaintAddImageAsParent(
-            session, SPR_JUNIOR_RC_BOOSTER_NW_SE | session.TrackColours[SCHEME_TRACK], { 0, 0, height }, { 32, 20, 1 });
+            session, session.TrackColours[SCHEME_TRACK].WithIndex(SPR_JUNIOR_RC_BOOSTER_NW_SE), { 0, 0, height },
+            { 32, 20, 1 });
 
         paint_util_push_tunnel_left(session, height, TUNNEL_0);
     }
@@ -5897,14 +5891,15 @@ static void junior_rc_track_on_ride_photo(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId = junior_rc_track_pieces_flat[0][direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(junior_rc_track_pieces_flat[0][direction]);
     constexpr const int8_t photoCameraOffset = -1;
 
     switch (direction)
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height + photoCameraOffset }, { 32, 32, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height + photoCameraOffset },
+                { 32, 32, 1 });
             metal_a_supports_paint_setup(
                 session, METAL_SUPPORTS_FORK, 5, 6, height + photoCameraOffset, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(
@@ -5913,7 +5908,8 @@ static void junior_rc_track_on_ride_photo(
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height + photoCameraOffset }, { 32, 32, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height + photoCameraOffset },
+                { 32, 32, 1 });
             metal_a_supports_paint_setup(
                 session, METAL_SUPPORTS_FORK_ALT, 6, 6, height + photoCameraOffset, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(
@@ -5922,7 +5918,8 @@ static void junior_rc_track_on_ride_photo(
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height + photoCameraOffset }, { 32, 32, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height + photoCameraOffset },
+                { 32, 32, 1 });
             metal_a_supports_paint_setup(
                 session, METAL_SUPPORTS_FORK, 5, 6, height + photoCameraOffset, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(
@@ -5931,7 +5928,8 @@ static void junior_rc_track_on_ride_photo(
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height + photoCameraOffset }, { 32, 32, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height + photoCameraOffset },
+                { 32, 32, 1 });
             metal_a_supports_paint_setup(
                 session, METAL_SUPPORTS_FORK_ALT, 6, 6, height + photoCameraOffset, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(

--- a/src/openrct2/ride/coaster/LayDownRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/LayDownRollerCoaster.cpp
@@ -31,23 +31,23 @@ static void lay_down_rc_track_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16226, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16226), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16227, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16227), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16228, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16228), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16229, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16229), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -63,14 +63,14 @@ static void lay_down_rc_track_flat(
                 case 0:
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16224, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16224), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16225, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16225), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -93,14 +93,14 @@ static void lay_down_rc_track_flat(
                 case 0:
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26557, { 0, 0, height + 24 }, { 32, 20, 1 },
-                        { 0, 6, height + 22 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26557), { 0, 0, height + 24 },
+                        { 32, 20, 1 }, { 0, 6, height + 22 });
                     break;
                 case 1:
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26558, { 0, 0, height + 24 }, { 32, 20, 1 },
-                        { 0, 6, height + 22 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26558), { 0, 0, height + 24 },
+                        { 32, 20, 1 }, { 0, 6, height + 22 });
                     break;
             }
         }
@@ -111,14 +111,14 @@ static void lay_down_rc_track_flat(
                 case 0:
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26555, { 0, 0, height + 24 }, { 32, 20, 1 },
-                        { 0, 6, height + 22 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26555), { 0, 0, height + 24 },
+                        { 32, 20, 1 }, { 0, 6, height + 22 });
                     break;
                 case 1:
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26556, { 0, 0, height + 24 }, { 32, 20, 1 },
-                        { 0, 6, height + 22 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26556), { 0, 0, height + 24 },
+                        { 32, 20, 1 }, { 0, 6, height + 22 });
                     break;
             }
         }
@@ -151,13 +151,13 @@ static void lay_down_rc_track_station(
         };
 
         PaintAddImageAsParentRotated(
-            session, direction, imageIds[direction][0] | session.TrackColours[SCHEME_MISC], { 0, 0, height }, { 32, 28, 1 },
-            { 0, 2, height });
+            session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][0]), { 0, 0, height },
+            { 32, 28, 1 }, { 0, 2, height });
         PaintAddImageAsParentRotated(
-            session, direction, imageIds[direction][1] | session.TrackColours[SCHEME_TRACK], { 0, 0, height + 24 },
+            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][1]), { 0, 0, height + 24 },
             { 32, 20, 3 }, { 0, 6, height + 24 });
         PaintAddImageAsChildRotated(
-            session, direction, imageIds[direction][2] | session.TrackColours[SCHEME_SUPPORTS], { 0, 6, height + 24 },
+            session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(imageIds[direction][2]), { 0, 6, height + 24 },
             { 32, 20, 1 }, { 0, 6, height + 24 });
         track_paint_util_draw_station_metal_supports_2(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], 11);
         track_paint_util_draw_station_inverted(session, ride, direction, height, trackElement, STATION_VARIANT_1);
@@ -175,17 +175,18 @@ static void lay_down_rc_track_station(
         if (trackElement.GetTrackType() == TrackElemType::EndStation)
         {
             PaintAddImageAsParentRotated(
-                session, direction, imageIds[direction][1] | session.TrackColours[SCHEME_TRACK], { 0, 0, height },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][1]), { 0, 0, height },
                 { 32, 20, 1 }, { 0, 6, height + 3 });
         }
         else
         {
             PaintAddImageAsParentRotated(
-                session, direction, imageIds[direction][0] | session.TrackColours[SCHEME_TRACK], { 0, 0, height },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]), { 0, 0, height },
                 { 32, 20, 1 }, { 0, 6, height + 3 });
         }
         PaintAddImageAsParentRotated(
-            session, direction, imageIds[direction][2] | session.TrackColours[SCHEME_MISC], { 0, 0, height }, { 32, 32, 1 });
+            session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][2]), { 0, 0, height },
+            { 32, 32, 1 });
         track_paint_util_draw_station_metal_supports_2(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], 11);
         track_paint_util_draw_station_2(session, ride, direction, height, trackElement, 9, 11);
         paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -207,23 +208,23 @@ static void lay_down_rc_track_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16314, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16314), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16315, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16315), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16316, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16316), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16317, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16317), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -238,23 +239,23 @@ static void lay_down_rc_track_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16286, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16286), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16287, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16287), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16288, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16288), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16289, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16289), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -283,23 +284,23 @@ static void lay_down_rc_track_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26621, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 40 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26621), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 40 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26622, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 40 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26622), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 40 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26623, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 40 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26623), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 40 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26624, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 40 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26624), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 40 });
                     break;
             }
         }
@@ -309,23 +310,23 @@ static void lay_down_rc_track_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26569, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 40 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26569), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 40 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26570, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 40 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26570), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 40 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26571, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 40 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26571), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 40 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26572, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 40 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26572), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 40 });
                     break;
             }
         }
@@ -380,23 +381,23 @@ static void lay_down_rc_track_60_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16330, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16330), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16331, { 0, 0, height }, { 32, 1, 98 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16331), { 0, 0, height },
+                        { 32, 1, 98 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16332, { 0, 0, height }, { 32, 1, 98 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16332), { 0, 0, height },
+                        { 32, 1, 98 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16333, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16333), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -411,23 +412,23 @@ static void lay_down_rc_track_60_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16302, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16302), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16303, { 0, 0, height }, { 32, 1, 98 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16303), { 0, 0, height },
+                        { 32, 1, 98 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16304, { 0, 0, height }, { 32, 1, 98 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16304), { 0, 0, height },
+                        { 32, 1, 98 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16305, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16305), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -454,23 +455,23 @@ static void lay_down_rc_track_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26585, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 88 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26585), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 88 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26586, { 0, 0, height + 24 }, { 32, 2, 81 },
-                    { 0, 4, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26586), { 0, 0, height + 24 },
+                    { 32, 2, 81 }, { 0, 4, height + 6 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26587, { 0, 0, height + 24 }, { 32, 2, 81 },
-                    { 0, 4, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26587), { 0, 0, height + 24 },
+                    { 32, 2, 81 }, { 0, 4, height + 6 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26588, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 88 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26588), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 88 });
                 break;
         }
         if (direction == 0 || direction == 3)
@@ -500,23 +501,23 @@ static void lay_down_rc_track_flat_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16306, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16306), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16307, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16307), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16308, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16308), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16309, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16309), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -531,23 +532,23 @@ static void lay_down_rc_track_flat_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16278, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16278), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16279, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16279), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16280, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16280), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16281, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16281), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -576,23 +577,23 @@ static void lay_down_rc_track_flat_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26613, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26613), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26614, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26614), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26615, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26615), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26616, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26616), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
             }
         }
@@ -602,23 +603,23 @@ static void lay_down_rc_track_flat_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26561, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26561), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26562, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26562), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26563, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26563), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26564, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26564), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
             }
         }
@@ -673,29 +674,29 @@ static void lay_down_rc_track_25_deg_up_to_60_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16318, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16318), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16319, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16319), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16322, { 0, 0, height }, { 32, 1, 66 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16322), { 0, 0, height },
+                        { 32, 1, 66 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16320, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16320), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16323, { 0, 0, height }, { 32, 1, 66 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16323), { 0, 0, height },
+                        { 32, 1, 66 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16321, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16321), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -710,29 +711,29 @@ static void lay_down_rc_track_25_deg_up_to_60_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16290, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16290), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16291, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16291), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16294, { 0, 0, height }, { 32, 1, 66 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16294), { 0, 0, height },
+                        { 32, 1, 66 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16292, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16292), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16295, { 0, 0, height }, { 32, 1, 66 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16295), { 0, 0, height },
+                        { 32, 1, 66 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16293, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16293), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -759,29 +760,29 @@ static void lay_down_rc_track_25_deg_up_to_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26573, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 56 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26573), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 56 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26577, { 0, 0, height + 24 }, { 32, 10, 49 },
-                    { 0, 10, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26577), { 0, 0, height + 24 },
+                    { 32, 10, 49 }, { 0, 10, height + 6 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26574, { 0, 0, height + 24 }, { 32, 2, 49 },
-                    { 0, 4, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26574), { 0, 0, height + 24 },
+                    { 32, 2, 49 }, { 0, 4, height + 6 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26578, { 0, 0, height + 24 }, { 32, 10, 49 },
-                    { 0, 10, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26578), { 0, 0, height + 24 },
+                    { 32, 10, 49 }, { 0, 10, height + 6 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26575, { 0, 0, height + 24 }, { 32, 2, 49 },
-                    { 0, 4, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26575), { 0, 0, height + 24 },
+                    { 32, 2, 49 }, { 0, 4, height + 6 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26576, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 56 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26576), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 56 });
                 break;
         }
         if (direction == 0 || direction == 3)
@@ -811,29 +812,29 @@ static void lay_down_rc_track_60_deg_up_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16324, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16324), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16325, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16325), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16328, { 0, 0, height }, { 32, 1, 66 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16328), { 0, 0, height },
+                        { 32, 1, 66 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16326, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16326), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16329, { 0, 0, height }, { 32, 1, 66 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16329), { 0, 0, height },
+                        { 32, 1, 66 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16327, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16327), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -848,29 +849,29 @@ static void lay_down_rc_track_60_deg_up_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16296, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16296), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16297, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16297), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16300, { 0, 0, height }, { 32, 1, 66 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16300), { 0, 0, height },
+                        { 32, 1, 66 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16298, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16298), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16301, { 0, 0, height }, { 32, 1, 66 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16301), { 0, 0, height },
+                        { 32, 1, 66 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16299, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16299), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -897,29 +898,29 @@ static void lay_down_rc_track_60_deg_up_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26579, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 56 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26579), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 56 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26583, { 0, 0, height + 24 }, { 32, 10, 49 },
-                    { 0, 10, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26583), { 0, 0, height + 24 },
+                    { 32, 10, 49 }, { 0, 10, height + 6 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26580, { 0, 0, height + 24 }, { 32, 2, 49 },
-                    { 0, 4, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26580), { 0, 0, height + 24 },
+                    { 32, 2, 49 }, { 0, 4, height + 6 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26584, { 0, 0, height + 24 }, { 32, 10, 49 },
-                    { 0, 10, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26584), { 0, 0, height + 24 },
+                    { 32, 10, 49 }, { 0, 10, height + 6 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26581, { 0, 0, height + 24 }, { 32, 2, 49 },
-                    { 0, 4, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26581), { 0, 0, height + 24 },
+                    { 32, 2, 49 }, { 0, 4, height + 6 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26582, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 56 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26582), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 56 });
                 break;
         }
 
@@ -973,23 +974,23 @@ static void lay_down_rc_track_25_deg_up_to_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16310, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16310), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16311, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16311), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16312, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16312), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16313, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16313), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -1004,23 +1005,23 @@ static void lay_down_rc_track_25_deg_up_to_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16282, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16282), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16283, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16283), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16284, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16284), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16285, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16285), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -1049,23 +1050,23 @@ static void lay_down_rc_track_25_deg_up_to_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26617, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26617), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26618, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26618), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26619, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26619), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26620, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26620), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
             }
         }
@@ -1075,23 +1076,23 @@ static void lay_down_rc_track_25_deg_up_to_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26565, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26565), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26566, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26566), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26567, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26567), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26568, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26568), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
             }
         }
@@ -1195,23 +1196,23 @@ static void lay_down_rc_track_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16343, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16343), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16348, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16348), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16353, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16353), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16338, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16338), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -1233,23 +1234,23 @@ static void lay_down_rc_track_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16342, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16342), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16347, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16347), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16352, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16352), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16337, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16337), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -1264,23 +1265,23 @@ static void lay_down_rc_track_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16341, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16341), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16346, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16346), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 16, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16351, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16351), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16336, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16336), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -1296,23 +1297,23 @@ static void lay_down_rc_track_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16340, { 0, 0, height }, { 16, 32, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16340), { 0, 0, height },
+                            { 16, 32, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16345, { 0, 0, height }, { 16, 32, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16345), { 0, 0, height },
+                            { 16, 32, 3 }, { 0, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16350, { 0, 0, height }, { 16, 32, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16350), { 0, 0, height },
+                            { 16, 32, 3 }, { 0, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16335, { 0, 0, height }, { 16, 32, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16335), { 0, 0, height },
+                            { 16, 32, 3 }, { 16, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -1327,23 +1328,23 @@ static void lay_down_rc_track_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16339, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16339), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16344, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16344), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16349, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16349), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16334, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16334), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -1373,22 +1374,22 @@ static void lay_down_rc_track_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26694, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26694), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26699, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26699), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26704, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26704), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26689, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26689), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                 }
@@ -1414,22 +1415,22 @@ static void lay_down_rc_track_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26693, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26693), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26698, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26698), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26703, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26703), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 16, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26688, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26688), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 16, height + 22 });
                         break;
                 }
@@ -1445,22 +1446,22 @@ static void lay_down_rc_track_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26692, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26692), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 16, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26697, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26697), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 16, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26702, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26702), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 0, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26687, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26687), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 0, height + 22 });
                         break;
                 }
@@ -1477,22 +1478,22 @@ static void lay_down_rc_track_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26691, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26691), { 0, 0, height + 24 },
                             { 16, 32, 3 }, { 16, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26696, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26696), { 0, 0, height + 24 },
                             { 16, 32, 3 }, { 0, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26701, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26701), { 0, 0, height + 24 },
                             { 16, 32, 3 }, { 0, 0, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26686, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26686), { 0, 0, height + 24 },
                             { 16, 32, 3 }, { 16, 0, height + 22 });
                         break;
                 }
@@ -1508,22 +1509,22 @@ static void lay_down_rc_track_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26690, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26690), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26695, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26695), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26700, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26700), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26685, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26685), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 22 });
                         break;
                 }
@@ -1570,28 +1571,28 @@ static void lay_down_rc_track_flat_to_left_bank(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16238, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16238), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16246, { 0, 0, height }, { 32, 1, 26 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16246), { 0, 0, height }, { 32, 1, 26 },
                     { 0, 27, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16239, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16239), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16247, { 0, 0, height }, { 32, 1, 26 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16247), { 0, 0, height }, { 32, 1, 26 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16240, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16240), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16241, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16241), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -1611,23 +1612,23 @@ static void lay_down_rc_track_flat_to_left_bank(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26657, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26657), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26658, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26658), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26659, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26659), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26660, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26660), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
         }
 
@@ -1657,28 +1658,28 @@ static void lay_down_rc_track_flat_to_right_bank(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16242, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16242), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16243, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16243), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16244, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16244), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16248, { 0, 0, height }, { 32, 1, 26 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16248), { 0, 0, height }, { 32, 1, 26 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16245, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16245), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16249, { 0, 0, height }, { 32, 1, 26 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16249), { 0, 0, height }, { 32, 1, 26 },
                     { 0, 27, height });
                 break;
         }
@@ -1698,23 +1699,23 @@ static void lay_down_rc_track_flat_to_right_bank(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26661, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26661), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26662, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26662), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26663, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26663), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26664, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26664), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
         }
 
@@ -1744,28 +1745,28 @@ static void lay_down_rc_track_left_bank_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16244, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16244), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16248, { 0, 0, height }, { 32, 1, 26 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16248), { 0, 0, height }, { 32, 1, 26 },
                     { 0, 27, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16245, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16245), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16249, { 0, 0, height }, { 32, 1, 26 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16249), { 0, 0, height }, { 32, 1, 26 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16242, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16242), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16243, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16243), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -1785,23 +1786,23 @@ static void lay_down_rc_track_left_bank_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26663, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26663), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26664, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26664), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26661, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26661), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26662, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26662), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
         }
 
@@ -1831,28 +1832,28 @@ static void lay_down_rc_track_right_bank_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16240, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16240), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16241, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16241), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16238, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16238), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16246, { 0, 0, height }, { 32, 1, 26 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16246), { 0, 0, height }, { 32, 1, 26 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16239, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16239), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16247, { 0, 0, height }, { 32, 1, 26 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16247), { 0, 0, height }, { 32, 1, 26 },
                     { 0, 27, height });
                 break;
         }
@@ -1872,23 +1873,23 @@ static void lay_down_rc_track_right_bank_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26659, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26659), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26660, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26660), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26657, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26657), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26658, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26658), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
         }
 
@@ -1921,26 +1922,26 @@ static void lay_down_rc_track_banked_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16363, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16363), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16374, { 0, 0, height }, { 32, 1, 26 },
-                            { 0, 27, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16374), { 0, 0, height },
+                            { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16368, { 0, 0, height }, { 32, 1, 26 },
-                            { 0, 27, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16368), { 0, 0, height },
+                            { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16373, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16373), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16358, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16358), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -1962,23 +1963,23 @@ static void lay_down_rc_track_banked_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16362, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16362), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16367, { 0, 0, height }, { 32, 16, 1 },
-                            { 0, 0, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16367), { 0, 0, height },
+                            { 32, 16, 1 }, { 0, 0, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16372, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16372), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16357, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16357), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -1993,23 +1994,23 @@ static void lay_down_rc_track_banked_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16361, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16361), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16366, { 0, 0, height }, { 16, 16, 1 },
-                            { 16, 16, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16366), { 0, 0, height },
+                            { 16, 16, 1 }, { 16, 16, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16371, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16371), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16356, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16356), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -2025,23 +2026,23 @@ static void lay_down_rc_track_banked_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16360, { 0, 0, height }, { 16, 32, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16360), { 0, 0, height },
+                            { 16, 32, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16365, { 0, 0, height }, { 16, 32, 1 },
-                            { 0, 0, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16365), { 0, 0, height },
+                            { 16, 32, 1 }, { 0, 0, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16370, { 0, 0, height }, { 16, 32, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16370), { 0, 0, height },
+                            { 16, 32, 3 }, { 0, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16355, { 0, 0, height }, { 16, 32, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16355), { 0, 0, height },
+                            { 16, 32, 3 }, { 16, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -2056,26 +2057,26 @@ static void lay_down_rc_track_banked_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16359, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16359), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16364, { 0, 0, height }, { 1, 32, 26 },
-                            { 27, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16364), { 0, 0, height },
+                            { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16369, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16369), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16375, { 0, 0, height }, { 1, 32, 26 },
-                            { 27, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16375), { 0, 0, height },
+                            { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16354, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16354), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -2105,22 +2106,22 @@ static void lay_down_rc_track_banked_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26738, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26738), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 24 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26743, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26743), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 24 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26748, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26748), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 24 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26733, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26733), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 24 });
                         break;
                 }
@@ -2146,22 +2147,22 @@ static void lay_down_rc_track_banked_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26737, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26737), { 0, 0, height + 24 },
                             { 32, 16, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26742, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26742), { 0, 0, height + 24 },
                             { 32, 16, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26747, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26747), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 16, height + 24 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26732, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26732), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 16, height + 24 });
                         break;
                 }
@@ -2177,22 +2178,22 @@ static void lay_down_rc_track_banked_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26736, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26736), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 16, height + 24 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26741, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26741), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 16, height + 24 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26746, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26746), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 0, height + 24 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26731, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26731), { 0, 0, height + 24 },
                             { 16, 16, 3 });
                         break;
                 }
@@ -2209,22 +2210,22 @@ static void lay_down_rc_track_banked_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26735, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26735), { 0, 0, height + 24 },
                             { 16, 32, 3 }, { 16, 0, height + 24 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26740, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26740), { 0, 0, height + 24 },
                             { 16, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26745, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26745), { 0, 0, height + 24 },
                             { 16, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26730, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26730), { 0, 0, height + 24 },
                             { 16, 32, 3 }, { 16, 0, height + 24 });
                         break;
                 }
@@ -2240,22 +2241,22 @@ static void lay_down_rc_track_banked_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26734, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26734), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 24 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26739, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26739), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 24 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26744, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26744), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 24 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26729, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26729), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 24 });
                         break;
                 }
@@ -2302,28 +2303,28 @@ static void lay_down_rc_track_left_bank_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16250, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16250), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16254, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16254), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16251, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16251), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16255, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16255), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16252, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16252), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16253, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16253), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -2350,23 +2351,23 @@ static void lay_down_rc_track_left_bank_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26665, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26665), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26666, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26666), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26667, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26667), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26668, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26668), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
         }
 
@@ -2420,28 +2421,28 @@ static void lay_down_rc_track_right_bank_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16256, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16256), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16257, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16257), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16258, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16258), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16260, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16260), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16259, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16259), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16261, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16261), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
         }
@@ -2468,23 +2469,23 @@ static void lay_down_rc_track_right_bank_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26669, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26669), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26670, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26670), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26671, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26671), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26672, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26672), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
         }
 
@@ -2538,28 +2539,28 @@ static void lay_down_rc_track_25_deg_up_to_left_bank(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16262, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16262), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16266, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16266), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16263, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16263), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16267, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16267), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16264, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16264), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16265, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16265), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -2586,23 +2587,23 @@ static void lay_down_rc_track_25_deg_up_to_left_bank(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26673, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26673), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26674, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26674), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26675, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26675), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26676, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26676), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
         }
 
@@ -2656,28 +2657,28 @@ static void lay_down_rc_track_25_deg_up_to_right_bank(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16268, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16268), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16269, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16269), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16270, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16270), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16272, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16272), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16271, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16271), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16273, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16273), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
         }
@@ -2704,23 +2705,23 @@ static void lay_down_rc_track_25_deg_up_to_right_bank(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26677, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26677), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26678, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26678), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26679, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26679), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26680, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26680), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
         }
 
@@ -2806,22 +2807,22 @@ static void lay_down_rc_track_left_bank(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16274, { 0, 0, height }, { 32, 1, 26 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16274), { 0, 0, height }, { 32, 1, 26 },
                     { 0, 27, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16275, { 0, 0, height }, { 32, 1, 26 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16275), { 0, 0, height }, { 32, 1, 26 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16276, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16276), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16277, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16277), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -2841,23 +2842,23 @@ static void lay_down_rc_track_left_bank(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26681, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26681), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26682, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26682), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26683, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26683), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26684, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26684), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
         }
 
@@ -2898,23 +2899,23 @@ static void lay_down_rc_track_left_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16510, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16510), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16515, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16515), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16520, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16520), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16525, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16525), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -2936,21 +2937,23 @@ static void lay_down_rc_track_left_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16511, { 0, 0, height }, { 32, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16511), { 0, 0, height },
+                            { 32, 16, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16516, { 0, 0, height }, { 32, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16516), { 0, 0, height },
+                            { 32, 16, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16521, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16521), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16526, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16526), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -2965,22 +2968,23 @@ static void lay_down_rc_track_left_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16512, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16512), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16517, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16517), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 16, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16522, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16522), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16527, { 0, 0, height }, { 16, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16527), { 0, 0, height },
+                            { 16, 16, 3 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -2996,21 +3000,23 @@ static void lay_down_rc_track_left_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16513, { 0, 0, height }, { 16, 32, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16513), { 0, 0, height },
+                            { 16, 32, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16518, { 0, 0, height }, { 16, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16518), { 0, 0, height },
+                            { 16, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16523, { 0, 0, height }, { 16, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16523), { 0, 0, height },
+                            { 16, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16528, { 0, 0, height }, { 16, 32, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16528), { 0, 0, height },
+                            { 16, 32, 3 }, { 16, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -3025,23 +3031,23 @@ static void lay_down_rc_track_left_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16514, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16514), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16519, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16519), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16524, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16524), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16529, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16529), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -3071,22 +3077,22 @@ static void lay_down_rc_track_left_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26949, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26949), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26954, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26954), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26959, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26959), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26964, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26964), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                 }
@@ -3112,22 +3118,22 @@ static void lay_down_rc_track_left_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26950, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26950), { 0, 0, height + 24 },
                             { 32, 16, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26955, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26955), { 0, 0, height + 24 },
                             { 32, 16, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26960, { 0, 16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26960), { 0, 16, height + 24 },
                             { 32, 16, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26965, { 0, 16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26965), { 0, 16, height + 24 },
                             { 32, 16, 3 });
                         break;
                 }
@@ -3143,22 +3149,22 @@ static void lay_down_rc_track_left_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26951, { 0, 16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26951), { 0, 16, height + 24 },
                             { 16, 16, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26956, { 16, 16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26956), { 16, 16, height + 24 },
                             { 16, 16, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26961, { 16, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26961), { 16, 0, height + 24 },
                             { 16, 16, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26966, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26966), { 0, 0, height + 24 },
                             { 16, 16, 3 });
                         break;
                 }
@@ -3175,22 +3181,22 @@ static void lay_down_rc_track_left_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26952, { 16, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26952), { 16, 0, height + 24 },
                             { 16, 32, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26957, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26957), { 0, 0, height + 24 },
                             { 16, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26962, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26962), { 0, 0, height + 24 },
                             { 16, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26967, { 16, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26967), { 16, 0, height + 24 },
                             { 16, 32, 3 });
                         break;
                 }
@@ -3206,22 +3212,22 @@ static void lay_down_rc_track_left_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26953, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26953), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26958, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26958), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26963, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26963), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26968, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26968), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                 }
@@ -3262,23 +3268,23 @@ static void lay_down_rc_track_right_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16490, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16490), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16495, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16495), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16500, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16500), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16505, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16505), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -3300,21 +3306,23 @@ static void lay_down_rc_track_right_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16491, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16491), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16496, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16496), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16501, { 0, 0, height }, { 32, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16501), { 0, 0, height },
+                            { 32, 16, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16506, { 0, 0, height }, { 32, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16506), { 0, 0, height },
+                            { 32, 16, 3 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -3329,22 +3337,23 @@ static void lay_down_rc_track_right_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16492, { 0, 0, height }, { 16, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16492), { 0, 0, height },
+                            { 16, 16, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16497, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16497), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16502, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16502), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16507, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16507), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -3360,21 +3369,23 @@ static void lay_down_rc_track_right_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16493, { 0, 0, height }, { 16, 32, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16493), { 0, 0, height },
+                            { 16, 32, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16498, { 0, 0, height }, { 16, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16498), { 0, 0, height },
+                            { 16, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16503, { 0, 0, height }, { 16, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16503), { 0, 0, height },
+                            { 16, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16508, { 0, 0, height }, { 16, 32, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16508), { 0, 0, height },
+                            { 16, 32, 3 }, { 16, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -3389,23 +3400,23 @@ static void lay_down_rc_track_right_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16494, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16494), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16499, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16499), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16504, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16504), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16509, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16509), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -3435,22 +3446,22 @@ static void lay_down_rc_track_right_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26929, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26929), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26934, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26934), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26939, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26939), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26944, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26944), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                 }
@@ -3476,22 +3487,22 @@ static void lay_down_rc_track_right_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26930, { 0, 16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26930), { 0, 16, height + 24 },
                             { 32, 16, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26935, { 0, 16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26935), { 0, 16, height + 24 },
                             { 32, 16, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26940, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26940), { 0, 0, height + 24 },
                             { 32, 16, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26945, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26945), { 0, 0, height + 24 },
                             { 32, 16, 3 });
                         break;
                 }
@@ -3507,22 +3518,22 @@ static void lay_down_rc_track_right_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26931, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26931), { 0, 0, height + 24 },
                             { 16, 16, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26936, { 16, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26936), { 16, 0, height + 24 },
                             { 16, 16, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26941, { 16, 16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26941), { 16, 16, height + 24 },
                             { 16, 16, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26946, { 0, 16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26946), { 0, 16, height + 24 },
                             { 16, 16, 3 });
                         break;
                 }
@@ -3539,22 +3550,22 @@ static void lay_down_rc_track_right_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26932, { 16, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26932), { 16, 0, height + 24 },
                             { 16, 32, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26937, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26937), { 0, 0, height + 24 },
                             { 16, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26942, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26942), { 0, 0, height + 24 },
                             { 16, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26947, { 16, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26947), { 16, 0, height + 24 },
                             { 16, 32, 3 });
                         break;
                 }
@@ -3570,22 +3581,22 @@ static void lay_down_rc_track_right_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26933, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26933), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26938, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26938), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26943, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26943), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26948, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26948), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                 }
@@ -3644,23 +3655,23 @@ static void lay_down_rc_track_s_bend_left(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16402, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16402), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16406, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16406), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16405, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16405), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16409, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16409), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -3679,25 +3690,27 @@ static void lay_down_rc_track_s_bend_left(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16403, { 0, 0, height }, { 32, 26, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16403), { 0, 0, height },
+                            { 32, 26, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16407, { 0, 0, height }, { 32, 26, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16407), { 0, 0, height },
+                            { 32, 26, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 6, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16404, { 0, 0, height }, { 32, 26, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16404), { 0, 0, height },
+                            { 32, 26, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16408, { 0, 0, height }, { 32, 26, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16408), { 0, 0, height },
+                            { 32, 26, 3 }, { 0, 6, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -3712,23 +3725,25 @@ static void lay_down_rc_track_s_bend_left(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16404, { 0, 0, height }, { 32, 26, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16404), { 0, 0, height },
+                            { 32, 26, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16408, { 0, 0, height }, { 32, 26, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16408), { 0, 0, height },
+                            { 32, 26, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16403, { 0, 0, height }, { 32, 26, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16403), { 0, 0, height },
+                            { 32, 26, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16407, { 0, 0, height }, { 32, 26, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16407), { 0, 0, height },
+                            { 32, 26, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 6, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -3745,23 +3760,23 @@ static void lay_down_rc_track_s_bend_left(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16405, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16405), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16409, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16409), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16402, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16402), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16406, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16406), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -3791,22 +3806,22 @@ static void lay_down_rc_track_s_bend_left(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26641, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26641), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26645, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26645), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26644, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26644), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26648, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26648), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                 }
@@ -3828,22 +3843,22 @@ static void lay_down_rc_track_s_bend_left(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26642, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26642), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26646, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26646), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26643, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26643), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 6, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26647, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26647), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 6, height + 22 });
                         break;
                 }
@@ -3872,22 +3887,22 @@ static void lay_down_rc_track_s_bend_left(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26643, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26643), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 6, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26647, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26647), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 6, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26642, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26642), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 0, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26646, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26646), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 0, height + 22 });
                         break;
                 }
@@ -3916,22 +3931,22 @@ static void lay_down_rc_track_s_bend_left(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26644, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26644), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26648, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26648), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26641, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26641), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26645, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26645), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                 }
@@ -3971,23 +3986,23 @@ static void lay_down_rc_track_s_bend_right(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16410, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16410), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16414, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16414), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16413, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16413), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16417, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16417), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -4006,25 +4021,27 @@ static void lay_down_rc_track_s_bend_right(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16411, { 0, 0, height }, { 32, 26, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16411), { 0, 0, height },
+                            { 32, 26, 3 }, { 0, 6, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16415, { 0, 0, height }, { 32, 26, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16415), { 0, 0, height },
+                            { 32, 26, 3 }, { 0, 6, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16412, { 0, 0, height }, { 32, 26, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16412), { 0, 0, height },
+                            { 32, 26, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16416, { 0, 0, height }, { 32, 26, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16416), { 0, 0, height },
+                            { 32, 26, 3 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -4039,23 +4056,25 @@ static void lay_down_rc_track_s_bend_right(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16412, { 0, 0, height }, { 32, 26, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16412), { 0, 0, height },
+                            { 32, 26, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16416, { 0, 0, height }, { 32, 26, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16416), { 0, 0, height },
+                            { 32, 26, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16411, { 0, 0, height }, { 32, 26, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16411), { 0, 0, height },
+                            { 32, 26, 3 }, { 0, 6, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16415, { 0, 0, height }, { 32, 26, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16415), { 0, 0, height },
+                            { 32, 26, 3 }, { 0, 6, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -4072,23 +4091,23 @@ static void lay_down_rc_track_s_bend_right(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16413, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16413), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16417, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16417), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16410, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16410), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16414, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16414), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -4118,22 +4137,22 @@ static void lay_down_rc_track_s_bend_right(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26649, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26649), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26653, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26653), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26652, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26652), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26656, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26656), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                 }
@@ -4155,22 +4174,22 @@ static void lay_down_rc_track_s_bend_right(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26650, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26650), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 6, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26654, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26654), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 6, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26651, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26651), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 0, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26655, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26655), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 0, height + 22 });
                         break;
                 }
@@ -4199,22 +4218,22 @@ static void lay_down_rc_track_s_bend_right(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26651, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26651), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26655, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26655), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26650, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26650), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 6, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26654, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26654), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 6, height + 22 });
                         break;
                 }
@@ -4243,22 +4262,22 @@ static void lay_down_rc_track_s_bend_right(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26652, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26652), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26656, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26656), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26649, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26649), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26653, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26653), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                 }
@@ -4296,25 +4315,29 @@ static void lay_down_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16562, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16562), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES_INVERTED, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16570, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16570), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES_INVERTED, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16569, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16569), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES_INVERTED, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16577, { 0, 6, height }, { 32, 20, 7 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16577), { 0, 6, height },
+                        { 32, 20, 7 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES_INVERTED, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -4335,25 +4358,29 @@ static void lay_down_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16563, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16563), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES_INVERTED, 4, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16571, { 0, 14, height }, { 32, 2, 63 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16571), { 0, 14, height },
+                        { 32, 2, 63 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES_INVERTED, 4, 15, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16568, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16568), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES_INVERTED, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16576, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16576), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES_INVERTED, 4, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -4370,23 +4397,23 @@ static void lay_down_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16564, { 16, 0, height }, { 3, 16, 119 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16564), { 16, 0, height },
+                        { 3, 16, 119 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16572, { 12, 0, height }, { 3, 16, 119 },
-                        { 12, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16572), { 12, 0, height },
+                        { 3, 16, 119 }, { 12, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16567, { 10, 16, height }, { 4, 16, 119 },
-                        { 10, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16567), { 10, 16, height },
+                        { 4, 16, 119 }, { 10, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16575, { 16, 16, height }, { 2, 16, 119 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16575), { 16, 16, height },
+                        { 2, 16, 119 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4398,19 +4425,23 @@ static void lay_down_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16565, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16565), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16573, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16573), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16566, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16566), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16574, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16574), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4431,19 +4462,23 @@ static void lay_down_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16566, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16566), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16574, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16574), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16565, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16565), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16573, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16573), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4458,23 +4493,23 @@ static void lay_down_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16567, { 10, 16, height }, { 4, 16, 119 },
-                        { 10, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16567), { 10, 16, height },
+                        { 4, 16, 119 }, { 10, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16575, { 16, 16, height }, { 2, 16, 119 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16575), { 16, 16, height },
+                        { 2, 16, 119 }, { 16, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16564, { 16, 0, height }, { 3, 16, 119 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16564), { 16, 0, height },
+                        { 3, 16, 119 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16572, { 12, 0, height }, { 3, 16, 119 },
-                        { 12, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16572), { 12, 0, height },
+                        { 3, 16, 119 }, { 12, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4486,25 +4521,29 @@ static void lay_down_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16568, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16568), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES_INVERTED, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16576, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16576), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES_INVERTED, 4, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16563, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16563), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES_INVERTED, 4, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16571, { 0, 14, height }, { 32, 2, 63 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16571), { 0, 14, height },
+                        { 32, 2, 63 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES_INVERTED, 4, 15, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -4521,25 +4560,29 @@ static void lay_down_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16569, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16569), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES_INVERTED, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16577, { 0, 6, height }, { 32, 20, 7 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16577), { 0, 6, height },
+                        { 32, 20, 7 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES_INVERTED, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16562, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16562), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES_INVERTED, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16570, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16570), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES_INVERTED, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -4575,19 +4618,23 @@ static void lay_down_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16593, { 0, 6, height }, { 32, 20, 7 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16593), { 0, 6, height },
+                        { 32, 20, 7 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16585, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16585), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16586, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16586), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16578, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16578), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -4603,25 +4650,29 @@ static void lay_down_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16592, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16592), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES_INVERTED, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16584, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16584), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES_INVERTED, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16587, { 0, 14, height }, { 32, 2, 63 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16587), { 0, 14, height },
+                        { 32, 2, 63 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES_INVERTED, 4, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16579, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16579), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES_INVERTED, 4, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -4633,23 +4684,23 @@ static void lay_down_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16591, { 16, 16, height }, { 2, 16, 119 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16591), { 16, 16, height },
+                        { 2, 16, 119 }, { 16, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16583, { 10, 16, height }, { 4, 16, 119 },
-                        { 10, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16583), { 10, 16, height },
+                        { 4, 16, 119 }, { 10, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16588, { 12, 0, height }, { 3, 16, 119 },
-                        { 12, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16588), { 12, 0, height },
+                        { 3, 16, 119 }, { 12, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16580, { 16, 0, height }, { 2, 16, 119 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16580), { 16, 0, height },
+                        { 2, 16, 119 }, { 16, 0, height });
                     break;
             }
             paint_util_set_general_support_height(session, height + 168, 0x20);
@@ -4659,19 +4710,23 @@ static void lay_down_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16590, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16590), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16582, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16582), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16589, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16589), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16581, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16581), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_general_support_height(session, height + 48, 0x20);
@@ -4687,19 +4742,23 @@ static void lay_down_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16589, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16589), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16581, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16581), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16590, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16590), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16582, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16582), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_general_support_height(session, height + 48, 0x20);
@@ -4709,23 +4768,23 @@ static void lay_down_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16588, { 12, 0, height }, { 3, 16, 119 },
-                        { 12, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16588), { 12, 0, height },
+                        { 3, 16, 119 }, { 12, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16580, { 16, 0, height }, { 2, 16, 119 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16580), { 16, 0, height },
+                        { 2, 16, 119 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16591, { 16, 16, height }, { 2, 16, 119 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16591), { 16, 16, height },
+                        { 2, 16, 119 }, { 16, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16583, { 10, 16, height }, { 4, 16, 119 },
-                        { 10, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16583), { 10, 16, height },
+                        { 4, 16, 119 }, { 10, 16, height });
                     break;
             }
             paint_util_set_general_support_height(session, height + 168, 0x20);
@@ -4735,25 +4794,29 @@ static void lay_down_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16587, { 0, 14, height }, { 32, 2, 63 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16587), { 0, 14, height },
+                        { 32, 2, 63 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES_INVERTED, 4, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16579, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16579), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES_INVERTED, 4, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16592, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16592), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES_INVERTED, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16584, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16584), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES_INVERTED, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -4765,19 +4828,23 @@ static void lay_down_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16586, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16586), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16578, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16578), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16593, { 0, 6, height }, { 32, 20, 7 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16593), { 0, 6, height },
+                        { 32, 20, 7 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16585, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16585), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -4812,23 +4879,23 @@ static void lay_down_rc_track_left_quarter_turn_3(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16381, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16381), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16384, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16384), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16387, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16387), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16378, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16378), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -4850,23 +4917,23 @@ static void lay_down_rc_track_left_quarter_turn_3(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16380, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16380), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16383, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16383), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16386, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16386), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16377, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16377), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -4879,23 +4946,23 @@ static void lay_down_rc_track_left_quarter_turn_3(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16379, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16379), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16382, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16382), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16385, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16385), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16376, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16376), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -4925,22 +4992,22 @@ static void lay_down_rc_track_left_quarter_turn_3(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26710, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26710), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26713, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26713), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26716, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26716), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26707, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26707), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                 }
@@ -4966,22 +5033,22 @@ static void lay_down_rc_track_left_quarter_turn_3(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26709, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26709), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26712, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26712), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26715, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26715), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 16, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26706, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26706), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 16, height + 22 });
                         break;
                 }
@@ -4995,22 +5062,22 @@ static void lay_down_rc_track_left_quarter_turn_3(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26708, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26708), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26711, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26711), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26714, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26714), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26705, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26705), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 22 });
                         break;
                 }
@@ -5060,26 +5127,26 @@ static void lay_down_rc_track_left_quarter_turn_3_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16393, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16393), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16400, { 0, 0, height }, { 32, 1, 26 },
-                            { 0, 27, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16400), { 0, 0, height },
+                            { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16396, { 0, 0, height }, { 32, 1, 26 },
-                            { 0, 27, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16396), { 0, 0, height },
+                            { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16399, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16399), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16390, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16390), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -5101,23 +5168,23 @@ static void lay_down_rc_track_left_quarter_turn_3_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16392, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16392), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16395, { 0, 0, height }, { 16, 16, 1 },
-                            { 0, 0, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16395), { 0, 0, height },
+                            { 16, 16, 1 }, { 0, 0, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16398, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16398), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16389, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16389), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -5130,26 +5197,26 @@ static void lay_down_rc_track_left_quarter_turn_3_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16391, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16391), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16394, { 0, 0, height }, { 1, 32, 26 },
-                            { 27, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16394), { 0, 0, height },
+                            { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16397, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16397), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16401, { 0, 0, height }, { 1, 32, 26 },
-                            { 27, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16401), { 0, 0, height },
+                            { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16388, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16388), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -5179,22 +5246,22 @@ static void lay_down_rc_track_left_quarter_turn_3_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26722, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26722), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26725, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26725), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26728, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26728), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26719, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26719), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                 }
@@ -5220,22 +5287,22 @@ static void lay_down_rc_track_left_quarter_turn_3_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26721, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26721), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26724, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26724), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26727, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26727), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 16, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26718, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26718), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 16, height + 22 });
                         break;
                 }
@@ -5249,22 +5316,22 @@ static void lay_down_rc_track_left_quarter_turn_3_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26720, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26720), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26723, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26723), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26726, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26726), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26717, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26717), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 22 });
                         break;
                 }
@@ -5314,19 +5381,23 @@ static void lay_down_rc_track_left_quarter_turn_3_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16541, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16541), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16543, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16543), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16545, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16545), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16539, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16539), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -5351,19 +5422,23 @@ static void lay_down_rc_track_left_quarter_turn_3_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16540, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16540), { 6, 0, height },
+                            { 20, 32, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16542, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16542), { 6, 0, height },
+                            { 20, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16544, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16544), { 6, 0, height },
+                            { 20, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16538, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16538), { 6, 0, height },
+                            { 20, 32, 3 });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -5393,22 +5468,22 @@ static void lay_down_rc_track_left_quarter_turn_3_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26924, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26924), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26926, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26926), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26928, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26928), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26922, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26922), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                 }
@@ -5437,22 +5512,22 @@ static void lay_down_rc_track_left_quarter_turn_3_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26923, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26923), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26925, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26925), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26927, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26927), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26921, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26921), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                 }
@@ -5493,19 +5568,23 @@ static void lay_down_rc_track_right_quarter_turn_3_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16530, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16530), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16532, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16532), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16534, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16534), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16536, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16536), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -5530,25 +5609,29 @@ static void lay_down_rc_track_right_quarter_turn_3_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16531, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16531), { 6, 0, height },
+                            { 20, 32, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16533, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16533), { 6, 0, height },
+                            { 20, 32, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16535, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16535), { 6, 0, height },
+                            { 20, 32, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 4, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16537, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16537), { 6, 0, height },
+                            { 20, 32, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5578,22 +5661,22 @@ static void lay_down_rc_track_right_quarter_turn_3_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26913, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26913), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26915, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26915), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26917, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26917), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26919, { 0, 6, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26919), { 0, 6, height + 24 },
                             { 32, 20, 3 });
                         break;
                 }
@@ -5622,22 +5705,22 @@ static void lay_down_rc_track_right_quarter_turn_3_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26914, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26914), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26916, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26916), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26918, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26918), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26920, { 6, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26920), { 6, 0, height + 24 },
                             { 20, 32, 3 });
                         break;
                 }
@@ -5694,26 +5777,26 @@ static void lay_down_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16481, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16481), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16488, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16488), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16484, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16484), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16487, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16487), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16478, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16478), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -5735,23 +5818,23 @@ static void lay_down_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16480, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16480), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16483, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16483), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16486, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16486), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16477, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16477), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5763,26 +5846,26 @@ static void lay_down_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16479, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16479), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16482, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16482), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16485, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16485), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16489, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16489), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16476, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16476), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 8 });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -5806,26 +5889,26 @@ static void lay_down_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16478, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16478), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16481, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16481), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16488, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16488), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16484, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16484), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16487, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16487), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -5852,23 +5935,23 @@ static void lay_down_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16477, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16477), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16480, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16480), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16483, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16483), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16486, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16486), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5880,26 +5963,26 @@ static void lay_down_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16476, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16476), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16479, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16479), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16482, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16482), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16485, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16485), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16489, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16489), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -5928,26 +6011,26 @@ static void lay_down_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16462, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16462), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16465, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16465), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16468, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16468), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16471, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16471), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16475, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16475), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -5969,23 +6052,23 @@ static void lay_down_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16463, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16463), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16466, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16466), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16469, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16469), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16472, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16472), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5997,26 +6080,26 @@ static void lay_down_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16464, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16464), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16467, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16467), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16474, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16474), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16470, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16470), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16473, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16473), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -6040,26 +6123,26 @@ static void lay_down_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16465, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16465), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16468, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16468), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16471, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16471), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16475, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16475), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16462, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16462), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -6086,23 +6169,23 @@ static void lay_down_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16466, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16466), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16469, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16469), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16472, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16472), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16463, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16463), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6114,26 +6197,26 @@ static void lay_down_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16467, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16467), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16474, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16474), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16470, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16470), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16473, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16473), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16464, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16464), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -6190,26 +6273,26 @@ static void lay_down_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16449, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16449), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16460, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16460), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16454, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16454), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16459, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16459), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16444, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16444), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -6231,23 +6314,23 @@ static void lay_down_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16448, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16448), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16453, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16453), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16458, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16458), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16443, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16443), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6262,23 +6345,23 @@ static void lay_down_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16447, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16447), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16452, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16452), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16457, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16457), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16442, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16442), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6293,23 +6376,23 @@ static void lay_down_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16446, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16446), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16451, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16451), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16456, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16456), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16441, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16441), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6324,26 +6407,26 @@ static void lay_down_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16445, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16445), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16450, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16450), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16455, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16455), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16461, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16461), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16440, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16440), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 8 });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -6367,26 +6450,26 @@ static void lay_down_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16444, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16444), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16449, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16449), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16460, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16460), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16454, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16454), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16459, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16459), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -6413,23 +6496,23 @@ static void lay_down_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16443, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16443), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16448, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16448), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16453, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16453), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16458, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16458), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6444,23 +6527,23 @@ static void lay_down_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16442, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16442), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16447, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16447), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16452, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16452), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16457, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16457), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6475,23 +6558,23 @@ static void lay_down_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16441, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16441), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16446, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16446), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16451, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16451), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16456, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16456), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6506,26 +6589,26 @@ static void lay_down_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16440, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16440), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16445, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16445), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16450, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16450), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16455, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16455), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16461, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16461), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -6554,26 +6637,26 @@ static void lay_down_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16418, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16418), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16423, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16423), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16428, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16428), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16433, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16433), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16439, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16439), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -6595,23 +6678,23 @@ static void lay_down_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16419, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16419), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16424, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16424), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16429, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16429), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16434, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16434), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6626,23 +6709,23 @@ static void lay_down_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16420, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16420), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16425, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16425), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16430, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16430), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16435, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16435), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6657,23 +6740,23 @@ static void lay_down_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16421, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16421), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16426, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16426), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16431, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16431), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16436, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16436), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6688,26 +6771,26 @@ static void lay_down_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16422, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16422), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16427, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16427), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16438, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16438), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16432, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16432), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16437, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16437), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -6731,26 +6814,26 @@ static void lay_down_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16423, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16423), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16428, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16428), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16433, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16433), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16439, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16439), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16418, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16418), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -6777,23 +6860,23 @@ static void lay_down_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16424, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16424), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16429, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16429), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16434, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16434), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16419, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16419), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6808,23 +6891,23 @@ static void lay_down_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16425, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16425), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16430, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16430), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16435, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16435), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16420, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16420), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6839,23 +6922,23 @@ static void lay_down_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16426, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16426), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16431, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16431), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16436, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16436), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16421, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16421), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6870,26 +6953,26 @@ static void lay_down_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16427, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16427), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16438, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16438), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16432, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16432), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16437, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16437), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16422, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16422), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -6945,34 +7028,34 @@ static void lay_down_rc_track_left_quarter_turn_1_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16555, { 0, 0, height }, { 28, 28, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16555), { 0, 0, height }, { 28, 28, 3 },
                     { 2, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16559, { 0, 0, height }, { 28, 28, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16559), { 0, 0, height }, { 28, 28, 1 },
                     { 2, 2, height + 99 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16556, { 0, 0, height }, { 28, 28, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16556), { 0, 0, height }, { 28, 28, 3 },
                     { 2, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16560, { 0, 0, height }, { 28, 28, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16560), { 0, 0, height }, { 28, 28, 1 },
                     { 2, 2, height + 99 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16557, { 0, 0, height }, { 28, 28, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16557), { 0, 0, height }, { 28, 28, 3 },
                     { 2, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16561, { 0, 0, height }, { 28, 28, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16561), { 0, 0, height }, { 28, 28, 1 },
                     { 2, 2, height + 99 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16554, { 0, 0, height }, { 28, 28, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16554), { 0, 0, height }, { 28, 28, 3 },
                     { 2, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16558, { 0, 0, height }, { 28, 28, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16558), { 0, 0, height }, { 28, 28, 1 },
                     { 2, 2, height + 99 });
                 break;
         }
@@ -6983,34 +7066,34 @@ static void lay_down_rc_track_left_quarter_turn_1_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26910, { 0, 0, height }, { 28, 28, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26910), { 0, 0, height }, { 28, 28, 3 },
                     { 2, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26906, { 0, 0, height }, { 28, 28, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26906), { 0, 0, height }, { 28, 28, 1 },
                     { 2, 2, height + 99 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26911, { 0, 0, height }, { 28, 28, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26911), { 0, 0, height }, { 28, 28, 3 },
                     { 2, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26907, { 0, 0, height }, { 28, 28, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26907), { 0, 0, height }, { 28, 28, 1 },
                     { 2, 2, height + 99 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26912, { 0, 0, height }, { 28, 28, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26912), { 0, 0, height }, { 28, 28, 3 },
                     { 2, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26908, { 0, 0, height }, { 28, 28, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26908), { 0, 0, height }, { 28, 28, 1 },
                     { 2, 2, height + 99 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26909, { 0, 0, height }, { 28, 28, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26909), { 0, 0, height }, { 28, 28, 3 },
                     { 2, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26905, { 0, 0, height }, { 28, 28, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26905), { 0, 0, height }, { 28, 28, 1 },
                     { 2, 2, height + 99 });
                 break;
         }
@@ -7031,34 +7114,34 @@ static void lay_down_rc_track_right_quarter_turn_1_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16546, { 0, 0, height }, { 28, 28, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16546), { 0, 0, height }, { 28, 28, 3 },
                     { 2, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16550, { 0, 0, height }, { 28, 28, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16550), { 0, 0, height }, { 28, 28, 1 },
                     { 2, 2, height + 99 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16547, { 0, 0, height }, { 28, 28, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16547), { 0, 0, height }, { 28, 28, 3 },
                     { 2, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16551, { 0, 0, height }, { 28, 28, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16551), { 0, 0, height }, { 28, 28, 1 },
                     { 2, 2, height + 99 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16548, { 0, 0, height }, { 28, 28, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16548), { 0, 0, height }, { 28, 28, 3 },
                     { 2, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16552, { 0, 0, height }, { 28, 28, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16552), { 0, 0, height }, { 28, 28, 1 },
                     { 2, 2, height + 99 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16549, { 0, 0, height }, { 28, 28, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16549), { 0, 0, height }, { 28, 28, 3 },
                     { 2, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16553, { 0, 0, height }, { 28, 28, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16553), { 0, 0, height }, { 28, 28, 1 },
                     { 2, 2, height + 99 });
                 break;
         }
@@ -7069,34 +7152,34 @@ static void lay_down_rc_track_right_quarter_turn_1_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26901, { 0, 0, height }, { 28, 28, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26901), { 0, 0, height }, { 28, 28, 3 },
                     { 2, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26897, { 0, 0, height }, { 28, 28, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26897), { 0, 0, height }, { 28, 28, 1 },
                     { 2, 2, height + 99 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26902, { 0, 0, height }, { 28, 28, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26902), { 0, 0, height }, { 28, 28, 3 },
                     { 2, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26898, { 0, 0, height }, { 28, 28, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26898), { 0, 0, height }, { 28, 28, 1 },
                     { 2, 2, height + 99 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26903, { 0, 0, height }, { 28, 28, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26903), { 0, 0, height }, { 28, 28, 3 },
                     { 2, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26899, { 0, 0, height }, { 28, 28, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26899), { 0, 0, height }, { 28, 28, 1 },
                     { 2, 2, height + 99 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26904, { 0, 0, height }, { 28, 28, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26904), { 0, 0, height }, { 28, 28, 3 },
                     { 2, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26900, { 0, 0, height }, { 28, 28, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26900), { 0, 0, height }, { 28, 28, 1 },
                     { 2, 2, height + 99 });
                 break;
         }
@@ -7135,13 +7218,13 @@ static void lay_down_rc_track_brakes(
             case 0:
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16230, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16230), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16231, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16231), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -7162,14 +7245,14 @@ static void lay_down_rc_track_brakes(
             case 0:
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26559, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 24 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26559), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 24 });
                 break;
             case 1:
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26560, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 24 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26560), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 24 });
                 break;
         }
 
@@ -7197,46 +7280,46 @@ static void lay_down_rc_track_on_ride_photo(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                    session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16224, { 0, 0, height }, { 32, 20, 0 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16224), { 0, 0, height }, { 32, 20, 0 },
                     { 0, 6, height + 3 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                    session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16225, { 0, 0, height }, { 32, 20, 0 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16225), { 0, 0, height }, { 32, 20, 0 },
                     { 0, 6, height + 3 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                    session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16224, { 0, 0, height }, { 32, 20, 0 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16224), { 0, 0, height }, { 32, 20, 0 },
                     { 0, 6, height + 3 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                    session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16225, { 0, 0, height }, { 32, 20, 0 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16225), { 0, 0, height }, { 32, 20, 0 },
                     { 0, 6, height + 3 });
                 break;
         }
@@ -7251,47 +7334,47 @@ static void lay_down_rc_track_on_ride_photo(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                    session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26555, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 24 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26555), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 24 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                    session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26556, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 24 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26556), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 24 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                    session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26555, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 24 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26555), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 24 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                    session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26556, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 24 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26556), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 24 });
                 break;
         }
         track_paint_util_onride_photo_paint(session, direction, height + 3, trackElement);
@@ -7315,23 +7398,23 @@ static void lay_down_rc_track_left_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16740, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16740), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16744, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16744), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16748, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16748), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16752, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16752), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -7349,23 +7432,23 @@ static void lay_down_rc_track_left_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16741, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16741), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16745, { 0, 0, height }, { 34, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16745), { 0, 0, height },
+                            { 34, 16, 3 }, { 0, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16749, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16749), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16753, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16753), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -7380,23 +7463,23 @@ static void lay_down_rc_track_left_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16742, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16742), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16746, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16746), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 16, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16750, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16750), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16754, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16754), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -7416,29 +7499,29 @@ static void lay_down_rc_track_left_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16743, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16743), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16747, { 0, 0, height }, { 16, 18, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16747), { 0, 0, height },
+                            { 16, 18, 3 }, { 0, 16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16751, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16751), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16755, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16755), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7461,22 +7544,22 @@ static void lay_down_rc_track_left_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26765, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26765), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26769, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26769), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26773, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26773), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26777, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26777), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                 }
@@ -7497,22 +7580,22 @@ static void lay_down_rc_track_left_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26766, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26766), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26770, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26770), { 0, 0, height + 24 },
                             { 34, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26774, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26774), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 16, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26778, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26778), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 16, height + 22 });
                         break;
                 }
@@ -7528,22 +7611,22 @@ static void lay_down_rc_track_left_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26767, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26767), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 16, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26771, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26771), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 16, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26775, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26775), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 0, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26779, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26779), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 0, height + 22 });
                         break;
                 }
@@ -7564,22 +7647,22 @@ static void lay_down_rc_track_left_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26768, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26768), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 16, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26772, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26772), { 0, 0, height + 24 },
                             { 16, 18, 3 }, { 0, 16, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26776, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26776), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26780, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26780), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 0, height + 22 });
                         break;
                 }
@@ -7629,23 +7712,23 @@ static void lay_down_rc_track_right_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16724, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16724), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16728, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16728), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16732, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16732), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16736, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16736), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -7663,23 +7746,23 @@ static void lay_down_rc_track_right_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16725, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16725), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16729, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16729), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16733, { 0, 0, height }, { 34, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16733), { 0, 0, height },
+                            { 34, 16, 3 }, { 0, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16737, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16737), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -7694,23 +7777,23 @@ static void lay_down_rc_track_right_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16726, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16726), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16730, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16730), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16734, { 0, 0, height }, { 28, 28, 3 },
-                            { 4, 4, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16734), { 0, 0, height },
+                            { 28, 28, 3 }, { 4, 4, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16738, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16738), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -7730,29 +7813,29 @@ static void lay_down_rc_track_right_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16727, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16727), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16731, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16731), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16735, { 0, 0, height }, { 16, 18, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16735), { 0, 0, height },
+                            { 16, 18, 3 }, { 0, 16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16739, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16739), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7775,22 +7858,22 @@ static void lay_down_rc_track_right_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26749, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26749), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26753, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26753), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26757, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26757), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26761, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26761), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                 }
@@ -7811,22 +7894,22 @@ static void lay_down_rc_track_right_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26750, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26750), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 16, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26754, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26754), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 16, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26758, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26758), { 0, 0, height + 24 },
                             { 34, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26762, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26762), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 0, height + 22 });
                         break;
                 }
@@ -7842,22 +7925,22 @@ static void lay_down_rc_track_right_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26751, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26751), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26755, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26755), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26759, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26759), { 0, 0, height + 24 },
                             { 28, 28, 3 }, { 4, 4, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26763, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26763), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 16, height + 22 });
                         break;
                 }
@@ -7878,22 +7961,22 @@ static void lay_down_rc_track_right_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26752, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26752), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26756, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26756), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26760, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26760), { 0, 0, height + 24 },
                             { 16, 18, 3 }, { 0, 16, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26764, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26764), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 16, height + 22 });
                         break;
                 }
@@ -7961,23 +8044,23 @@ static void lay_down_rc_track_left_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16772, { 0, 0, height }, { 32, 1, 26 },
-                            { 0, 27, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16772), { 0, 0, height },
+                            { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16776, { 0, 0, height }, { 32, 1, 26 },
-                            { 0, 27, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16776), { 0, 0, height },
+                            { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16780, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16780), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16784, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16784), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -7995,23 +8078,23 @@ static void lay_down_rc_track_left_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16773, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16773), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16777, { 0, 0, height }, { 34, 16, 0 },
-                            { 0, 0, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16777), { 0, 0, height },
+                            { 34, 16, 0 }, { 0, 0, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16781, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16781), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16785, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16785), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -8026,23 +8109,23 @@ static void lay_down_rc_track_left_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16774, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16774), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16778, { 0, 0, height }, { 16, 16, 0 },
-                            { 16, 16, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16778), { 0, 0, height },
+                            { 16, 16, 0 }, { 16, 16, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16782, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16782), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16786, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16786), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -8062,29 +8145,29 @@ static void lay_down_rc_track_left_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16775, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16775), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16779, { 0, 0, height }, { 16, 18, 0 },
-                            { 0, 16, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16779), { 0, 0, height },
+                            { 16, 18, 0 }, { 0, 16, height + 27 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16783, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16783), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16787, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16787), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -8107,22 +8190,22 @@ static void lay_down_rc_track_left_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26853, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26853), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26857, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26857), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26861, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26861), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26865, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26865), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                 }
@@ -8144,22 +8227,22 @@ static void lay_down_rc_track_left_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26854, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26854), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26858, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26858), { 0, 0, height + 24 },
                             { 34, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26862, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26862), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 16, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26866, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26866), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 16, height + 22 });
                         break;
                 }
@@ -8175,22 +8258,22 @@ static void lay_down_rc_track_left_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26855, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26855), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 16, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26859, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26859), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 16, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26863, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26863), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 0, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26867, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26867), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 0, height + 22 });
                         break;
                 }
@@ -8211,22 +8294,22 @@ static void lay_down_rc_track_left_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26856, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26856), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 16, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26860, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26860), { 0, 0, height + 24 },
                             { 16, 18, 3 }, { 0, 16, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26864, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26864), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26868, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26868), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 0, height + 22 });
                         break;
                 }
@@ -8276,23 +8359,23 @@ static void lay_down_rc_track_right_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16756, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16756), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16760, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16760), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16764, { 0, 0, height }, { 32, 1, 26 },
-                            { 0, 27, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16764), { 0, 0, height },
+                            { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16768, { 0, 0, height }, { 32, 1, 26 },
-                            { 0, 27, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16768), { 0, 0, height },
+                            { 32, 1, 26 }, { 0, 27, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -8310,23 +8393,23 @@ static void lay_down_rc_track_right_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16757, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16757), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16761, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16761), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16765, { 0, 0, height }, { 34, 16, 0 },
-                            { 0, 0, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16765), { 0, 0, height },
+                            { 34, 16, 0 }, { 0, 0, height + 27 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16769, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16769), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -8341,23 +8424,23 @@ static void lay_down_rc_track_right_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16758, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16758), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16762, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16762), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16766, { 0, 0, height }, { 28, 28, 0 },
-                            { 4, 4, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16766), { 0, 0, height },
+                            { 28, 28, 0 }, { 4, 4, height + 27 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16770, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16770), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -8377,29 +8460,29 @@ static void lay_down_rc_track_right_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16759, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16759), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16763, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16763), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16767, { 0, 0, height }, { 16, 18, 0 },
-                            { 0, 16, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16767), { 0, 0, height },
+                            { 16, 18, 0 }, { 0, 16, height + 27 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16771, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16771), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -8422,22 +8505,22 @@ static void lay_down_rc_track_right_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26837, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26837), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26841, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26841), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26845, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26845), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26849, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26849), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                 }
@@ -8459,22 +8542,22 @@ static void lay_down_rc_track_right_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26838, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26838), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 16, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26842, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26842), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 16, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26846, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26846), { 0, 0, height + 24 },
                             { 34, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26850, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26850), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 0, height + 22 });
                         break;
                 }
@@ -8490,22 +8573,22 @@ static void lay_down_rc_track_right_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26839, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26839), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26843, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26843), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26847, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26847), { 0, 0, height + 24 },
                             { 28, 28, 3 }, { 4, 4, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26851, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26851), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 16, height + 22 });
                         break;
                 }
@@ -8526,22 +8609,22 @@ static void lay_down_rc_track_right_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26840, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26840), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26844, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26844), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26848, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26848), { 0, 0, height + 24 },
                             { 16, 18, 3 }, { 0, 16, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26852, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26852), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 16, height + 22 });
                         break;
                 }
@@ -8611,7 +8694,7 @@ static void lay_down_rc_track_diag_flat(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16699, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16699), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -8622,7 +8705,7 @@ static void lay_down_rc_track_diag_flat(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16637, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16637), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -8639,7 +8722,7 @@ static void lay_down_rc_track_diag_flat(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16696, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16696), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -8650,7 +8733,7 @@ static void lay_down_rc_track_diag_flat(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16634, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16634), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -8667,7 +8750,7 @@ static void lay_down_rc_track_diag_flat(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16698, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16698), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -8678,7 +8761,7 @@ static void lay_down_rc_track_diag_flat(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16636, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16636), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -8699,7 +8782,7 @@ static void lay_down_rc_track_diag_flat(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16697, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16697), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_a_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -8724,7 +8807,7 @@ static void lay_down_rc_track_diag_flat(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16635, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16635), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_a_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -8757,8 +8840,8 @@ static void lay_down_rc_track_diag_flat(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26812, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 22 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26812),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 22 });
                             break;
                     }
                 }
@@ -8768,8 +8851,8 @@ static void lay_down_rc_track_diag_flat(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26784, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 22 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26784),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 22 });
                             break;
                     }
                 }
@@ -8785,8 +8868,8 @@ static void lay_down_rc_track_diag_flat(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26809, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 22 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26809),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 22 });
                             break;
                     }
                 }
@@ -8796,8 +8879,8 @@ static void lay_down_rc_track_diag_flat(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26781, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 22 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26781),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 22 });
                             break;
                     }
                 }
@@ -8813,8 +8896,8 @@ static void lay_down_rc_track_diag_flat(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26811, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 22 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26811),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 22 });
                             break;
                     }
                 }
@@ -8824,8 +8907,8 @@ static void lay_down_rc_track_diag_flat(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26783, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 22 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26783),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 22 });
                             break;
                     }
                 }
@@ -8841,8 +8924,8 @@ static void lay_down_rc_track_diag_flat(
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26810, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 22 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26810),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 22 });
                             break;
                     }
                 }
@@ -8852,8 +8935,8 @@ static void lay_down_rc_track_diag_flat(
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26782, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 22 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26782),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 22 });
                             break;
                     }
                 }
@@ -8903,7 +8986,7 @@ static void lay_down_rc_track_diag_25_deg_up(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16711, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16711), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -8914,7 +8997,7 @@ static void lay_down_rc_track_diag_25_deg_up(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16649, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16649), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -8931,7 +9014,7 @@ static void lay_down_rc_track_diag_25_deg_up(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16708, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16708), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -8942,7 +9025,7 @@ static void lay_down_rc_track_diag_25_deg_up(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16646, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16646), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -8959,7 +9042,7 @@ static void lay_down_rc_track_diag_25_deg_up(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16710, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16710), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -8970,7 +9053,7 @@ static void lay_down_rc_track_diag_25_deg_up(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16648, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16648), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -8991,7 +9074,7 @@ static void lay_down_rc_track_diag_25_deg_up(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16709, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16709), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -9016,7 +9099,7 @@ static void lay_down_rc_track_diag_25_deg_up(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16647, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16647), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -9049,8 +9132,8 @@ static void lay_down_rc_track_diag_25_deg_up(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26824, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 40 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26824),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 40 });
                             break;
                     }
                 }
@@ -9060,8 +9143,8 @@ static void lay_down_rc_track_diag_25_deg_up(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26796, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 40 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26796),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 40 });
                             break;
                     }
                 }
@@ -9077,8 +9160,8 @@ static void lay_down_rc_track_diag_25_deg_up(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26821, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 40 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26821),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 40 });
                             break;
                     }
                 }
@@ -9088,8 +9171,8 @@ static void lay_down_rc_track_diag_25_deg_up(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26793, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 40 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26793),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 40 });
                             break;
                     }
                 }
@@ -9105,8 +9188,8 @@ static void lay_down_rc_track_diag_25_deg_up(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26823, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 40 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26823),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 40 });
                             break;
                     }
                 }
@@ -9116,8 +9199,8 @@ static void lay_down_rc_track_diag_25_deg_up(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26795, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 40 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26795),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 40 });
                             break;
                     }
                 }
@@ -9133,8 +9216,8 @@ static void lay_down_rc_track_diag_25_deg_up(
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26822, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 40 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26822),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 40 });
                             break;
                     }
                 }
@@ -9144,8 +9227,8 @@ static void lay_down_rc_track_diag_25_deg_up(
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26794, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 40 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26794),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 40 });
                             break;
                     }
                 }
@@ -9195,7 +9278,7 @@ static void lay_down_rc_track_diag_60_deg_up(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16723, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16723), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9206,7 +9289,7 @@ static void lay_down_rc_track_diag_60_deg_up(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16661, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16661), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9223,7 +9306,7 @@ static void lay_down_rc_track_diag_60_deg_up(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16720, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16720), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9234,7 +9317,7 @@ static void lay_down_rc_track_diag_60_deg_up(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16658, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16658), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9251,7 +9334,7 @@ static void lay_down_rc_track_diag_60_deg_up(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16722, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16722), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9262,7 +9345,7 @@ static void lay_down_rc_track_diag_60_deg_up(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16660, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16660), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9283,7 +9366,7 @@ static void lay_down_rc_track_diag_60_deg_up(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16721, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16721), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 36, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -9308,7 +9391,7 @@ static void lay_down_rc_track_diag_60_deg_up(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16659, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16659), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 36, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -9339,7 +9422,7 @@ static void lay_down_rc_track_diag_60_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26808, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26808), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 88 });
                         break;
                 }
@@ -9353,7 +9436,7 @@ static void lay_down_rc_track_diag_60_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26805, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26805), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 88 });
                         break;
                 }
@@ -9367,7 +9450,7 @@ static void lay_down_rc_track_diag_60_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26807, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26807), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 88 });
                         break;
                 }
@@ -9381,7 +9464,7 @@ static void lay_down_rc_track_diag_60_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26806, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26806), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 24 });
                         break;
                 }
@@ -9431,7 +9514,7 @@ static void lay_down_rc_track_diag_flat_to_25_deg_up(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16703, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16703), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9442,7 +9525,7 @@ static void lay_down_rc_track_diag_flat_to_25_deg_up(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16641, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16641), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9459,7 +9542,7 @@ static void lay_down_rc_track_diag_flat_to_25_deg_up(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16700, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16700), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9470,7 +9553,7 @@ static void lay_down_rc_track_diag_flat_to_25_deg_up(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16638, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16638), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9487,7 +9570,7 @@ static void lay_down_rc_track_diag_flat_to_25_deg_up(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16702, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16702), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9498,7 +9581,7 @@ static void lay_down_rc_track_diag_flat_to_25_deg_up(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16640, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16640), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9519,7 +9602,7 @@ static void lay_down_rc_track_diag_flat_to_25_deg_up(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16701, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16701), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -9544,7 +9627,7 @@ static void lay_down_rc_track_diag_flat_to_25_deg_up(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16639, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16639), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -9577,8 +9660,8 @@ static void lay_down_rc_track_diag_flat_to_25_deg_up(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26816, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26816),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -9588,8 +9671,8 @@ static void lay_down_rc_track_diag_flat_to_25_deg_up(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26788, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26788),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -9605,8 +9688,8 @@ static void lay_down_rc_track_diag_flat_to_25_deg_up(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26813, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26813),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -9616,8 +9699,8 @@ static void lay_down_rc_track_diag_flat_to_25_deg_up(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26785, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26785),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -9633,8 +9716,8 @@ static void lay_down_rc_track_diag_flat_to_25_deg_up(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26815, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26815),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -9644,8 +9727,8 @@ static void lay_down_rc_track_diag_flat_to_25_deg_up(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26787, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26787),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -9661,8 +9744,8 @@ static void lay_down_rc_track_diag_flat_to_25_deg_up(
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26814, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26814),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -9672,8 +9755,8 @@ static void lay_down_rc_track_diag_flat_to_25_deg_up(
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26786, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26786),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -9723,7 +9806,7 @@ static void lay_down_rc_track_diag_25_deg_up_to_60_deg_up(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16715, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16715), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9734,7 +9817,7 @@ static void lay_down_rc_track_diag_25_deg_up_to_60_deg_up(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16653, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16653), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9751,7 +9834,7 @@ static void lay_down_rc_track_diag_25_deg_up_to_60_deg_up(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16712, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16712), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9762,7 +9845,7 @@ static void lay_down_rc_track_diag_25_deg_up_to_60_deg_up(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16650, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16650), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9779,7 +9862,7 @@ static void lay_down_rc_track_diag_25_deg_up_to_60_deg_up(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16714, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16714), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9790,7 +9873,7 @@ static void lay_down_rc_track_diag_25_deg_up_to_60_deg_up(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16652, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16652), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9811,7 +9894,7 @@ static void lay_down_rc_track_diag_25_deg_up_to_60_deg_up(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16713, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16713), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -9836,7 +9919,7 @@ static void lay_down_rc_track_diag_25_deg_up_to_60_deg_up(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16651, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16651), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -9867,7 +9950,7 @@ static void lay_down_rc_track_diag_25_deg_up_to_60_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26800, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26800), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 56 });
                         break;
                 }
@@ -9881,7 +9964,7 @@ static void lay_down_rc_track_diag_25_deg_up_to_60_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26797, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26797), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 56 });
                         break;
                 }
@@ -9895,7 +9978,7 @@ static void lay_down_rc_track_diag_25_deg_up_to_60_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26799, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26799), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 56 });
                         break;
                 }
@@ -9909,7 +9992,7 @@ static void lay_down_rc_track_diag_25_deg_up_to_60_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26798, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26798), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 56 });
                         break;
                 }
@@ -9959,7 +10042,7 @@ static void lay_down_rc_track_diag_60_deg_up_to_25_deg_up(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16719, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16719), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9970,7 +10053,7 @@ static void lay_down_rc_track_diag_60_deg_up_to_25_deg_up(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16657, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16657), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9987,7 +10070,7 @@ static void lay_down_rc_track_diag_60_deg_up_to_25_deg_up(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16716, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16716), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9998,7 +10081,7 @@ static void lay_down_rc_track_diag_60_deg_up_to_25_deg_up(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16654, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16654), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10015,7 +10098,7 @@ static void lay_down_rc_track_diag_60_deg_up_to_25_deg_up(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16718, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16718), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10026,7 +10109,7 @@ static void lay_down_rc_track_diag_60_deg_up_to_25_deg_up(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16656, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16656), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10047,7 +10130,7 @@ static void lay_down_rc_track_diag_60_deg_up_to_25_deg_up(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16717, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16717), { -16, -16, height },
                                 { 16, 16, 3 }, { 0, 0, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 21, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -10072,7 +10155,7 @@ static void lay_down_rc_track_diag_60_deg_up_to_25_deg_up(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16655, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16655), { -16, -16, height },
                                 { 16, 16, 3 }, { 0, 0, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 21, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -10103,7 +10186,7 @@ static void lay_down_rc_track_diag_60_deg_up_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26804, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26804), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 56 });
                         break;
                 }
@@ -10117,7 +10200,7 @@ static void lay_down_rc_track_diag_60_deg_up_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26801, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26801), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 56 });
                         break;
                 }
@@ -10131,7 +10214,7 @@ static void lay_down_rc_track_diag_60_deg_up_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26803, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26803), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 56 });
                         break;
                 }
@@ -10145,7 +10228,7 @@ static void lay_down_rc_track_diag_60_deg_up_to_25_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26802, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26802), { -16, -16, height + 24 },
                             { 16, 16, 3 }, { 0, 0, height + 56 });
                         break;
                 }
@@ -10195,7 +10278,7 @@ static void lay_down_rc_track_diag_25_deg_up_to_flat(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16707, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16707), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10206,7 +10289,7 @@ static void lay_down_rc_track_diag_25_deg_up_to_flat(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16645, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16645), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10223,7 +10306,7 @@ static void lay_down_rc_track_diag_25_deg_up_to_flat(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16704, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16704), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10234,7 +10317,7 @@ static void lay_down_rc_track_diag_25_deg_up_to_flat(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16642, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16642), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10251,7 +10334,7 @@ static void lay_down_rc_track_diag_25_deg_up_to_flat(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16706, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16706), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10262,7 +10345,7 @@ static void lay_down_rc_track_diag_25_deg_up_to_flat(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16644, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16644), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10283,7 +10366,7 @@ static void lay_down_rc_track_diag_25_deg_up_to_flat(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16705, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16705), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -10308,7 +10391,7 @@ static void lay_down_rc_track_diag_25_deg_up_to_flat(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16643, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16643), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -10341,8 +10424,8 @@ static void lay_down_rc_track_diag_25_deg_up_to_flat(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26820, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26820),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -10352,8 +10435,8 @@ static void lay_down_rc_track_diag_25_deg_up_to_flat(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26792, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26792),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -10369,8 +10452,8 @@ static void lay_down_rc_track_diag_25_deg_up_to_flat(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26817, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26817),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -10380,8 +10463,8 @@ static void lay_down_rc_track_diag_25_deg_up_to_flat(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26789, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26789),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -10397,8 +10480,8 @@ static void lay_down_rc_track_diag_25_deg_up_to_flat(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26819, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26819),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -10408,8 +10491,8 @@ static void lay_down_rc_track_diag_25_deg_up_to_flat(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26791, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26791),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -10425,8 +10508,8 @@ static void lay_down_rc_track_diag_25_deg_up_to_flat(
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26818, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26818),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -10436,8 +10519,8 @@ static void lay_down_rc_track_diag_25_deg_up_to_flat(
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26790, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26790),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -10487,7 +10570,7 @@ static void lay_down_rc_track_diag_25_deg_down(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16709, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16709), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10498,7 +10581,7 @@ static void lay_down_rc_track_diag_25_deg_down(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16647, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16647), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10515,7 +10598,7 @@ static void lay_down_rc_track_diag_25_deg_down(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16710, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16710), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10526,7 +10609,7 @@ static void lay_down_rc_track_diag_25_deg_down(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16648, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16648), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10543,7 +10626,7 @@ static void lay_down_rc_track_diag_25_deg_down(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16708, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16708), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10554,7 +10637,7 @@ static void lay_down_rc_track_diag_25_deg_down(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16646, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16646), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10575,7 +10658,7 @@ static void lay_down_rc_track_diag_25_deg_down(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16711, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16711), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -10600,7 +10683,7 @@ static void lay_down_rc_track_diag_25_deg_down(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16649, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16649), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -10631,7 +10714,7 @@ static void lay_down_rc_track_diag_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26794, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26794), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 40 });
                         break;
                 }
@@ -10645,7 +10728,7 @@ static void lay_down_rc_track_diag_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26795, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26795), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 40 });
                         break;
                 }
@@ -10659,7 +10742,7 @@ static void lay_down_rc_track_diag_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26793, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26793), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 40 });
                         break;
                 }
@@ -10673,7 +10756,7 @@ static void lay_down_rc_track_diag_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26796, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26796), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 40 });
                         break;
                 }
@@ -10723,7 +10806,7 @@ static void lay_down_rc_track_diag_60_deg_down(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16721, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16721), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10734,7 +10817,7 @@ static void lay_down_rc_track_diag_60_deg_down(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16659, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16659), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10751,7 +10834,7 @@ static void lay_down_rc_track_diag_60_deg_down(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16722, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16722), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10762,7 +10845,7 @@ static void lay_down_rc_track_diag_60_deg_down(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16660, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16660), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10779,7 +10862,7 @@ static void lay_down_rc_track_diag_60_deg_down(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16720, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16720), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10790,7 +10873,7 @@ static void lay_down_rc_track_diag_60_deg_down(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16658, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16658), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10811,7 +10894,7 @@ static void lay_down_rc_track_diag_60_deg_down(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16723, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16723), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 28, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -10836,7 +10919,7 @@ static void lay_down_rc_track_diag_60_deg_down(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16661, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16661), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 28, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -10867,7 +10950,7 @@ static void lay_down_rc_track_diag_60_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26806, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26806), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 24 });
                         break;
                 }
@@ -10881,7 +10964,7 @@ static void lay_down_rc_track_diag_60_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26807, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26807), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 88 });
                         break;
                 }
@@ -10895,7 +10978,7 @@ static void lay_down_rc_track_diag_60_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26805, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26805), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 88 });
                         break;
                 }
@@ -10909,7 +10992,7 @@ static void lay_down_rc_track_diag_60_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26808, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26808), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 88 });
                         break;
                 }
@@ -10959,7 +11042,7 @@ static void lay_down_rc_track_diag_flat_to_25_deg_down(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16705, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16705), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10970,7 +11053,7 @@ static void lay_down_rc_track_diag_flat_to_25_deg_down(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16643, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16643), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10986,7 +11069,7 @@ static void lay_down_rc_track_diag_flat_to_25_deg_down(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16706, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16706), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -10997,7 +11080,7 @@ static void lay_down_rc_track_diag_flat_to_25_deg_down(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16644, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16644), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -11013,7 +11096,7 @@ static void lay_down_rc_track_diag_flat_to_25_deg_down(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16704, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16704), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -11024,7 +11107,7 @@ static void lay_down_rc_track_diag_flat_to_25_deg_down(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16642, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16642), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -11044,7 +11127,7 @@ static void lay_down_rc_track_diag_flat_to_25_deg_down(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16707, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16707), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11069,7 +11152,7 @@ static void lay_down_rc_track_diag_flat_to_25_deg_down(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16645, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16645), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11099,7 +11182,7 @@ static void lay_down_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26790, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26790), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -11112,7 +11195,7 @@ static void lay_down_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26791, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26791), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -11125,7 +11208,7 @@ static void lay_down_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26789, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26789), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -11138,7 +11221,7 @@ static void lay_down_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26792, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26792), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -11188,7 +11271,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_60_deg_down(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16717, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16717), { -16, -16, height },
                                 { 16, 16, 3 }, { 0, 0, height });
                             break;
                     }
@@ -11199,7 +11282,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_60_deg_down(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16655, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16655), { -16, -16, height },
                                 { 16, 16, 3 }, { 0, 0, height });
                             break;
                     }
@@ -11216,7 +11299,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_60_deg_down(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16718, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16718), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -11227,7 +11310,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_60_deg_down(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16656, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16656), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -11244,7 +11327,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_60_deg_down(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16716, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16716), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -11255,7 +11338,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_60_deg_down(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16654, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16654), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -11276,7 +11359,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_60_deg_down(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16719, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16719), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 17, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11301,7 +11384,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_60_deg_down(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16657, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16657), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 17, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11332,7 +11415,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_60_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26802, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26802), { -16, -16, height + 24 },
                             { 16, 16, 3 }, { 0, 0, height + 56 });
                         break;
                 }
@@ -11346,7 +11429,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_60_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26803, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26803), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 56 });
                         break;
                 }
@@ -11360,7 +11443,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_60_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26801, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26801), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 56 });
                         break;
                 }
@@ -11374,7 +11457,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_60_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26804, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26804), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 56 });
                         break;
                 }
@@ -11424,7 +11507,7 @@ static void lay_down_rc_track_diag_60_deg_down_to_25_deg_down(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16713, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16713), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -11435,7 +11518,7 @@ static void lay_down_rc_track_diag_60_deg_down_to_25_deg_down(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16651, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16651), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -11452,7 +11535,7 @@ static void lay_down_rc_track_diag_60_deg_down_to_25_deg_down(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16714, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16714), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -11463,7 +11546,7 @@ static void lay_down_rc_track_diag_60_deg_down_to_25_deg_down(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16652, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16652), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -11480,7 +11563,7 @@ static void lay_down_rc_track_diag_60_deg_down_to_25_deg_down(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16712, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16712), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -11491,7 +11574,7 @@ static void lay_down_rc_track_diag_60_deg_down_to_25_deg_down(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16650, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16650), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -11512,7 +11595,7 @@ static void lay_down_rc_track_diag_60_deg_down_to_25_deg_down(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16715, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16715), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11537,7 +11620,7 @@ static void lay_down_rc_track_diag_60_deg_down_to_25_deg_down(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16653, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16653), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11568,7 +11651,7 @@ static void lay_down_rc_track_diag_60_deg_down_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26798, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26798), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 56 });
                         break;
                 }
@@ -11582,7 +11665,7 @@ static void lay_down_rc_track_diag_60_deg_down_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26799, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26799), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 56 });
                         break;
                 }
@@ -11596,7 +11679,7 @@ static void lay_down_rc_track_diag_60_deg_down_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26797, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26797), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 56 });
                         break;
                 }
@@ -11610,7 +11693,7 @@ static void lay_down_rc_track_diag_60_deg_down_to_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26800, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26800), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 56 });
                         break;
                 }
@@ -11660,7 +11743,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_flat(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16701, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16701), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -11671,7 +11754,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_flat(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16639, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16639), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -11688,7 +11771,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_flat(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16702, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16702), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -11699,7 +11782,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_flat(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16640, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16640), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -11716,7 +11799,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_flat(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16700, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16700), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -11727,7 +11810,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_flat(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16638, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16638), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -11748,7 +11831,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_flat(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16703, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16703), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11773,7 +11856,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_flat(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16641, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16641), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11804,7 +11887,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26786, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26786), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -11818,7 +11901,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26787, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26787), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -11832,7 +11915,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26785, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26785), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -11846,7 +11929,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26788, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26788), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -11894,8 +11977,8 @@ static void lay_down_rc_track_diag_flat_to_left_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16669, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16669), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -11908,11 +11991,11 @@ static void lay_down_rc_track_diag_flat_to_left_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16666, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16666), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16670, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16670), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 27 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -11925,8 +12008,8 @@ static void lay_down_rc_track_diag_flat_to_left_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16668, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16668), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -11943,8 +12026,8 @@ static void lay_down_rc_track_diag_flat_to_left_bank(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16667, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16667), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -11973,7 +12056,7 @@ static void lay_down_rc_track_diag_flat_to_left_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26876, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26876), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -11987,7 +12070,7 @@ static void lay_down_rc_track_diag_flat_to_left_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26873, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26873), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -12001,7 +12084,7 @@ static void lay_down_rc_track_diag_flat_to_left_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26875, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26875), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -12015,7 +12098,7 @@ static void lay_down_rc_track_diag_flat_to_left_bank(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26874, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26874), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -12064,8 +12147,8 @@ static void lay_down_rc_track_diag_flat_to_right_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16674, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16674), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -12078,8 +12161,8 @@ static void lay_down_rc_track_diag_flat_to_right_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16671, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16671), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -12092,11 +12175,11 @@ static void lay_down_rc_track_diag_flat_to_right_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16673, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16673), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16675, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16675), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 27 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -12113,8 +12196,8 @@ static void lay_down_rc_track_diag_flat_to_right_bank(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16672, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16672), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -12143,7 +12226,7 @@ static void lay_down_rc_track_diag_flat_to_right_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26880, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26880), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -12157,7 +12240,7 @@ static void lay_down_rc_track_diag_flat_to_right_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26877, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26877), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -12171,7 +12254,7 @@ static void lay_down_rc_track_diag_flat_to_right_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26879, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26879), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -12185,7 +12268,7 @@ static void lay_down_rc_track_diag_flat_to_right_bank(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26878, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26878), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -12234,8 +12317,8 @@ static void lay_down_rc_track_diag_left_bank_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16672, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16672), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -12248,11 +12331,11 @@ static void lay_down_rc_track_diag_left_bank_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16673, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16673), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16675, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16675), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 27 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -12265,8 +12348,8 @@ static void lay_down_rc_track_diag_left_bank_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16671, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16671), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -12283,8 +12366,8 @@ static void lay_down_rc_track_diag_left_bank_to_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16674, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16674), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -12313,7 +12396,7 @@ static void lay_down_rc_track_diag_left_bank_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26878, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26878), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -12327,7 +12410,7 @@ static void lay_down_rc_track_diag_left_bank_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26879, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26879), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -12341,7 +12424,7 @@ static void lay_down_rc_track_diag_left_bank_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26877, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26877), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -12355,7 +12438,7 @@ static void lay_down_rc_track_diag_left_bank_to_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26880, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26880), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -12404,8 +12487,8 @@ static void lay_down_rc_track_diag_right_bank_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16667, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16667), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -12418,8 +12501,8 @@ static void lay_down_rc_track_diag_right_bank_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16668, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16668), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -12432,11 +12515,11 @@ static void lay_down_rc_track_diag_right_bank_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16666, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16666), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16670, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16670), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 27 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -12453,8 +12536,8 @@ static void lay_down_rc_track_diag_right_bank_to_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16669, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16669), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -12483,7 +12566,7 @@ static void lay_down_rc_track_diag_right_bank_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26874, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26874), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -12497,7 +12580,7 @@ static void lay_down_rc_track_diag_right_bank_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26875, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26875), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -12511,7 +12594,7 @@ static void lay_down_rc_track_diag_right_bank_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26873, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26873), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -12525,7 +12608,7 @@ static void lay_down_rc_track_diag_right_bank_to_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26876, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26876), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -12574,8 +12657,8 @@ static void lay_down_rc_track_diag_left_bank_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16689, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16689), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -12588,11 +12671,11 @@ static void lay_down_rc_track_diag_left_bank_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16686, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16686), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16690, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 35 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16690), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 35 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -12605,8 +12688,8 @@ static void lay_down_rc_track_diag_left_bank_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16688, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16688), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -12623,8 +12706,8 @@ static void lay_down_rc_track_diag_left_bank_to_25_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16687, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16687), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -12653,7 +12736,7 @@ static void lay_down_rc_track_diag_left_bank_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26892, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26892), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -12667,7 +12750,7 @@ static void lay_down_rc_track_diag_left_bank_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26889, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26889), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -12681,7 +12764,7 @@ static void lay_down_rc_track_diag_left_bank_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26891, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26891), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -12695,7 +12778,7 @@ static void lay_down_rc_track_diag_left_bank_to_25_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26890, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26890), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -12743,8 +12826,8 @@ static void lay_down_rc_track_diag_right_bank_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16694, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16694), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -12757,8 +12840,8 @@ static void lay_down_rc_track_diag_right_bank_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16691, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16691), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -12771,11 +12854,11 @@ static void lay_down_rc_track_diag_right_bank_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16693, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16693), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16695, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 35 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16695), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 35 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -12792,8 +12875,8 @@ static void lay_down_rc_track_diag_right_bank_to_25_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16692, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16692), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -12822,7 +12905,7 @@ static void lay_down_rc_track_diag_right_bank_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26896, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26896), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -12836,7 +12919,7 @@ static void lay_down_rc_track_diag_right_bank_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26893, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26893), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -12850,7 +12933,7 @@ static void lay_down_rc_track_diag_right_bank_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26895, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26895), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -12864,7 +12947,7 @@ static void lay_down_rc_track_diag_right_bank_to_25_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26894, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26894), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -12912,8 +12995,8 @@ static void lay_down_rc_track_diag_25_deg_up_to_left_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16679, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16679), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -12926,11 +13009,11 @@ static void lay_down_rc_track_diag_25_deg_up_to_left_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16676, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16676), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16680, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 35 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16680), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 35 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -12943,8 +13026,8 @@ static void lay_down_rc_track_diag_25_deg_up_to_left_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16678, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16678), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -12961,8 +13044,8 @@ static void lay_down_rc_track_diag_25_deg_up_to_left_bank(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16677, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16677), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -12991,7 +13074,7 @@ static void lay_down_rc_track_diag_25_deg_up_to_left_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26884, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26884), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13005,7 +13088,7 @@ static void lay_down_rc_track_diag_25_deg_up_to_left_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26881, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26881), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13019,7 +13102,7 @@ static void lay_down_rc_track_diag_25_deg_up_to_left_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26883, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26883), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13033,7 +13116,7 @@ static void lay_down_rc_track_diag_25_deg_up_to_left_bank(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26882, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26882), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13081,8 +13164,8 @@ static void lay_down_rc_track_diag_25_deg_up_to_right_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16684, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16684), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -13095,8 +13178,8 @@ static void lay_down_rc_track_diag_25_deg_up_to_right_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16681, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16681), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -13109,11 +13192,11 @@ static void lay_down_rc_track_diag_25_deg_up_to_right_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16683, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16683), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16685, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 35 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16685), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 35 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -13130,8 +13213,8 @@ static void lay_down_rc_track_diag_25_deg_up_to_right_bank(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16682, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16682), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -13160,7 +13243,7 @@ static void lay_down_rc_track_diag_25_deg_up_to_right_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26888, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26888), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13174,7 +13257,7 @@ static void lay_down_rc_track_diag_25_deg_up_to_right_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26885, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26885), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13188,7 +13271,7 @@ static void lay_down_rc_track_diag_25_deg_up_to_right_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26887, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26887), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13202,7 +13285,7 @@ static void lay_down_rc_track_diag_25_deg_up_to_right_bank(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26886, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26886), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13250,8 +13333,8 @@ static void lay_down_rc_track_diag_left_bank_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16682, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16682), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -13263,11 +13346,11 @@ static void lay_down_rc_track_diag_left_bank_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16683, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16683), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16685, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 35 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16685), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 35 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -13279,8 +13362,8 @@ static void lay_down_rc_track_diag_left_bank_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16681, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16681), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -13296,8 +13379,8 @@ static void lay_down_rc_track_diag_left_bank_to_25_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16684, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16684), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -13325,7 +13408,7 @@ static void lay_down_rc_track_diag_left_bank_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26886, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26886), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13338,7 +13421,7 @@ static void lay_down_rc_track_diag_left_bank_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26887, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26887), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13351,7 +13434,7 @@ static void lay_down_rc_track_diag_left_bank_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26885, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26885), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13364,7 +13447,7 @@ static void lay_down_rc_track_diag_left_bank_to_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26888, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26888), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13412,8 +13495,8 @@ static void lay_down_rc_track_diag_right_bank_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16677, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16677), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -13425,8 +13508,8 @@ static void lay_down_rc_track_diag_right_bank_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16678, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16678), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -13438,11 +13521,11 @@ static void lay_down_rc_track_diag_right_bank_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16676, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16676), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16680, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 35 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16680), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 35 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -13458,8 +13541,8 @@ static void lay_down_rc_track_diag_right_bank_to_25_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16679, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16679), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -13487,7 +13570,7 @@ static void lay_down_rc_track_diag_right_bank_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26882, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26882), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13500,7 +13583,7 @@ static void lay_down_rc_track_diag_right_bank_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26883, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26883), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13513,7 +13596,7 @@ static void lay_down_rc_track_diag_right_bank_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26881, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26881), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13526,7 +13609,7 @@ static void lay_down_rc_track_diag_right_bank_to_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26884, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26884), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13574,8 +13657,8 @@ static void lay_down_rc_track_diag_25_deg_down_to_left_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16692, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16692), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -13588,11 +13671,11 @@ static void lay_down_rc_track_diag_25_deg_down_to_left_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16693, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16693), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16695, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 35 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16695), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 35 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -13605,8 +13688,8 @@ static void lay_down_rc_track_diag_25_deg_down_to_left_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16691, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16691), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -13623,8 +13706,8 @@ static void lay_down_rc_track_diag_25_deg_down_to_left_bank(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16694, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16694), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -13653,7 +13736,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_left_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26894, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26894), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13667,7 +13750,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_left_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26895, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26895), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13681,7 +13764,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_left_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26893, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26893), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13695,7 +13778,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_left_bank(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26896, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26896), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13743,8 +13826,8 @@ static void lay_down_rc_track_diag_25_deg_down_to_right_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16687, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16687), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -13757,8 +13840,8 @@ static void lay_down_rc_track_diag_25_deg_down_to_right_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16688, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16688), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -13771,11 +13854,11 @@ static void lay_down_rc_track_diag_25_deg_down_to_right_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16686, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16686), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16690, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 35 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16690), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 35 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -13792,8 +13875,8 @@ static void lay_down_rc_track_diag_25_deg_down_to_right_bank(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16689, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16689), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -13822,7 +13905,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_right_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26890, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26890), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13836,7 +13919,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_right_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26891, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26891), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13850,7 +13933,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_right_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26889, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26889), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13864,7 +13947,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_right_bank(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26892, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26892), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -13912,8 +13995,8 @@ static void lay_down_rc_track_diag_left_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16665, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16665), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -13926,8 +14009,8 @@ static void lay_down_rc_track_diag_left_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16662, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16662), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 27 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -13940,8 +14023,8 @@ static void lay_down_rc_track_diag_left_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16664, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16664), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -13958,8 +14041,8 @@ static void lay_down_rc_track_diag_left_bank(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16663, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16663), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -13988,7 +14071,7 @@ static void lay_down_rc_track_diag_left_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26872, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26872), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -14002,7 +14085,7 @@ static void lay_down_rc_track_diag_left_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26869, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26869), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -14016,7 +14099,7 @@ static void lay_down_rc_track_diag_left_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26871, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26871), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -14030,7 +14113,7 @@ static void lay_down_rc_track_diag_left_bank(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26870, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26870), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -14079,8 +14162,8 @@ static void lay_down_rc_track_diag_right_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16663, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16663), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -14093,8 +14176,8 @@ static void lay_down_rc_track_diag_right_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16664, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16664), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -14107,8 +14190,8 @@ static void lay_down_rc_track_diag_right_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16662, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16662), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 27 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -14125,8 +14208,8 @@ static void lay_down_rc_track_diag_right_bank(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16665, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16665), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -14155,7 +14238,7 @@ static void lay_down_rc_track_diag_right_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26870, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26870), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -14169,7 +14252,7 @@ static void lay_down_rc_track_diag_right_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26871, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26871), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -14183,7 +14266,7 @@ static void lay_down_rc_track_diag_right_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26869, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26869), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -14197,7 +14280,7 @@ static void lay_down_rc_track_diag_right_bank(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26872, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26872), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -14244,19 +14327,23 @@ static void lay_down_rc_track_left_flyer_twist_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26972, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26972), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26978, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26978), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26971, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26971), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26977, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26977), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -14277,20 +14364,23 @@ static void lay_down_rc_track_left_flyer_twist_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26973, { 0, 6, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26973), { 0, 6, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 24 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26979, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26979), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26970, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26970), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26976, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26976), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -14305,20 +14395,23 @@ static void lay_down_rc_track_left_flyer_twist_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26974, { 0, 6, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26974), { 0, 6, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 24 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26980, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26980), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26969, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26969), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26975, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26975), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
             }
 
@@ -14356,19 +14449,23 @@ static void lay_down_rc_track_right_flyer_twist_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26984, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26984), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26990, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26990), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26983, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26983), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26989, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26989), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -14389,19 +14486,23 @@ static void lay_down_rc_track_right_flyer_twist_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26985, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26985), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26991, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26991), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26982, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26982), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26988, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26988), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -14416,19 +14517,23 @@ static void lay_down_rc_track_right_flyer_twist_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26986, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26986), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26992, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26992), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26981, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26981), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26987, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26987), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
             }
 
@@ -14466,20 +14571,23 @@ static void lay_down_rc_track_left_flyer_twist_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26969, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26969), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26975, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26975), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26974, { 0, 6, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26974), { 0, 6, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 24 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26980, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26980), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
             }
 
@@ -14502,20 +14610,23 @@ static void lay_down_rc_track_left_flyer_twist_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26970, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26970), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26976, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26976), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26973, { 0, 6, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26973), { 0, 6, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 24 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26979, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26979), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -14530,19 +14641,23 @@ static void lay_down_rc_track_left_flyer_twist_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26971, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26971), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26977, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26977), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26972, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26972), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26978, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26978), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -14578,19 +14693,23 @@ static void lay_down_rc_track_right_flyer_twist_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26981, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26981), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26987, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26987), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26986, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26986), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26992, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26992), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
             }
 
@@ -14613,19 +14732,23 @@ static void lay_down_rc_track_right_flyer_twist_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26982, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26982), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26988, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26988), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26985, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26985), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26991, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26991), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -14640,19 +14763,23 @@ static void lay_down_rc_track_right_flyer_twist_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26983, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26983), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26989, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26989), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26984, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26984), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26990, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26990), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -14688,19 +14815,23 @@ static void lay_down_rc_track_flyer_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16594, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16594), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16602, { 0, 6, height }, { 32, 20, 11 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16602), { 0, 6, height },
+                        { 32, 20, 11 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16601, { 0, 6, height }, { 32, 20, 9 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16601), { 0, 6, height },
+                        { 32, 20, 9 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16609, { 0, 6, height }, { 32, 20, 7 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16609), { 0, 6, height },
+                        { 32, 20, 7 });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -14718,28 +14849,29 @@ static void lay_down_rc_track_flyer_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16595, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16595), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES_INVERTED, 4, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16603, { 0, 14, height }, { 3, 20, 63 },
-                        { 28, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16603), { 0, 14, height },
+                        { 3, 20, 63 }, { 28, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES_INVERTED, 4, 15, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16600, { 0, 6, height }, { 3, 20, 63 },
-                        { 28, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16600), { 0, 6, height },
+                        { 3, 20, 63 }, { 28, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES_INVERTED, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16608, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16608), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES_INVERTED, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -14752,21 +14884,23 @@ static void lay_down_rc_track_flyer_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16596, { 16, 0, height }, { 2, 16, 119 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16596), { 16, 0, height },
+                        { 2, 16, 119 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16604, { 12, 0, height }, { 3, 16, 119 },
-                        { 12, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16604), { 12, 0, height },
+                        { 3, 16, 119 }, { 12, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16599, { 10, 16, height }, { 4, 12, 119 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16599), { 10, 16, height },
+                        { 4, 12, 119 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16607, { 16, 16, height }, { 2, 16, 119 },
-                        { 15, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16607), { 16, 16, height },
+                        { 2, 16, 119 }, { 15, 6, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -14781,19 +14915,23 @@ static void lay_down_rc_track_flyer_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16597, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16597), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16605, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16605), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16598, { 0, 16, height + 32 }, { 32, 12, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16598), { 0, 16, height + 32 },
+                        { 32, 12, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16606, { 0, 16, height + 32 }, { 32, 12, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16606), { 0, 16, height + 32 },
+                        { 32, 12, 3 });
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -14819,19 +14957,23 @@ static void lay_down_rc_track_flyer_half_loop_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16597, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16597), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16605, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16605), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16598, { 0, 16, height + 32 }, { 32, 12, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16598), { 0, 16, height + 32 },
+                        { 32, 12, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16606, { 0, 16, height + 32 }, { 32, 12, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16606), { 0, 16, height + 32 },
+                        { 32, 12, 3 });
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -14847,21 +14989,23 @@ static void lay_down_rc_track_flyer_half_loop_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16596, { 16, 0, height }, { 2, 16, 119 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16596), { 16, 0, height },
+                        { 2, 16, 119 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16604, { 12, 0, height }, { 3, 16, 119 },
-                        { 12, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16604), { 12, 0, height },
+                        { 3, 16, 119 }, { 12, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16599, { 10, 16, height }, { 4, 12, 119 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16599), { 10, 16, height },
+                        { 4, 12, 119 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16607, { 16, 16, height }, { 2, 16, 119 },
-                        { 15, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16607), { 16, 16, height },
+                        { 2, 16, 119 }, { 15, 6, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -14876,28 +15020,29 @@ static void lay_down_rc_track_flyer_half_loop_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16595, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16595), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES_INVERTED, 4, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16603, { 0, 14, height }, { 3, 20, 63 },
-                        { 28, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16603), { 0, 14, height },
+                        { 3, 20, 63 }, { 28, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES_INVERTED, 4, 15, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16600, { 0, 6, height }, { 3, 20, 63 },
-                        { 28, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16600), { 0, 6, height },
+                        { 3, 20, 63 }, { 28, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES_INVERTED, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16608, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16608), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES_INVERTED, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -14910,19 +15055,23 @@ static void lay_down_rc_track_flyer_half_loop_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16594, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16594), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16602, { 0, 6, height }, { 32, 20, 11 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16602), { 0, 6, height },
+                        { 32, 20, 11 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16601, { 0, 6, height }, { 32, 20, 9 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16601), { 0, 6, height },
+                        { 32, 20, 9 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16609, { 0, 6, height }, { 32, 20, 7 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16609), { 0, 6, height },
+                        { 32, 20, 7 });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -14950,23 +15099,23 @@ static void lay_down_rc_track_left_flyer_corkscrew_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16610, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16610), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 4 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16613, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16613), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 4 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16616, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16616), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 4 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16619, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16619), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 4 });
                     break;
             }
 
@@ -14998,23 +15147,23 @@ static void lay_down_rc_track_left_flyer_corkscrew_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16611, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16611), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16614, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16614), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16617, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16617), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16620, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16620), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -15025,23 +15174,23 @@ static void lay_down_rc_track_left_flyer_corkscrew_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16612, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16612), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 24 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16615, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16615), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 24 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16618, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16618), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 24 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16621, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16621), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 24 });
                     break;
             }
 
@@ -15077,23 +15226,23 @@ static void lay_down_rc_track_right_flyer_corkscrew_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16622, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16622), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 4 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16625, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16625), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 4 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16628, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16628), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 4 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16631, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16631), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 4 });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -15112,23 +15261,23 @@ static void lay_down_rc_track_right_flyer_corkscrew_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16623, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16623), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16626, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16626), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16629, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16629), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16632, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16632), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -15139,23 +15288,23 @@ static void lay_down_rc_track_right_flyer_corkscrew_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16624, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16624), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 24 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16627, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16627), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 24 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16630, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16630), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 24 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16633, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16633), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 24 });
                     break;
             }
 
@@ -15191,23 +15340,23 @@ static void lay_down_rc_track_left_flyer_corkscrew_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16627, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16627), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 24 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16630, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16630), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 24 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16633, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16633), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 24 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16624, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16624), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 24 });
                     break;
             }
 
@@ -15228,23 +15377,23 @@ static void lay_down_rc_track_left_flyer_corkscrew_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16626, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16626), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16629, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16629), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16632, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16632), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16623, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16623), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -15255,23 +15404,23 @@ static void lay_down_rc_track_left_flyer_corkscrew_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16625, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16625), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 4 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16628, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16628), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 4 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16631, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16631), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 4 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16622, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16622), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 4 });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -15313,13 +15462,13 @@ static void lay_down_rc_track_block_brakes(
             case 0:
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16232, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16232), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16233, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16233), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -15337,14 +15486,14 @@ static void lay_down_rc_track_block_brakes(
             case 0:
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26559, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 24 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26559), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 24 });
                 break;
             case 1:
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26560, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 24 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26560), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 24 });
                 break;
         }
 
@@ -15372,23 +15521,23 @@ static void lay_down_rc_track_left_quarter_banked_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27118, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 30 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27118), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 30 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27123, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 30 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27123), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 30 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27128, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 30 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27128), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 30 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27113, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 30 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27113), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 30 });
                     break;
             }
 
@@ -15412,23 +15561,23 @@ static void lay_down_rc_track_left_quarter_banked_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27117, { 0, 0, height + 24 }, { 32, 16, 3 },
-                        { 0, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27117), { 0, 0, height + 24 },
+                        { 32, 16, 3 }, { 0, 0, height + 38 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27122, { 0, 0, height + 24 }, { 32, 16, 3 },
-                        { 0, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27122), { 0, 0, height + 24 },
+                        { 32, 16, 3 }, { 0, 0, height + 38 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27127, { 0, 0, height + 24 }, { 32, 16, 3 },
-                        { 0, 16, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27127), { 0, 0, height + 24 },
+                        { 32, 16, 3 }, { 0, 16, height + 38 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27112, { 0, 0, height + 24 }, { 32, 16, 3 },
-                        { 0, 16, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27112), { 0, 0, height + 24 },
+                        { 32, 16, 3 }, { 0, 16, height + 38 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -15443,23 +15592,23 @@ static void lay_down_rc_track_left_quarter_banked_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27116, { 0, 0, height + 24 }, { 16, 16, 3 },
-                        { 0, 16, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27116), { 0, 0, height + 24 },
+                        { 16, 16, 3 }, { 0, 16, height + 38 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27121, { 0, 0, height + 24 }, { 16, 16, 3 },
-                        { 16, 16, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27121), { 0, 0, height + 24 },
+                        { 16, 16, 3 }, { 16, 16, height + 38 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27126, { 0, 0, height + 24 }, { 16, 16, 3 },
-                        { 16, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27126), { 0, 0, height + 24 },
+                        { 16, 16, 3 }, { 16, 0, height + 38 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27111, { 0, 0, height + 24 }, { 16, 16, 3 },
-                        { 0, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27111), { 0, 0, height + 24 },
+                        { 16, 16, 3 }, { 0, 0, height + 38 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -15474,23 +15623,23 @@ static void lay_down_rc_track_left_quarter_banked_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27115, { 0, 0, height + 24 }, { 16, 32, 3 },
-                        { 16, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27115), { 0, 0, height + 24 },
+                        { 16, 32, 3 }, { 16, 0, height + 38 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27120, { 0, 0, height + 24 }, { 16, 32, 3 },
-                        { 0, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27120), { 0, 0, height + 24 },
+                        { 16, 32, 3 }, { 0, 0, height + 38 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27125, { 0, 0, height + 24 }, { 16, 32, 3 },
-                        { 0, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27125), { 0, 0, height + 24 },
+                        { 16, 32, 3 }, { 0, 0, height + 38 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27110, { 0, 0, height + 24 }, { 16, 32, 3 },
-                        { 16, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27110), { 0, 0, height + 24 },
+                        { 16, 32, 3 }, { 16, 0, height + 38 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -15505,23 +15654,23 @@ static void lay_down_rc_track_left_quarter_banked_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27114, { 0, 0, height + 24 }, { 20, 32, 3 },
-                        { 6, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27114), { 0, 0, height + 24 },
+                        { 20, 32, 3 }, { 6, 0, height + 38 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27119, { 0, 0, height + 24 }, { 20, 32, 3 },
-                        { 6, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27119), { 0, 0, height + 24 },
+                        { 20, 32, 3 }, { 6, 0, height + 38 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27124, { 0, 0, height + 24 }, { 20, 32, 3 },
-                        { 6, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27124), { 0, 0, height + 24 },
+                        { 20, 32, 3 }, { 6, 0, height + 38 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27109, { 0, 0, height + 24 }, { 20, 32, 3 },
-                        { 6, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27109), { 0, 0, height + 24 },
+                        { 20, 32, 3 }, { 6, 0, height + 38 });
                     break;
             }
 
@@ -15556,23 +15705,23 @@ static void lay_down_rc_track_right_quarter_banked_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27089, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 30 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27089), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 30 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27094, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 30 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27094), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 30 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27099, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 30 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27099), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 30 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27104, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 30 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27104), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 30 });
                     break;
             }
 
@@ -15596,23 +15745,23 @@ static void lay_down_rc_track_right_quarter_banked_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27090, { 0, 0, height + 24 }, { 32, 16, 3 },
-                        { 0, 16, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27090), { 0, 0, height + 24 },
+                        { 32, 16, 3 }, { 0, 16, height + 38 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27095, { 0, 0, height + 24 }, { 32, 16, 3 },
-                        { 0, 16, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27095), { 0, 0, height + 24 },
+                        { 32, 16, 3 }, { 0, 16, height + 38 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27100, { 0, 0, height + 24 }, { 32, 16, 3 },
-                        { 0, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27100), { 0, 0, height + 24 },
+                        { 32, 16, 3 }, { 0, 0, height + 38 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27105, { 0, 0, height + 24 }, { 32, 16, 3 },
-                        { 0, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27105), { 0, 0, height + 24 },
+                        { 32, 16, 3 }, { 0, 0, height + 38 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -15627,23 +15776,23 @@ static void lay_down_rc_track_right_quarter_banked_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27091, { 0, 0, height + 24 }, { 16, 16, 3 },
-                        { 0, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27091), { 0, 0, height + 24 },
+                        { 16, 16, 3 }, { 0, 0, height + 38 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27096, { 0, 0, height + 24 }, { 16, 16, 3 },
-                        { 16, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27096), { 0, 0, height + 24 },
+                        { 16, 16, 3 }, { 16, 0, height + 38 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27101, { 0, 0, height + 24 }, { 16, 16, 3 },
-                        { 16, 16, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27101), { 0, 0, height + 24 },
+                        { 16, 16, 3 }, { 16, 16, height + 38 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27106, { 0, 0, height + 24 }, { 16, 16, 3 },
-                        { 0, 16, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27106), { 0, 0, height + 24 },
+                        { 16, 16, 3 }, { 0, 16, height + 38 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -15658,23 +15807,23 @@ static void lay_down_rc_track_right_quarter_banked_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27092, { 0, 0, height + 24 }, { 16, 32, 3 },
-                        { 16, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27092), { 0, 0, height + 24 },
+                        { 16, 32, 3 }, { 16, 0, height + 38 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27097, { 0, 0, height + 24 }, { 16, 32, 3 },
-                        { 0, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27097), { 0, 0, height + 24 },
+                        { 16, 32, 3 }, { 0, 0, height + 38 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27102, { 0, 0, height + 24 }, { 16, 32, 3 },
-                        { 0, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27102), { 0, 0, height + 24 },
+                        { 16, 32, 3 }, { 0, 0, height + 38 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27107, { 0, 0, height + 24 }, { 16, 32, 3 },
-                        { 16, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27107), { 0, 0, height + 24 },
+                        { 16, 32, 3 }, { 16, 0, height + 38 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -15689,23 +15838,23 @@ static void lay_down_rc_track_right_quarter_banked_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27093, { 0, 0, height + 24 }, { 20, 32, 3 },
-                        { 6, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27093), { 0, 0, height + 24 },
+                        { 20, 32, 3 }, { 6, 0, height + 38 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27098, { 0, 0, height + 24 }, { 20, 32, 3 },
-                        { 6, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27098), { 0, 0, height + 24 },
+                        { 20, 32, 3 }, { 6, 0, height + 38 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27103, { 0, 0, height + 24 }, { 20, 32, 3 },
-                        { 6, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27103), { 0, 0, height + 24 },
+                        { 20, 32, 3 }, { 6, 0, height + 38 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27108, { 0, 0, height + 24 }, { 20, 32, 3 },
-                        { 6, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27108), { 0, 0, height + 24 },
+                        { 20, 32, 3 }, { 6, 0, height + 38 });
                     break;
             }
 
@@ -15740,23 +15889,23 @@ static void lay_down_rc_track_left_quarter_banked_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27098, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27098), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 38 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27103, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27103), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 38 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27108, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27108), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 38 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27093, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27093), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 38 });
                     break;
             }
 
@@ -15780,23 +15929,23 @@ static void lay_down_rc_track_left_quarter_banked_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27097, { 0, 0, height + 24 }, { 32, 16, 3 },
-                        { 0, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27097), { 0, 0, height + 24 },
+                        { 32, 16, 3 }, { 0, 0, height + 38 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27102, { 0, 0, height + 24 }, { 32, 16, 3 },
-                        { 0, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27102), { 0, 0, height + 24 },
+                        { 32, 16, 3 }, { 0, 0, height + 38 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27107, { 0, 0, height + 24 }, { 32, 16, 3 },
-                        { 0, 16, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27107), { 0, 0, height + 24 },
+                        { 32, 16, 3 }, { 0, 16, height + 38 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27092, { 0, 0, height + 24 }, { 32, 16, 3 },
-                        { 0, 16, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27092), { 0, 0, height + 24 },
+                        { 32, 16, 3 }, { 0, 16, height + 38 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -15811,23 +15960,23 @@ static void lay_down_rc_track_left_quarter_banked_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27096, { 0, 0, height + 24 }, { 16, 16, 3 },
-                        { 0, 16, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27096), { 0, 0, height + 24 },
+                        { 16, 16, 3 }, { 0, 16, height + 38 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27101, { 0, 0, height + 24 }, { 16, 16, 3 },
-                        { 16, 16, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27101), { 0, 0, height + 24 },
+                        { 16, 16, 3 }, { 16, 16, height + 38 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27106, { 0, 0, height + 24 }, { 16, 16, 3 },
-                        { 16, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27106), { 0, 0, height + 24 },
+                        { 16, 16, 3 }, { 16, 0, height + 38 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27091, { 0, 0, height + 24 }, { 16, 16, 3 },
-                        { 0, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27091), { 0, 0, height + 24 },
+                        { 16, 16, 3 }, { 0, 0, height + 38 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -15842,23 +15991,23 @@ static void lay_down_rc_track_left_quarter_banked_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27095, { 0, 0, height + 24 }, { 16, 32, 3 },
-                        { 16, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27095), { 0, 0, height + 24 },
+                        { 16, 32, 3 }, { 16, 0, height + 38 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27100, { 0, 0, height + 24 }, { 16, 32, 3 },
-                        { 0, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27100), { 0, 0, height + 24 },
+                        { 16, 32, 3 }, { 0, 0, height + 38 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27105, { 0, 0, height + 24 }, { 16, 32, 3 },
-                        { 0, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27105), { 0, 0, height + 24 },
+                        { 16, 32, 3 }, { 0, 0, height + 38 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27090, { 0, 0, height + 24 }, { 16, 32, 3 },
-                        { 16, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27090), { 0, 0, height + 24 },
+                        { 16, 32, 3 }, { 16, 0, height + 38 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -15873,23 +16022,23 @@ static void lay_down_rc_track_left_quarter_banked_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27094, { 0, 0, height + 24 }, { 20, 32, 3 },
-                        { 6, 0, height + 30 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27094), { 0, 0, height + 24 },
+                        { 20, 32, 3 }, { 6, 0, height + 30 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27099, { 0, 0, height + 24 }, { 20, 32, 3 },
-                        { 6, 0, height + 30 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27099), { 0, 0, height + 24 },
+                        { 20, 32, 3 }, { 6, 0, height + 30 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27104, { 0, 0, height + 24 }, { 20, 32, 3 },
-                        { 6, 0, height + 30 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27104), { 0, 0, height + 24 },
+                        { 20, 32, 3 }, { 6, 0, height + 30 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27089, { 0, 0, height + 24 }, { 20, 32, 3 },
-                        { 6, 0, height + 30 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27089), { 0, 0, height + 24 },
+                        { 20, 32, 3 }, { 6, 0, height + 30 });
                     break;
             }
 
@@ -15924,23 +16073,23 @@ static void lay_down_rc_track_right_quarter_banked_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27109, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27109), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 38 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27114, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27114), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 38 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27119, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27119), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 38 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27124, { 0, 0, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27124), { 0, 0, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 38 });
                     break;
             }
 
@@ -15964,23 +16113,23 @@ static void lay_down_rc_track_right_quarter_banked_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27110, { 0, 0, height + 24 }, { 32, 16, 3 },
-                        { 0, 16, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27110), { 0, 0, height + 24 },
+                        { 32, 16, 3 }, { 0, 16, height + 38 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27115, { 0, 0, height + 24 }, { 32, 16, 3 },
-                        { 0, 16, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27115), { 0, 0, height + 24 },
+                        { 32, 16, 3 }, { 0, 16, height + 38 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27120, { 0, 0, height + 24 }, { 32, 16, 3 },
-                        { 0, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27120), { 0, 0, height + 24 },
+                        { 32, 16, 3 }, { 0, 0, height + 38 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27125, { 0, 0, height + 24 }, { 32, 16, 3 },
-                        { 0, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27125), { 0, 0, height + 24 },
+                        { 32, 16, 3 }, { 0, 0, height + 38 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -15995,23 +16144,23 @@ static void lay_down_rc_track_right_quarter_banked_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27111, { 0, 0, height + 24 }, { 16, 16, 3 },
-                        { 0, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27111), { 0, 0, height + 24 },
+                        { 16, 16, 3 }, { 0, 0, height + 38 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27116, { 0, 0, height + 24 }, { 16, 16, 3 },
-                        { 16, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27116), { 0, 0, height + 24 },
+                        { 16, 16, 3 }, { 16, 0, height + 38 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27121, { 0, 0, height + 24 }, { 16, 16, 3 },
-                        { 16, 16, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27121), { 0, 0, height + 24 },
+                        { 16, 16, 3 }, { 16, 16, height + 38 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27126, { 0, 0, height + 24 }, { 16, 16, 3 },
-                        { 0, 16, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27126), { 0, 0, height + 24 },
+                        { 16, 16, 3 }, { 0, 16, height + 38 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -16026,23 +16175,23 @@ static void lay_down_rc_track_right_quarter_banked_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27112, { 0, 0, height + 24 }, { 16, 32, 3 },
-                        { 16, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27112), { 0, 0, height + 24 },
+                        { 16, 32, 3 }, { 16, 0, height + 38 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27117, { 0, 0, height + 24 }, { 16, 32, 3 },
-                        { 0, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27117), { 0, 0, height + 24 },
+                        { 16, 32, 3 }, { 0, 0, height + 38 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27122, { 0, 0, height + 24 }, { 16, 32, 3 },
-                        { 0, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27122), { 0, 0, height + 24 },
+                        { 16, 32, 3 }, { 0, 0, height + 38 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27127, { 0, 0, height + 24 }, { 16, 32, 3 },
-                        { 16, 0, height + 38 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27127), { 0, 0, height + 24 },
+                        { 16, 32, 3 }, { 16, 0, height + 38 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -16057,23 +16206,23 @@ static void lay_down_rc_track_right_quarter_banked_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27113, { 0, 0, height + 24 }, { 20, 32, 3 },
-                        { 6, 0, height + 30 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27113), { 0, 0, height + 24 },
+                        { 20, 32, 3 }, { 6, 0, height + 30 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27118, { 0, 0, height + 24 }, { 20, 32, 3 },
-                        { 6, 0, height + 30 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27118), { 0, 0, height + 24 },
+                        { 20, 32, 3 }, { 6, 0, height + 30 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27123, { 0, 0, height + 24 }, { 20, 32, 3 },
-                        { 6, 0, height + 30 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27123), { 0, 0, height + 24 },
+                        { 20, 32, 3 }, { 6, 0, height + 30 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27128, { 0, 0, height + 24 }, { 20, 32, 3 },
-                        { 6, 0, height + 30 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27128), { 0, 0, height + 24 },
+                        { 20, 32, 3 }, { 6, 0, height + 30 });
                     break;
             }
 
@@ -16107,23 +16256,23 @@ static void lay_down_rc_track_half_loop_inverted_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27073, { 0, 6, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 45 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27073), { 0, 6, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 45 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27081, { 0, 6, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 45 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27081), { 0, 6, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 45 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27080, { 0, 6, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 45 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27080), { 0, 6, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 45 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27088, { 0, 6, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 45 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27088), { 0, 6, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 45 });
                     break;
             }
 
@@ -16160,23 +16309,23 @@ static void lay_down_rc_track_half_loop_inverted_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27074, { 0, 0, height + 24 }, { 32, 2, 3 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27074), { 0, 0, height + 24 },
+                        { 32, 2, 3 }, { 0, 29, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27082, { 0, 14, height + 24 }, { 32, 2, 63 },
-                        { 0, 29, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27082), { 0, 14, height + 24 },
+                        { 32, 2, 63 }, { 0, 29, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27079, { 0, 6, height + 24 }, { 32, 2, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27079), { 0, 6, height + 24 },
+                        { 32, 2, 3 }, { 0, 0, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27087, { 0, 6, height + 24 }, { 2, 2, 3 },
-                        { 29, 20, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27087), { 0, 6, height + 24 },
+                        { 2, 2, 3 }, { 29, 20, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -16187,23 +16336,23 @@ static void lay_down_rc_track_half_loop_inverted_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27075, { 16, 0, height - 3 }, { 5, 2, 119 },
-                        { 16, 29, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27075), { 16, 0, height - 3 },
+                        { 5, 2, 119 }, { 16, 29, height + 2 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27083, { 12, 0, height - 3 }, { 32, 2, 119 },
-                        { 0, -6, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27083), { 12, 0, height - 3 },
+                        { 32, 2, 119 }, { 0, -6, height + 2 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27078, { 10, 16, height - 3 }, { 4, 2, 119 },
-                        { 10, 0, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27078), { 10, 16, height - 3 },
+                        { 4, 2, 119 }, { 10, 0, height + 2 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27086, { 16, 16, height - 3 }, { 2, 2, 119 },
-                        { 29, 29, height + 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27086), { 16, 16, height - 3 },
+                        { 2, 2, 119 }, { 29, 29, height + 2 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -16218,23 +16367,23 @@ static void lay_down_rc_track_half_loop_inverted_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27076, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 34 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27076), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 34 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27084, { 0, 0, height + 29 }, { 2, 2, 3 },
-                        { 0, 0, height - 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27084), { 0, 0, height + 29 },
+                        { 2, 2, 3 }, { 0, 0, height - 6 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27077, { 0, 16, height + 29 }, { 32, 2, 3 },
-                        { 0, 0, height - 6 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27077), { 0, 16, height + 29 },
+                        { 32, 2, 3 }, { 0, 0, height - 6 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 27085, { 0, 16, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 34 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(27085), { 0, 16, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 34 });
                     break;
             }
             if (direction == 0 || direction == 3)

--- a/src/openrct2/ride/coaster/LimLaunchedRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/LimLaunchedRollerCoaster.cpp
@@ -46,17 +46,18 @@ static void lim_launched_rc_track_station(
     {
         bool isClosed = trackElement.BlockBrakeClosed();
         PaintAddImageAsParentRotated(
-            session, direction, _LimLauncherBlockBrakeImages[direction][isClosed] | session.TrackColours[SCHEME_TRACK],
+            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(_LimLauncherBlockBrakeImages[direction][isClosed]),
             { 0, 0, height }, { 32, 20, 1 }, { 0, 6, height + 3 });
     }
     else
     {
         PaintAddImageAsParentRotated(
-            session, direction, imageIds[direction][0] | session.TrackColours[SCHEME_TRACK], { 0, 0, height }, { 32, 20, 1 },
-            { 0, 6, height + 3 });
+            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]), { 0, 0, height },
+            { 32, 20, 1 }, { 0, 6, height + 3 });
     }
     PaintAddImageAsParentRotated(
-        session, direction, imageIds[direction][1] | session.TrackColours[SCHEME_MISC], { 0, 0, height }, { 32, 32, 1 });
+        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][1]), { 0, 0, height },
+        { 32, 32, 1 });
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], 0);
     track_paint_util_draw_station(session, ride, direction, height, trackElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -76,25 +77,29 @@ static void lim_launched_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15388, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15388), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15396, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15396), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15395, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15395), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15403, { 0, 6, height }, { 32, 20, 7 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15403), { 0, 6, height },
+                        { 32, 20, 7 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -115,19 +120,23 @@ static void lim_launched_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15389, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15389), { 0, 0, height },
+                        { 32, 26, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15397, { 0, 14, height }, { 32, 2, 63 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15397), { 0, 14, height },
+                        { 32, 2, 63 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15394, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15394), { 0, 6, height },
+                        { 32, 26, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15402, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15402), { 0, 6, height },
+                        { 32, 26, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -142,23 +151,23 @@ static void lim_launched_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15390, { 16, 0, height }, { 3, 16, 119 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15390), { 16, 0, height },
+                        { 3, 16, 119 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15398, { 12, 0, height }, { 3, 16, 119 },
-                        { 12, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15398), { 12, 0, height },
+                        { 3, 16, 119 }, { 12, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15393, { 10, 16, height }, { 4, 16, 119 },
-                        { 10, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15393), { 10, 16, height },
+                        { 4, 16, 119 }, { 10, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15401, { 16, 16, height }, { 2, 16, 119 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15401), { 16, 16, height },
+                        { 2, 16, 119 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -170,19 +179,23 @@ static void lim_launched_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15391, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15391), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15399, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15399), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15392, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15392), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15400, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15400), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -203,19 +216,23 @@ static void lim_launched_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15392, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15392), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15400, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15400), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15391, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15391), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15399, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15399), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -230,23 +247,23 @@ static void lim_launched_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15393, { 10, 16, height }, { 4, 16, 119 },
-                        { 10, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15393), { 10, 16, height },
+                        { 4, 16, 119 }, { 10, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15401, { 16, 16, height }, { 2, 16, 119 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15401), { 16, 16, height },
+                        { 2, 16, 119 }, { 16, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15390, { 16, 0, height }, { 3, 16, 119 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15390), { 16, 0, height },
+                        { 3, 16, 119 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15398, { 12, 0, height }, { 3, 16, 119 },
-                        { 12, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15398), { 12, 0, height },
+                        { 3, 16, 119 }, { 12, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -258,19 +275,23 @@ static void lim_launched_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15394, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15394), { 0, 6, height },
+                        { 32, 26, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15402, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15402), { 0, 6, height },
+                        { 32, 26, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15389, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15389), { 0, 0, height },
+                        { 32, 26, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15397, { 0, 14, height }, { 32, 2, 63 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15397), { 0, 14, height },
+                        { 32, 2, 63 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -285,25 +306,29 @@ static void lim_launched_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15395, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15395), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15403, { 0, 6, height }, { 32, 20, 7 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15403), { 0, 6, height },
+                        { 32, 20, 7 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15388, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15388), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15396, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15396), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -339,19 +364,23 @@ static void lim_launched_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15419, { 0, 6, height }, { 32, 20, 7 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15419), { 0, 6, height },
+                        { 32, 20, 7 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15411, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15411), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15412, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15412), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15404, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15404), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -366,19 +395,23 @@ static void lim_launched_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15418, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15418), { 0, 6, height },
+                        { 32, 26, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15410, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15410), { 0, 6, height },
+                        { 32, 26, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15413, { 0, 14, height }, { 32, 2, 63 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15413), { 0, 14, height },
+                        { 32, 2, 63 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15405, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15405), { 0, 0, height },
+                        { 32, 26, 3 });
                     break;
             }
             paint_util_set_general_support_height(session, height + 72, 0x20);
@@ -388,23 +421,23 @@ static void lim_launched_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15417, { 16, 16, height }, { 2, 16, 119 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15417), { 16, 16, height },
+                        { 2, 16, 119 }, { 16, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15409, { 10, 16, height }, { 4, 16, 119 },
-                        { 10, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15409), { 10, 16, height },
+                        { 4, 16, 119 }, { 10, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15414, { 12, 0, height }, { 3, 16, 119 },
-                        { 12, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15414), { 12, 0, height },
+                        { 3, 16, 119 }, { 12, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15406, { 16, 0, height }, { 2, 16, 119 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15406), { 16, 0, height },
+                        { 2, 16, 119 }, { 16, 0, height });
                     break;
             }
             paint_util_set_general_support_height(session, height + 168, 0x20);
@@ -414,19 +447,23 @@ static void lim_launched_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15416, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15416), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15408, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15408), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15415, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15415), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15407, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15407), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_general_support_height(session, height + 48, 0x20);
@@ -442,19 +479,23 @@ static void lim_launched_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15415, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15415), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15407, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15407), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15416, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15416), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15408, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15408), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_general_support_height(session, height + 48, 0x20);
@@ -464,23 +505,23 @@ static void lim_launched_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15414, { 12, 0, height }, { 3, 16, 119 },
-                        { 12, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15414), { 12, 0, height },
+                        { 3, 16, 119 }, { 12, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15406, { 16, 0, height }, { 2, 16, 119 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15406), { 16, 0, height },
+                        { 2, 16, 119 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15417, { 16, 16, height }, { 2, 16, 119 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15417), { 16, 16, height },
+                        { 2, 16, 119 }, { 16, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15409, { 10, 16, height }, { 4, 16, 119 },
-                        { 10, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15409), { 10, 16, height },
+                        { 4, 16, 119 }, { 10, 16, height });
                     break;
             }
             paint_util_set_general_support_height(session, height + 168, 0x20);
@@ -490,19 +531,23 @@ static void lim_launched_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15413, { 0, 14, height }, { 32, 2, 63 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15413), { 0, 14, height },
+                        { 32, 2, 63 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15405, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15405), { 0, 0, height },
+                        { 32, 26, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15418, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15418), { 0, 6, height },
+                        { 32, 26, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15410, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15410), { 0, 6, height },
+                        { 32, 26, 3 });
                     break;
             }
             paint_util_set_general_support_height(session, height + 72, 0x20);
@@ -512,19 +557,23 @@ static void lim_launched_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15412, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15412), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15404, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15404), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15419, { 0, 6, height }, { 32, 20, 7 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15419), { 0, 6, height },
+                        { 32, 20, 7 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15411, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15411), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -556,35 +605,35 @@ static void lim_launched_rc_track_left_twist_down_to_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15758, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15758), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15782, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15782), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15761, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15761), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15785, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15785), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15764, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15764), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15788, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15788), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15767, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15767), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15791, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15791), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -602,35 +651,35 @@ static void lim_launched_rc_track_left_twist_down_to_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15759, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15759), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15783, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15783), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15762, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15762), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15786, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15786), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15765, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15765), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15789, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15789), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15768, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15768), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15792, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15792), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -645,35 +694,35 @@ static void lim_launched_rc_track_left_twist_down_to_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15760, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15760), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15784, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 44 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15784), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 44 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15763, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15763), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15787, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 44 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15787), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 44 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15766, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15766), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15790, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 44 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15790), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 44 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15769, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15769), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15793, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 44 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15793), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 44 });
                     break;
             }
             switch (direction)
@@ -705,35 +754,35 @@ static void lim_launched_rc_track_right_twist_down_to_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15770, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15770), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15794, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15794), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15773, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15773), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15797, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15797), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15776, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15776), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15800, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15800), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15779, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15779), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15803, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15803), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -751,35 +800,35 @@ static void lim_launched_rc_track_right_twist_down_to_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15771, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15771), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15795, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15795), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15774, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15774), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15798, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15798), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15777, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15777), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15801, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15801), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15780, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15780), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15804, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15804), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -794,35 +843,35 @@ static void lim_launched_rc_track_right_twist_down_to_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15772, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15772), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15796, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 44 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15796), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 44 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15775, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15775), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15799, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 44 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15799), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 44 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15778, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15778), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15802, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 44 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15802), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 44 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15781, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15781), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15805, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 44 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15805), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 44 });
                     break;
             }
             switch (direction)
@@ -854,35 +903,35 @@ static void lim_launched_rc_track_left_twist_up_to_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15766, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15766), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15790, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 44 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15790), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 44 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15769, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15769), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15793, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 44 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15793), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 44 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15760, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15760), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15784, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 44 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15784), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 44 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15763, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15763), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15787, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 44 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15787), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 44 });
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -899,35 +948,35 @@ static void lim_launched_rc_track_left_twist_up_to_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15765, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15765), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15789, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15789), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15768, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15768), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15792, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15792), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15759, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15759), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15783, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15783), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15762, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15762), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15786, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15786), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -942,35 +991,35 @@ static void lim_launched_rc_track_left_twist_up_to_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15764, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15764), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15788, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15788), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15767, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15767), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15791, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15791), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15758, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15758), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15782, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15782), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15761, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15761), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15785, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15785), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1003,35 +1052,35 @@ static void lim_launched_rc_track_right_twist_up_to_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15778, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15778), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15802, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 44 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15802), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 44 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15781, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15781), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15805, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 44 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15805), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 44 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15772, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15772), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15796, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 44 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15796), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 44 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15775, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15775), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15799, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 44 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15799), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 44 });
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -1048,35 +1097,35 @@ static void lim_launched_rc_track_right_twist_up_to_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15777, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15777), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15801, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15801), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15780, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15780), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15804, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15804), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15771, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15771), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15795, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15795), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15774, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15774), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15798, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15798), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1091,35 +1140,35 @@ static void lim_launched_rc_track_right_twist_up_to_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15776, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15776), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15800, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15800), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15779, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15779), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15803, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15803), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15770, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15770), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15794, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15794), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15773, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15773), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15797, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 28 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15797), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 28 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1152,23 +1201,23 @@ static void lim_launched_rc_track_left_corkscrew_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15734, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15734), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 4 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15737, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15737), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 4 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15740, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15740), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 4 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15743, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15743), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 4 });
                     break;
             }
 
@@ -1185,23 +1234,23 @@ static void lim_launched_rc_track_left_corkscrew_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15735, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15735), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15738, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15738), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15741, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15741), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15744, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15744), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -1212,23 +1261,23 @@ static void lim_launched_rc_track_left_corkscrew_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15736, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15736), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 24 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15739, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15739), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 24 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15742, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15742), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 24 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15745, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15745), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 24 });
                     break;
             }
 
@@ -1264,23 +1313,23 @@ static void lim_launched_rc_track_right_corkscrew_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15746, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15746), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 4 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15749, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15749), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 4 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15752, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15752), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 4 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15755, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15755), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 4 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1298,23 +1347,23 @@ static void lim_launched_rc_track_right_corkscrew_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15747, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15747), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15750, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15750), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15753, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15753), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15756, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15756), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -1325,23 +1374,23 @@ static void lim_launched_rc_track_right_corkscrew_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15748, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15748), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 24 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15751, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15751), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 24 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15754, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15754), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 24 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15757, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15757), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 24 });
                     break;
             }
 
@@ -1391,13 +1440,13 @@ static void lim_launched_rc_track_brakes(
         case 0:
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15018, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15018), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15019, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15019), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -1423,23 +1472,23 @@ static void lim_launched_rc_track_90_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15702, { 0, 0, height }, { 2, 20, 31 },
-                        { 4, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15702), { 0, 0, height },
+                        { 2, 20, 31 }, { 4, 6, height + 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15703, { 0, 0, height }, { 2, 20, 31 },
-                        { 24, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15703), { 0, 0, height },
+                        { 2, 20, 31 }, { 24, 6, height + 8 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15704, { 0, 0, height }, { 2, 20, 31 },
-                        { 24, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15704), { 0, 0, height },
+                        { 2, 20, 31 }, { 24, 6, height + 8 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15705, { 0, 0, height }, { 2, 20, 31 },
-                        { 4, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15705), { 0, 0, height },
+                        { 2, 20, 31 }, { 4, 6, height + 8 });
                     break;
             }
             paint_util_set_vertical_tunnel(session, height + 32);
@@ -1472,23 +1521,23 @@ static void lim_launched_rc_track_60_deg_up_to_90_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15694, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15694), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15695, { 0, 0, height }, { 2, 20, 55 },
-                        { 24, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15695), { 0, 0, height },
+                        { 2, 20, 55 }, { 24, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15696, { 0, 0, height }, { 2, 20, 55 },
-                        { 24, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15696), { 0, 0, height },
+                        { 2, 20, 55 }, { 24, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15697, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15697), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -1522,22 +1571,22 @@ static void lim_launched_rc_track_90_deg_up_to_60_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15698, { 0, 0, height }, { 6, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15698), { 0, 0, height }, { 6, 20, 3 },
                 { 0, 6, height + 2 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15699, { 0, 0, height }, { 2, 20, 31 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15699), { 0, 0, height }, { 2, 20, 31 },
                 { 39, 6, height + 8 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15700, { 0, 0, height }, { 2, 20, 31 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15700), { 0, 0, height }, { 2, 20, 31 },
                 { 39, 6, height + 8 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15701, { 0, 0, height }, { 6, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15701), { 0, 0, height }, { 6, 20, 3 },
                 { 0, 6, height + 2 });
             break;
     }
@@ -1567,23 +1616,23 @@ static void lim_launched_rc_track_60_deg_down_to_90_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15700, { 0, 0, height }, { 2, 20, 31 },
-                        { 39, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15700), { 0, 0, height },
+                        { 2, 20, 31 }, { 39, 6, height + 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15701, { 0, 0, height }, { 6, 20, 3 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15701), { 0, 0, height }, { 6, 20, 3 },
                         { 0, 6, height + 2 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15698, { 0, 0, height }, { 6, 20, 3 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15698), { 0, 0, height }, { 6, 20, 3 },
                         { 0, 6, height + 2 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15699, { 0, 0, height }, { 2, 20, 31 },
-                        { 39, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15699), { 0, 0, height },
+                        { 2, 20, 31 }, { 39, 6, height + 8 });
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -1611,23 +1660,23 @@ static void lim_launched_rc_track_90_deg_to_inverted_flat_quarter_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15722, { 0, 0, height }, { 2, 20, 31 },
-                        { 4, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15722), { 0, 0, height },
+                        { 2, 20, 31 }, { 4, 6, height + 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15725, { 0, 0, height }, { 2, 20, 31 },
-                        { 24, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15725), { 0, 0, height },
+                        { 2, 20, 31 }, { 24, 6, height + 8 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15728, { 0, 0, height }, { 2, 20, 31 },
-                        { 24, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15728), { 0, 0, height },
+                        { 2, 20, 31 }, { 24, 6, height + 8 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15731, { 0, 0, height }, { 2, 20, 31 },
-                        { 4, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15731), { 0, 0, height },
+                        { 2, 20, 31 }, { 4, 6, height + 8 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1639,23 +1688,23 @@ static void lim_launched_rc_track_90_deg_to_inverted_flat_quarter_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15723, { 0, 0, height }, { 2, 20, 31 },
-                        { -8, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15723), { 0, 0, height },
+                        { 2, 20, 31 }, { -8, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15726, { 0, 0, height }, { 2, 20, 63 },
-                        { 24, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15726), { 0, 0, height },
+                        { 2, 20, 63 }, { 24, 6, height + 8 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15729, { 0, 0, height }, { 2, 20, 63 },
-                        { 24, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15729), { 0, 0, height },
+                        { 2, 20, 63 }, { 24, 6, height + 8 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15732, { 0, 0, height }, { 2, 20, 31 },
-                        { -8, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15732), { 0, 0, height },
+                        { 2, 20, 31 }, { -8, 6, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1667,23 +1716,23 @@ static void lim_launched_rc_track_90_deg_to_inverted_flat_quarter_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15724, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15724), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 24 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15727, { 0, 0, height }, { 2, 20, 31 },
-                        { 24, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15727), { 0, 0, height },
+                        { 2, 20, 31 }, { 24, 6, height + 8 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15730, { 0, 0, height }, { 2, 20, 31 },
-                        { 24, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15730), { 0, 0, height },
+                        { 2, 20, 31 }, { 24, 6, height + 8 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15733, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15733), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 24 });
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -1713,7 +1762,7 @@ static void lim_launched_rc_track_block_brakes(
 {
     bool isClosed = trackElement.BlockBrakeClosed();
     PaintAddImageAsParentRotated(
-        session, direction, session.TrackColours[SCHEME_TRACK] | _LimLauncherBlockBrakeImages[direction][isClosed],
+        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(_LimLauncherBlockBrakeImages[direction][isClosed]),
         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
 
     if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -1737,29 +1786,29 @@ static void lim_launched_rc_track_left_quarter_turn_1_90_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15706, { 0, 0, height }, { 2, 20, 63 },
-                        { 4, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15706), { 0, 0, height },
+                        { 2, 20, 63 }, { 4, 6, height + 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15707, { 0, 0, height }, { 2, 20, 63 },
-                        { 4, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15707), { 0, 0, height },
+                        { 2, 20, 63 }, { 4, 6, height + 8 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15715, { 0, 0, height }, { 2, 20, 63 },
-                        { 24, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15715), { 0, 0, height },
+                        { 2, 20, 63 }, { 24, 6, height + 8 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15716, { 0, 0, height }, { 2, 2, 63 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15716), { 0, 0, height }, { 2, 2, 63 },
                         { 24, 24, height + 8 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15709, { 0, 0, height }, { 2, 20, 63 },
-                        { 4, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15709), { 0, 0, height },
+                        { 2, 20, 63 }, { 4, 6, height + 8 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15717, { 0, 0, height }, { 2, 20, 63 },
-                        { 24, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15717), { 0, 0, height },
+                        { 2, 20, 63 }, { 24, 6, height + 8 });
                     break;
             }
             paint_util_set_vertical_tunnel(session, height + 96);
@@ -1784,29 +1833,29 @@ static void lim_launched_rc_track_right_quarter_turn_1_90_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15710, { 0, 0, height }, { 2, 20, 63 },
-                        { 4, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15710), { 0, 0, height },
+                        { 2, 20, 63 }, { 4, 6, height + 8 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15718, { 0, 0, height }, { 2, 20, 63 },
-                        { 24, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15718), { 0, 0, height },
+                        { 2, 20, 63 }, { 24, 6, height + 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15719, { 0, 0, height }, { 2, 2, 63 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15719), { 0, 0, height }, { 2, 2, 63 },
                         { 24, 24, height + 8 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15712, { 0, 0, height }, { 2, 20, 63 },
-                        { 4, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15712), { 0, 0, height },
+                        { 2, 20, 63 }, { 4, 6, height + 8 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15720, { 0, 0, height }, { 2, 20, 63 },
-                        { 24, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15720), { 0, 0, height },
+                        { 2, 20, 63 }, { 24, 6, height + 8 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15713, { 0, 0, height }, { 2, 20, 63 },
-                        { 4, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15713), { 0, 0, height },
+                        { 2, 20, 63 }, { 4, 6, height + 8 });
                     break;
             }
             paint_util_set_vertical_tunnel(session, height + 96);

--- a/src/openrct2/ride/coaster/LoopingRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/LoopingRollerCoaster.cpp
@@ -35,22 +35,22 @@ static void looping_rc_track_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15006, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15006), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15007, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15007), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15008, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15008), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15009, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15009), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -66,13 +66,13 @@ static void looping_rc_track_flat(
             case 0:
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15004, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15004), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15005, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15005), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -106,10 +106,11 @@ static void looping_rc_track_station(
     const auto& imageIds = is_csg_loaded() ? imageIdsFrictionWheels : imageIdsShuttleLaunch;
 
     PaintAddImageAsParentRotated(
-        session, direction, imageIds[direction][0] | session.TrackColours[SCHEME_TRACK], { 0, 0, height }, { 32, 20, 1 },
-        { 0, 6, height + 3 });
+        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]), { 0, 0, height },
+        { 32, 20, 1 }, { 0, 6, height + 3 });
     PaintAddImageAsParentRotated(
-        session, direction, imageIds[direction][1] | session.TrackColours[SCHEME_MISC], { 0, 0, height }, { 32, 32, 1 });
+        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][1]), { 0, 0, height },
+        { 32, 32, 1 });
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], 0);
     track_paint_util_draw_station(session, ride, direction, height, trackElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -128,22 +129,22 @@ static void looping_rc_track_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15060, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15060), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15061, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15061), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15062, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15062), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15063, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15063), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -158,22 +159,22 @@ static void looping_rc_track_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15032, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15032), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15033, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15033), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15034, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15034), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15035, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15035), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -206,22 +207,22 @@ static void looping_rc_track_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15076, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15076), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15077, { 0, 0, height }, { 32, 1, 98 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15077), { 0, 0, height }, { 32, 1, 98 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15078, { 0, 0, height }, { 32, 1, 98 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15078), { 0, 0, height }, { 32, 1, 98 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15079, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15079), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -236,22 +237,22 @@ static void looping_rc_track_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15048, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15048), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15049, { 0, 0, height }, { 32, 1, 98 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15049), { 0, 0, height }, { 32, 1, 98 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15050, { 0, 0, height }, { 32, 1, 98 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15050), { 0, 0, height }, { 32, 1, 98 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15051, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15051), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -284,22 +285,22 @@ static void looping_rc_track_flat_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15052, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15052), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15053, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15053), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15054, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15054), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15055, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15055), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -314,22 +315,22 @@ static void looping_rc_track_flat_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15024, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15024), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15025, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15025), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15026, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15026), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15027, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15027), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -362,28 +363,28 @@ static void looping_rc_track_25_deg_up_to_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15064, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15064), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15065, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15065), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15068, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15068), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15066, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15066), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15069, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15069), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15067, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15067), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -398,28 +399,28 @@ static void looping_rc_track_25_deg_up_to_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15036, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15036), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15037, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15037), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15040, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15040), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15038, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15038), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15041, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15041), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15039, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15039), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -452,28 +453,28 @@ static void looping_rc_track_60_deg_up_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15070, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15070), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15071, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15071), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15074, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15074), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15072, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15072), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15075, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15075), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15073, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15073), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -488,28 +489,28 @@ static void looping_rc_track_60_deg_up_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15042, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15042), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15043, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15043), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15046, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15046), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15044, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15044), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15047, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15047), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15045, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15045), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -542,22 +543,22 @@ static void looping_rc_track_25_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15056, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15056), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15057, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15057), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15058, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15058), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15059, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15059), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -572,22 +573,22 @@ static void looping_rc_track_25_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15028, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15028), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15029, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15029), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15030, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15030), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15031, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15031), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -669,23 +670,23 @@ static void looping_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15183, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15183), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15188, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15188), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15193, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15193), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15178, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15178), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -705,23 +706,23 @@ static void looping_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15182, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15182), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15187, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15187), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15192, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15192), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15177, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15177), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -736,23 +737,23 @@ static void looping_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15181, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15181), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15186, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15186), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15191, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15191), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15176, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15176), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -767,23 +768,23 @@ static void looping_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15180, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15180), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15185, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15185), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15190, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15190), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15175, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15175), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -798,23 +799,23 @@ static void looping_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15179, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15179), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15184, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15184), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15189, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15189), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15174, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15174), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -852,28 +853,28 @@ static void looping_rc_track_flat_to_left_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15080, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15080), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15092, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15092), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15081, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15081), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15093, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15093), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15082, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15082), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15083, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15083), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -896,28 +897,28 @@ static void looping_rc_track_flat_to_right_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15084, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15084), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15085, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15085), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15086, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15086), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15094, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15094), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15087, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15087), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15095, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15095), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
     }
@@ -940,28 +941,28 @@ static void looping_rc_track_left_bank_to_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15086, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15086), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15094, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15094), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15087, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15087), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15095, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15095), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15084, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15084), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15085, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15085), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -984,28 +985,28 @@ static void looping_rc_track_right_bank_to_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15082, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15082), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15083, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15083), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15080, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15080), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15092, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15092), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15081, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15081), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15093, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15093), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
     }
@@ -1031,26 +1032,26 @@ static void looping_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15203, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15203), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15214, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15214), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15208, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15208), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15213, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15213), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15198, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15198), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1070,23 +1071,23 @@ static void looping_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15202, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15202), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15207, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15207), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15212, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15212), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15197, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15197), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1101,23 +1102,23 @@ static void looping_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15201, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15201), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15206, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15206), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15211, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15211), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15196, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15196), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1132,23 +1133,23 @@ static void looping_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15200, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15200), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15205, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15205), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15210, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15210), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15195, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15195), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1163,26 +1164,26 @@ static void looping_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15199, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15199), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15204, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15204), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15209, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15209), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15215, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15215), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15194, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15194), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1220,28 +1221,28 @@ static void looping_rc_track_left_bank_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15096, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15096), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15112, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15112), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15097, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15097), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15113, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15113), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15098, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15098), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15099, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15099), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -1271,28 +1272,28 @@ static void looping_rc_track_right_bank_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15100, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15100), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15101, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15101), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15102, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15102), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15114, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15114), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15103, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15103), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15115, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15115), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
     }
@@ -1322,28 +1323,28 @@ static void looping_rc_track_25_deg_up_to_left_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15104, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15104), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15116, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15116), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15105, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15105), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15117, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15117), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15106, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15106), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15107, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15107), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -1373,28 +1374,28 @@ static void looping_rc_track_25_deg_up_to_right_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15108, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15108), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15109, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15109), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15110, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15110), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15118, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15118), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15111, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15111), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15119, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15119), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
     }
@@ -1456,22 +1457,22 @@ static void looping_rc_track_left_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15088, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15088), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15089, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15089), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15090, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15090), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15091, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15091), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -1505,23 +1506,23 @@ static void looping_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15296, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15296), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15301, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15301), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15306, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15306), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15311, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15311), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1541,21 +1542,23 @@ static void looping_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15297, { 0, 0, height }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15297), { 0, 0, height },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15302, { 0, 0, height }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15302), { 0, 0, height },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15307, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15307), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15312, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15312), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1570,22 +1573,23 @@ static void looping_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15298, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15298), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15303, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15303), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15308, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15308), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15313, { 0, 0, height }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15313), { 0, 0, height },
+                        { 16, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1600,21 +1604,23 @@ static void looping_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15299, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15299), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15304, { 0, 0, height }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15304), { 0, 0, height },
+                        { 16, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15309, { 0, 0, height }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15309), { 0, 0, height },
+                        { 16, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15314, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15314), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1629,23 +1635,23 @@ static void looping_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15300, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15300), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15305, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15305), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15310, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15310), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15315, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15315), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1677,23 +1683,23 @@ static void looping_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15276, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15276), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15281, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15281), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15286, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15286), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15291, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15291), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1713,21 +1719,23 @@ static void looping_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15277, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15277), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15282, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15282), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15287, { 0, 0, height }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15287), { 0, 0, height },
+                        { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15292, { 0, 0, height }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15292), { 0, 0, height },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1742,22 +1750,23 @@ static void looping_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15278, { 0, 0, height }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15278), { 0, 0, height },
+                        { 16, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15283, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15283), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15288, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15288), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15293, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15293), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1772,21 +1781,23 @@ static void looping_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15279, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15279), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15284, { 0, 0, height }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15284), { 0, 0, height },
+                        { 16, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15289, { 0, 0, height }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15289), { 0, 0, height },
+                        { 16, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15294, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15294), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1801,23 +1812,23 @@ static void looping_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15280, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15280), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15285, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15285), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15290, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15290), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15295, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15295), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1867,23 +1878,23 @@ static void looping_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15260, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15260), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15264, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15264), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15263, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15263), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15267, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15267), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1900,25 +1911,27 @@ static void looping_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15261, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15261), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15265, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15265), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 6, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15262, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15262), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15266, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15266), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1933,23 +1946,25 @@ static void looping_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15262, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15262), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15266, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15266), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15261, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15261), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15265, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15265), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 6, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -1966,23 +1981,23 @@ static void looping_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15263, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15263), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15267, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15267), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15260, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15260), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15264, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15264), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2014,23 +2029,23 @@ static void looping_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15268, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15268), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15272, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15272), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15271, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15271), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15275, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15275), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2047,25 +2062,27 @@ static void looping_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15269, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15269), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15273, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15273), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15270, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15270), { 0, 0, height },
+                        { 32, 26, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15274, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15274), { 0, 0, height },
+                        { 32, 26, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2080,23 +2097,25 @@ static void looping_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15270, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15270), { 0, 0, height },
+                        { 32, 26, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15274, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15274), { 0, 0, height },
+                        { 32, 26, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15269, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15269), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15273, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15273), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2113,23 +2132,23 @@ static void looping_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15271, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15271), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15275, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15275), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15268, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15268), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15272, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15272), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2161,19 +2180,23 @@ static void looping_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15348, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15348), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15356, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15356), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15355, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15355), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15363, { 0, 6, height }, { 32, 20, 7 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15363), { 0, 6, height },
+                        { 32, 20, 7 });
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -2192,19 +2215,23 @@ static void looping_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15349, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15349), { 0, 0, height },
+                        { 32, 26, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15357, { 0, 14, height }, { 32, 2, 63 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15357), { 0, 14, height },
+                        { 32, 2, 63 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15354, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15354), { 0, 6, height },
+                        { 32, 26, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15362, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15362), { 0, 6, height },
+                        { 32, 26, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2219,43 +2246,43 @@ static void looping_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15350, { 16, 0, height }, { 3, 16, 119 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15350), { 16, 0, height },
+                        { 3, 16, 119 }, { 16, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_THICK_CENTRED, 1, 0, height - 8, session.TrackColours[SCHEME_TRACK]);
                     PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15364, { 16, 0, height }, { 3, 16, 119 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15364), { 16, 0, height },
+                        { 3, 16, 119 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15358, { 12, 0, height }, { 3, 16, 119 },
-                        { 12, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15358), { 12, 0, height },
+                        { 3, 16, 119 }, { 12, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_THICK_ALT_CENTRED, 0, 0, height - 8, session.TrackColours[SCHEME_TRACK]);
                     PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15366, { 12, 0, height }, { 3, 16, 119 },
-                        { 12, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15366), { 12, 0, height },
+                        { 3, 16, 119 }, { 12, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15353, { 10, 16, height }, { 4, 16, 119 },
-                        { 10, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15353), { 10, 16, height },
+                        { 4, 16, 119 }, { 10, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_THICK, 2, 0, height - 8, session.TrackColours[SCHEME_TRACK]);
                     PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15365, { 10, 16, height }, { 4, 16, 119 },
-                        { 10, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15365), { 10, 16, height },
+                        { 4, 16, 119 }, { 10, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15361, { 16, 16, height }, { 2, 16, 119 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15361), { 16, 16, height },
+                        { 2, 16, 119 }, { 16, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_THICK_ALT, 3, 0, height - 8, session.TrackColours[SCHEME_TRACK]);
                     PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15367, { 16, 16, height }, { 2, 16, 119 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15367), { 16, 16, height },
+                        { 2, 16, 119 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2267,19 +2294,23 @@ static void looping_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15351, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15351), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15359, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15359), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15352, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15352), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15360, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15360), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2300,19 +2331,23 @@ static void looping_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15352, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15352), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15360, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15360), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15351, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15351), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15359, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15359), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2327,43 +2362,43 @@ static void looping_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15353, { 10, 16, height }, { 4, 16, 119 },
-                        { 10, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15353), { 10, 16, height },
+                        { 4, 16, 119 }, { 10, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_THICK, 2, 0, height - 8, session.TrackColours[SCHEME_TRACK]);
                     PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15365, { 10, 16, height }, { 4, 16, 119 },
-                        { 10, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15365), { 10, 16, height },
+                        { 4, 16, 119 }, { 10, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15361, { 16, 16, height }, { 2, 16, 119 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15361), { 16, 16, height },
+                        { 2, 16, 119 }, { 16, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_THICK_ALT, 3, 0, height - 8, session.TrackColours[SCHEME_TRACK]);
                     PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15367, { 16, 16, height }, { 2, 16, 119 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15367), { 16, 16, height },
+                        { 2, 16, 119 }, { 16, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15350, { 16, 0, height }, { 3, 16, 119 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15350), { 16, 0, height },
+                        { 3, 16, 119 }, { 16, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_THICK_CENTRED, 1, 0, height - 8, session.TrackColours[SCHEME_TRACK]);
                     PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15364, { 16, 0, height }, { 3, 16, 119 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15364), { 16, 0, height },
+                        { 3, 16, 119 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15358, { 12, 0, height }, { 3, 16, 119 },
-                        { 12, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15358), { 12, 0, height },
+                        { 3, 16, 119 }, { 12, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_THICK_ALT_CENTRED, 0, 0, height - 8, session.TrackColours[SCHEME_TRACK]);
                     PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15366, { 12, 0, height }, { 3, 16, 119 },
-                        { 12, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15366), { 12, 0, height },
+                        { 3, 16, 119 }, { 12, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2375,19 +2410,23 @@ static void looping_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15354, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15354), { 0, 6, height },
+                        { 32, 26, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15362, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15362), { 0, 6, height },
+                        { 32, 26, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15349, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15349), { 0, 0, height },
+                        { 32, 26, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15357, { 0, 14, height }, { 32, 2, 63 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15357), { 0, 14, height },
+                        { 32, 2, 63 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2402,19 +2441,23 @@ static void looping_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15355, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15355), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15363, { 0, 6, height }, { 32, 20, 7 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15363), { 0, 6, height },
+                        { 32, 20, 7 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15348, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15348), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15356, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15356), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             switch (direction)
@@ -2448,19 +2491,23 @@ static void looping_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15383, { 0, 6, height }, { 32, 20, 7 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15383), { 0, 6, height },
+                        { 32, 20, 7 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15375, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15375), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15376, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15376), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15368, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15368), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -2474,19 +2521,23 @@ static void looping_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15382, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15382), { 0, 6, height },
+                        { 32, 26, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15374, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15374), { 0, 6, height },
+                        { 32, 26, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15377, { 0, 14, height }, { 32, 2, 63 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15377), { 0, 14, height },
+                        { 32, 2, 63 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15369, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15369), { 0, 0, height },
+                        { 32, 26, 3 });
                     break;
             }
             paint_util_set_general_support_height(session, height + 72, 0x20);
@@ -2496,43 +2547,43 @@ static void looping_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15381, { 16, 16, height }, { 2, 16, 119 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15381), { 16, 16, height },
+                        { 2, 16, 119 }, { 16, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_THICK, 3, 0, height - 8, session.TrackColours[SCHEME_TRACK]);
                     PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15384, { 16, 16, height }, { 2, 16, 119 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15384), { 16, 16, height },
+                        { 2, 16, 119 }, { 16, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15373, { 10, 16, height }, { 4, 16, 119 },
-                        { 10, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15373), { 10, 16, height },
+                        { 4, 16, 119 }, { 10, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_THICK_ALT, 1, 0, height - 8, session.TrackColours[SCHEME_TRACK]);
                     PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15386, { 10, 16, height }, { 4, 16, 119 },
-                        { 10, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15386), { 10, 16, height },
+                        { 4, 16, 119 }, { 10, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15378, { 12, 0, height }, { 3, 16, 119 },
-                        { 12, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15378), { 12, 0, height },
+                        { 3, 16, 119 }, { 12, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_THICK_CENTRED, 0, 0, height - 8, session.TrackColours[SCHEME_TRACK]);
                     PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15385, { 12, 0, height }, { 3, 16, 119 },
-                        { 12, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15385), { 12, 0, height },
+                        { 3, 16, 119 }, { 12, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15370, { 16, 0, height }, { 2, 16, 119 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15370), { 16, 0, height },
+                        { 2, 16, 119 }, { 16, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_THICK_ALT_CENTRED, 2, 0, height - 8, session.TrackColours[SCHEME_TRACK]);
                     PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15387, { 16, 0, height }, { 2, 16, 119 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15387), { 16, 0, height },
+                        { 2, 16, 119 }, { 16, 0, height });
                     break;
             }
             paint_util_set_general_support_height(session, height + 168, 0x20);
@@ -2542,19 +2593,23 @@ static void looping_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15380, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15380), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15372, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15372), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15379, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15379), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15371, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15371), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_general_support_height(session, height + 48, 0x20);
@@ -2570,19 +2625,23 @@ static void looping_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15379, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15379), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15371, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15371), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15380, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15380), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15372, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15372), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_general_support_height(session, height + 48, 0x20);
@@ -2592,43 +2651,43 @@ static void looping_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15378, { 12, 0, height }, { 3, 16, 119 },
-                        { 12, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15378), { 12, 0, height },
+                        { 3, 16, 119 }, { 12, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_THICK_CENTRED, 0, 0, height - 8, session.TrackColours[SCHEME_TRACK]);
                     PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15385, { 12, 0, height }, { 3, 16, 119 },
-                        { 12, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15385), { 12, 0, height },
+                        { 3, 16, 119 }, { 12, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15370, { 16, 0, height }, { 2, 16, 119 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15370), { 16, 0, height },
+                        { 2, 16, 119 }, { 16, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_THICK_ALT_CENTRED, 2, 0, height - 8, session.TrackColours[SCHEME_TRACK]);
                     PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15387, { 16, 0, height }, { 2, 16, 119 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15387), { 16, 0, height },
+                        { 2, 16, 119 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15381, { 16, 16, height }, { 2, 16, 119 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15381), { 16, 16, height },
+                        { 2, 16, 119 }, { 16, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_THICK, 3, 0, height - 8, session.TrackColours[SCHEME_TRACK]);
                     PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15384, { 16, 16, height }, { 2, 16, 119 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15384), { 16, 16, height },
+                        { 2, 16, 119 }, { 16, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15373, { 10, 16, height }, { 4, 16, 119 },
-                        { 10, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15373), { 10, 16, height },
+                        { 4, 16, 119 }, { 10, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_THICK_ALT, 1, 0, height - 8, session.TrackColours[SCHEME_TRACK]);
                     PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15386, { 10, 16, height }, { 4, 16, 119 },
-                        { 10, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15386), { 10, 16, height },
+                        { 4, 16, 119 }, { 10, 16, height });
                     break;
             }
             paint_util_set_general_support_height(session, height + 168, 0x20);
@@ -2638,19 +2697,23 @@ static void looping_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15377, { 0, 14, height }, { 32, 2, 63 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15377), { 0, 14, height },
+                        { 32, 2, 63 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15369, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15369), { 0, 0, height },
+                        { 32, 26, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15382, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15382), { 0, 6, height },
+                        { 32, 26, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15374, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15374), { 0, 6, height },
+                        { 32, 26, 3 });
                     break;
             }
             paint_util_set_general_support_height(session, height + 72, 0x20);
@@ -2660,19 +2723,23 @@ static void looping_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15376, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15376), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15368, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15368), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15383, { 0, 6, height }, { 32, 20, 7 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15383), { 0, 6, height },
+                        { 32, 20, 7 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15375, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15375), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             switch (direction)
@@ -2703,23 +2770,23 @@ static void looping_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15125, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15125), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15128, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15128), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15131, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15131), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15122, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15122), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2739,23 +2806,23 @@ static void looping_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15124, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15124), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15127, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15127), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15130, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15130), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15121, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15121), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2767,23 +2834,23 @@ static void looping_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15123, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15123), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15126, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15126), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15129, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15129), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15120, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15120), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2824,26 +2891,26 @@ static void looping_rc_track_left_quarter_turn_3_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15137, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15137), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15144, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15144), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15140, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15140), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15143, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15143), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15134, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15134), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2863,23 +2930,23 @@ static void looping_rc_track_left_quarter_turn_3_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15136, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15136), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15139, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15139), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15142, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15142), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15133, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15133), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2891,26 +2958,26 @@ static void looping_rc_track_left_quarter_turn_3_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15135, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15135), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15138, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15138), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15141, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15141), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15145, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15145), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15132, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15132), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2951,19 +3018,23 @@ static void looping_rc_track_left_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15327, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15327), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15329, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15329), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15331, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15331), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15325, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15325), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2986,19 +3057,23 @@ static void looping_rc_track_left_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15326, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15326), { 6, 0, height },
+                        { 20, 32, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15328, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15328), { 6, 0, height },
+                        { 20, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15330, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15330), { 6, 0, height },
+                        { 20, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15324, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15324), { 6, 0, height },
+                        { 20, 32, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3030,19 +3105,23 @@ static void looping_rc_track_right_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15316, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15316), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15318, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15318), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15320, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15320), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15322, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15322), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3065,25 +3144,29 @@ static void looping_rc_track_right_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15317, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15317), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15319, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15319), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15321, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15321), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15323, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15323), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3134,26 +3217,26 @@ static void looping_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15165, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15165), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15172, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15172), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15168, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15168), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15171, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15171), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15162, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15162), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3174,23 +3257,23 @@ static void looping_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15164, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15164), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15167, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15167), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15170, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15170), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15161, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15161), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3202,26 +3285,26 @@ static void looping_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15163, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15163), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15166, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15166), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15169, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15169), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15173, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15173), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15160, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15160), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 8 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3244,26 +3327,26 @@ static void looping_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15162, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15162), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15165, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15165), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15172, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15172), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15168, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15168), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15171, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15171), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3289,23 +3372,23 @@ static void looping_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15161, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15161), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15164, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15164), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15167, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15167), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15170, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15170), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3317,26 +3400,26 @@ static void looping_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15160, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15160), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15163, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15163), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15166, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15166), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15169, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15169), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15173, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15173), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3364,26 +3447,26 @@ static void looping_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15146, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15146), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15149, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15149), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15152, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15152), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15155, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15155), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15159, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15159), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3404,23 +3487,23 @@ static void looping_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15147, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15147), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15150, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15150), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15153, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15153), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15156, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15156), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3432,26 +3515,26 @@ static void looping_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15148, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15148), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15151, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15151), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15158, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15158), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15154, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15154), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15157, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15157), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3474,26 +3557,26 @@ static void looping_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15149, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15149), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15152, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15152), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15155, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15155), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15159, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15159), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15146, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15146), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3519,23 +3602,23 @@ static void looping_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15150, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15150), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15153, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15153), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15156, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15156), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15147, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15147), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3547,26 +3630,26 @@ static void looping_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15151, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15151), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15158, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15158), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15154, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15154), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15157, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15157), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15148, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15148), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3622,26 +3705,26 @@ static void looping_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15247, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15247), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15258, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15258), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15252, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15252), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15257, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15257), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15242, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15242), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3662,23 +3745,23 @@ static void looping_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15246, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15246), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15251, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15251), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15256, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15256), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15241, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15241), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3693,23 +3776,23 @@ static void looping_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15245, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15245), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15250, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15250), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15255, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15255), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15240, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15240), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3724,23 +3807,23 @@ static void looping_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15244, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15244), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15249, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15249), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15254, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15254), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15239, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15239), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3755,26 +3838,26 @@ static void looping_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15243, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15243), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15248, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15248), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15253, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15253), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15259, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15259), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15238, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15238), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 8 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3797,26 +3880,26 @@ static void looping_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15242, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15242), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15247, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15247), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15258, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15258), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15252, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15252), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15257, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15257), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3842,23 +3925,23 @@ static void looping_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15241, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15241), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15246, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15246), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15251, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15251), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15256, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15256), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3873,23 +3956,23 @@ static void looping_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15240, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15240), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15245, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15245), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15250, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15250), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15255, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15255), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3904,23 +3987,23 @@ static void looping_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15239, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15239), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15244, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15244), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15249, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15249), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15254, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15254), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3935,26 +4018,26 @@ static void looping_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15238, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15238), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15243, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15243), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15248, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15248), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15253, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15253), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15259, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15259), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3982,26 +4065,26 @@ static void looping_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15216, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15216), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15221, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15221), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15226, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15226), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15231, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15231), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15237, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15237), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4022,23 +4105,23 @@ static void looping_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15217, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15217), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15222, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15222), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15227, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15227), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15232, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15232), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4053,23 +4136,23 @@ static void looping_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15218, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15218), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15223, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15223), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15228, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15228), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15233, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15233), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4084,23 +4167,23 @@ static void looping_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15219, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15219), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15224, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15224), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15229, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15229), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15234, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15234), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4115,26 +4198,26 @@ static void looping_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15220, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15220), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15225, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15225), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15236, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15236), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15230, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15230), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15235, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15235), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4157,26 +4240,26 @@ static void looping_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15221, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15221), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15226, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15226), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15231, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15231), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15237, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15237), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15216, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15216), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4202,23 +4285,23 @@ static void looping_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15222, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15222), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15227, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15227), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15232, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15232), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15217, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15217), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4233,23 +4316,23 @@ static void looping_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15223, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15223), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15228, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15228), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15233, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15233), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15218, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15218), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4264,23 +4347,23 @@ static void looping_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15224, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15224), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15229, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15229), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15234, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15234), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15219, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15219), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4295,26 +4378,26 @@ static void looping_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15225, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15225), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15236, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15236), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15230, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15230), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15235, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15235), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15220, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15220), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4367,34 +4450,34 @@ static void looping_rc_track_left_quarter_turn_1_60_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15341, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15341), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15345, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15345), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15342, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15342), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15346, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15346), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15343, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15343), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15347, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15347), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15340, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15340), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15344, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15344), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
     }
@@ -4412,34 +4495,34 @@ static void looping_rc_track_right_quarter_turn_1_60_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15332, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15332), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15336, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15336), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15333, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15333), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15337, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15337), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15334, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15334), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15338, { 0, 0, height }, { 2, 28, 59 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15338), { 0, 0, height }, { 2, 28, 59 },
                 { 28, 2, height + 2 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15335, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15335), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15339, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15339), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
     }
@@ -4474,19 +4557,19 @@ static void looping_rc_track_brakes(
         case 0:
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15012, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15012), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15014, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15014), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 1:
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15013, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15013), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15015, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15015), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
     }
@@ -4509,22 +4592,22 @@ static void looping_rc_track_25_deg_up_left_banked(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15594, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15594), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15595, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15595), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15596, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15596), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15597, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15597), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -4554,22 +4637,22 @@ static void looping_rc_track_25_deg_up_right_banked(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15598, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15598), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15599, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15599), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15600, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15600), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15601, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15601), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -4599,38 +4682,42 @@ static void looping_rc_track_on_ride_photo(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_MISC] | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                session, direction, session.TrackColours[SCHEME_MISC].WithIndex(SPR_STATION_BASE_D), { 0, 0, height },
+                { 32, 32, 1 });
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15004, { 0, 0, height }, { 32, 20, 0 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15004), { 0, 0, height }, { 32, 20, 0 },
                 { 0, 6, height + 3 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_MISC] | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                session, direction, session.TrackColours[SCHEME_MISC].WithIndex(SPR_STATION_BASE_D), { 0, 0, height },
+                { 32, 32, 1 });
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15005, { 0, 0, height }, { 32, 20, 0 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15005), { 0, 0, height }, { 32, 20, 0 },
                 { 0, 6, height + 3 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_MISC] | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                session, direction, session.TrackColours[SCHEME_MISC].WithIndex(SPR_STATION_BASE_D), { 0, 0, height },
+                { 32, 32, 1 });
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15004, { 0, 0, height }, { 32, 20, 0 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15004), { 0, 0, height }, { 32, 20, 0 },
                 { 0, 6, height + 3 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_MISC] | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                session, direction, session.TrackColours[SCHEME_MISC].WithIndex(SPR_STATION_BASE_D), { 0, 0, height },
+                { 32, 32, 1 });
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15005, { 0, 0, height }, { 32, 20, 0 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15005), { 0, 0, height }, { 32, 20, 0 },
                 { 0, 6, height + 3 });
             break;
     }
@@ -4668,23 +4755,23 @@ static void looping_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15526, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15526), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15530, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15530), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15534, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15534), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15538, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15538), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4701,23 +4788,23 @@ static void looping_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15527, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15527), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15531, { 0, 0, height }, { 34, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15531), { 0, 0, height },
+                        { 34, 16, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15535, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15535), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15539, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15539), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4732,23 +4819,23 @@ static void looping_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15528, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15528), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15532, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15532), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15536, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15536), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15540, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15540), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4766,29 +4853,29 @@ static void looping_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15529, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15529), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15533, { 0, 0, height }, { 16, 18, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15533), { 0, 0, height },
+                        { 16, 18, 3 }, { 0, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15537, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15537), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15541, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15541), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -4815,23 +4902,23 @@ static void looping_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15510, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15510), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15514, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15514), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15518, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15518), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15522, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15522), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4848,23 +4935,23 @@ static void looping_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15511, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15511), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15515, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15515), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15519, { 0, 0, height }, { 34, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15519), { 0, 0, height },
+                        { 34, 16, 3 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15523, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15523), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4879,23 +4966,23 @@ static void looping_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15512, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15512), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15516, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15516), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15520, { 0, 0, height }, { 28, 28, 3 },
-                        { 4, 4, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15520), { 0, 0, height },
+                        { 28, 28, 3 }, { 4, 4, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15524, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15524), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4913,29 +5000,29 @@ static void looping_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15513, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15513), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15517, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15517), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15521, { 0, 0, height }, { 16, 18, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15521), { 0, 0, height },
+                        { 16, 18, 3 }, { 0, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15525, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15525), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -4980,23 +5067,23 @@ static void looping_rc_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15558, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15558), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15562, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15562), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15566, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15566), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15570, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15570), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -5013,23 +5100,23 @@ static void looping_rc_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15559, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15559), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15563, { 0, 0, height }, { 34, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15563), { 0, 0, height },
+                        { 34, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15567, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15567), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15571, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15571), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5044,23 +5131,23 @@ static void looping_rc_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15560, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15560), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15564, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15564), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15568, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15568), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15572, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15572), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5078,29 +5165,29 @@ static void looping_rc_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15561, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15561), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15565, { 0, 0, height }, { 16, 18, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15565), { 0, 0, height },
+                        { 16, 18, 0 }, { 0, 16, height + 27 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15569, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15569), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15573, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15573), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -5127,23 +5214,23 @@ static void looping_rc_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15542, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15542), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15546, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15546), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15550, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15550), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15554, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15554), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -5160,23 +5247,23 @@ static void looping_rc_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15543, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15543), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15547, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15547), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15551, { 0, 0, height }, { 34, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15551), { 0, 0, height },
+                        { 34, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15555, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15555), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5191,23 +5278,23 @@ static void looping_rc_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15544, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15544), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15548, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15548), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15552, { 0, 0, height }, { 28, 28, 0 },
-                        { 4, 4, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15552), { 0, 0, height },
+                        { 28, 28, 0 }, { 4, 4, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15556, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15556), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5225,29 +5312,29 @@ static void looping_rc_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15545, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15545), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15549, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15549), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15553, { 0, 0, height }, { 16, 18, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15553), { 0, 0, height },
+                        { 16, 18, 0 }, { 0, 16, height + 27 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15557, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15557), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -5294,8 +5381,8 @@ static void looping_rc_track_diag_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15451, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15451), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5305,8 +5392,8 @@ static void looping_rc_track_diag_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15423, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15423), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5321,8 +5408,8 @@ static void looping_rc_track_diag_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15448, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15448), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5332,8 +5419,8 @@ static void looping_rc_track_diag_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15420, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15420), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5348,8 +5435,8 @@ static void looping_rc_track_diag_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15450, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15450), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5359,8 +5446,8 @@ static void looping_rc_track_diag_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15422, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15422), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5379,8 +5466,8 @@ static void looping_rc_track_diag_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15449, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15449), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5404,8 +5491,8 @@ static void looping_rc_track_diag_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15421, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15421), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5440,8 +5527,8 @@ static void looping_rc_track_diag_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15463, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15463), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5451,8 +5538,8 @@ static void looping_rc_track_diag_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15435, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15435), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5467,8 +5554,8 @@ static void looping_rc_track_diag_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15460, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15460), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5478,8 +5565,8 @@ static void looping_rc_track_diag_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15432, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15432), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5494,8 +5581,8 @@ static void looping_rc_track_diag_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15462, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15462), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5505,8 +5592,8 @@ static void looping_rc_track_diag_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15434, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15434), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5525,8 +5612,8 @@ static void looping_rc_track_diag_25_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15461, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15461), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5550,8 +5637,8 @@ static void looping_rc_track_diag_25_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15433, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15433), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5586,8 +5673,8 @@ static void looping_rc_track_diag_60_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15475, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15475), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5597,8 +5684,8 @@ static void looping_rc_track_diag_60_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15447, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15447), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5613,8 +5700,8 @@ static void looping_rc_track_diag_60_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15472, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15472), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5624,8 +5711,8 @@ static void looping_rc_track_diag_60_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15444, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15444), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5640,8 +5727,8 @@ static void looping_rc_track_diag_60_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15474, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15474), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5651,8 +5738,8 @@ static void looping_rc_track_diag_60_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15446, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15446), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5671,8 +5758,8 @@ static void looping_rc_track_diag_60_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15473, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15473), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 36, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5696,8 +5783,8 @@ static void looping_rc_track_diag_60_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15445, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15445), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 36, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5732,8 +5819,8 @@ static void looping_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15455, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15455), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5743,8 +5830,8 @@ static void looping_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15427, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15427), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5759,8 +5846,8 @@ static void looping_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15452, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15452), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5770,8 +5857,8 @@ static void looping_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15424, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15424), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5786,8 +5873,8 @@ static void looping_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15454, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15454), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5797,8 +5884,8 @@ static void looping_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15426, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15426), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5817,8 +5904,8 @@ static void looping_rc_track_diag_flat_to_25_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15453, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15453), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5842,8 +5929,8 @@ static void looping_rc_track_diag_flat_to_25_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15425, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15425), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5878,8 +5965,8 @@ static void looping_rc_track_diag_25_deg_up_to_60_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15467, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15467), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5889,8 +5976,8 @@ static void looping_rc_track_diag_25_deg_up_to_60_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15439, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15439), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5905,8 +5992,8 @@ static void looping_rc_track_diag_25_deg_up_to_60_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15464, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15464), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5916,8 +6003,8 @@ static void looping_rc_track_diag_25_deg_up_to_60_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15436, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15436), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5932,8 +6019,8 @@ static void looping_rc_track_diag_25_deg_up_to_60_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15466, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15466), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5943,8 +6030,8 @@ static void looping_rc_track_diag_25_deg_up_to_60_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15438, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15438), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5963,8 +6050,8 @@ static void looping_rc_track_diag_25_deg_up_to_60_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15465, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15465), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5988,8 +6075,8 @@ static void looping_rc_track_diag_25_deg_up_to_60_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15437, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15437), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6024,8 +6111,8 @@ static void looping_rc_track_diag_60_deg_up_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15471, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15471), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6035,8 +6122,8 @@ static void looping_rc_track_diag_60_deg_up_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15443, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15443), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6051,8 +6138,8 @@ static void looping_rc_track_diag_60_deg_up_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15468, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15468), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6062,8 +6149,8 @@ static void looping_rc_track_diag_60_deg_up_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15440, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15440), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6078,8 +6165,8 @@ static void looping_rc_track_diag_60_deg_up_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15470, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15470), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6089,8 +6176,8 @@ static void looping_rc_track_diag_60_deg_up_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15442, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15442), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6109,8 +6196,8 @@ static void looping_rc_track_diag_60_deg_up_to_25_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15469, { -16, -16, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15469), { -16, -16, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 21, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6134,8 +6221,8 @@ static void looping_rc_track_diag_60_deg_up_to_25_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15441, { -16, -16, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15441), { -16, -16, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 21, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6170,8 +6257,8 @@ static void looping_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15459, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15459), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6181,8 +6268,8 @@ static void looping_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15431, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15431), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6197,8 +6284,8 @@ static void looping_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15456, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15456), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6208,8 +6295,8 @@ static void looping_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15428, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15428), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6224,8 +6311,8 @@ static void looping_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15458, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15458), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6235,8 +6322,8 @@ static void looping_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15430, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15430), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6255,8 +6342,8 @@ static void looping_rc_track_diag_25_deg_up_to_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15457, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15457), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6280,8 +6367,8 @@ static void looping_rc_track_diag_25_deg_up_to_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15429, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15429), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6316,8 +6403,8 @@ static void looping_rc_track_diag_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15461, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15461), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6327,8 +6414,8 @@ static void looping_rc_track_diag_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15433, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15433), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6343,8 +6430,8 @@ static void looping_rc_track_diag_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15462, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15462), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6354,8 +6441,8 @@ static void looping_rc_track_diag_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15434, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15434), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6370,8 +6457,8 @@ static void looping_rc_track_diag_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15460, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15460), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6381,8 +6468,8 @@ static void looping_rc_track_diag_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15432, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15432), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6401,8 +6488,8 @@ static void looping_rc_track_diag_25_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15463, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15463), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6426,8 +6513,8 @@ static void looping_rc_track_diag_25_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15435, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15435), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6462,8 +6549,8 @@ static void looping_rc_track_diag_60_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15473, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15473), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6473,8 +6560,8 @@ static void looping_rc_track_diag_60_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15445, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15445), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6489,8 +6576,8 @@ static void looping_rc_track_diag_60_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15474, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15474), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6500,8 +6587,8 @@ static void looping_rc_track_diag_60_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15446, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15446), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6516,8 +6603,8 @@ static void looping_rc_track_diag_60_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15472, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15472), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6527,8 +6614,8 @@ static void looping_rc_track_diag_60_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15444, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15444), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6547,8 +6634,8 @@ static void looping_rc_track_diag_60_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15475, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15475), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 28, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6572,8 +6659,8 @@ static void looping_rc_track_diag_60_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15447, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15447), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 28, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6608,8 +6695,8 @@ static void looping_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15457, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15457), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6619,8 +6706,8 @@ static void looping_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15429, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15429), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6634,8 +6721,8 @@ static void looping_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15458, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15458), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6645,8 +6732,8 @@ static void looping_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15430, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15430), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6660,8 +6747,8 @@ static void looping_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15456, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15456), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6671,8 +6758,8 @@ static void looping_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15428, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15428), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6690,8 +6777,8 @@ static void looping_rc_track_diag_flat_to_25_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15459, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15459), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6715,8 +6802,8 @@ static void looping_rc_track_diag_flat_to_25_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15431, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15431), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6752,8 +6839,8 @@ static void looping_rc_track_diag_25_deg_down_to_60_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15469, { -16, -16, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15469), { -16, -16, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         break;
                 }
             }
@@ -6763,8 +6850,8 @@ static void looping_rc_track_diag_25_deg_down_to_60_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15441, { -16, -16, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15441), { -16, -16, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         break;
                 }
             }
@@ -6779,8 +6866,8 @@ static void looping_rc_track_diag_25_deg_down_to_60_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15470, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15470), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6790,8 +6877,8 @@ static void looping_rc_track_diag_25_deg_down_to_60_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15442, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15442), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6806,8 +6893,8 @@ static void looping_rc_track_diag_25_deg_down_to_60_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15468, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15468), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6817,8 +6904,8 @@ static void looping_rc_track_diag_25_deg_down_to_60_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15440, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15440), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6837,8 +6924,8 @@ static void looping_rc_track_diag_25_deg_down_to_60_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15471, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15471), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 17, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6862,8 +6949,8 @@ static void looping_rc_track_diag_25_deg_down_to_60_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15443, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15443), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 17, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6898,8 +6985,8 @@ static void looping_rc_track_diag_60_deg_down_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15465, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15465), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6909,8 +6996,8 @@ static void looping_rc_track_diag_60_deg_down_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15437, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15437), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6925,8 +7012,8 @@ static void looping_rc_track_diag_60_deg_down_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15466, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15466), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6936,8 +7023,8 @@ static void looping_rc_track_diag_60_deg_down_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15438, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15438), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6952,8 +7039,8 @@ static void looping_rc_track_diag_60_deg_down_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15464, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15464), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6963,8 +7050,8 @@ static void looping_rc_track_diag_60_deg_down_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15436, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15436), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6983,8 +7070,8 @@ static void looping_rc_track_diag_60_deg_down_to_25_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15467, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15467), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7008,8 +7095,8 @@ static void looping_rc_track_diag_60_deg_down_to_25_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15439, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15439), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7044,8 +7131,8 @@ static void looping_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15453, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15453), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7055,8 +7142,8 @@ static void looping_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15425, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15425), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7071,8 +7158,8 @@ static void looping_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15454, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15454), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7082,8 +7169,8 @@ static void looping_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15426, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15426), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7098,8 +7185,8 @@ static void looping_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15452, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15452), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7109,8 +7196,8 @@ static void looping_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15424, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15424), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7129,8 +7216,8 @@ static void looping_rc_track_diag_25_deg_down_to_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15455, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15455), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7154,8 +7241,8 @@ static void looping_rc_track_diag_25_deg_down_to_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15427, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15427), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7188,8 +7275,8 @@ static void looping_rc_track_diag_flat_to_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15503, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15503), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7201,11 +7288,11 @@ static void looping_rc_track_diag_flat_to_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15500, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15500), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15504, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15504), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7217,8 +7304,8 @@ static void looping_rc_track_diag_flat_to_left_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15502, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15502), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7234,8 +7321,8 @@ static void looping_rc_track_diag_flat_to_left_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15501, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15501), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7267,8 +7354,8 @@ static void looping_rc_track_diag_flat_to_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15508, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15508), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7280,8 +7367,8 @@ static void looping_rc_track_diag_flat_to_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15505, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15505), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7293,11 +7380,11 @@ static void looping_rc_track_diag_flat_to_right_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15507, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15507), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15509, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15509), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7313,8 +7400,8 @@ static void looping_rc_track_diag_flat_to_right_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15506, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15506), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7346,8 +7433,8 @@ static void looping_rc_track_diag_left_bank_to_flat(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15506, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15506), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7359,11 +7446,11 @@ static void looping_rc_track_diag_left_bank_to_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15507, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15507), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15509, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15509), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7375,8 +7462,8 @@ static void looping_rc_track_diag_left_bank_to_flat(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15505, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15505), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7392,8 +7479,8 @@ static void looping_rc_track_diag_left_bank_to_flat(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15508, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15508), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7425,8 +7512,8 @@ static void looping_rc_track_diag_right_bank_to_flat(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15501, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15501), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7438,8 +7525,8 @@ static void looping_rc_track_diag_right_bank_to_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15502, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15502), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7451,11 +7538,11 @@ static void looping_rc_track_diag_right_bank_to_flat(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15500, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15500), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15504, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15504), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7471,8 +7558,8 @@ static void looping_rc_track_diag_right_bank_to_flat(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15503, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15503), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7504,8 +7591,8 @@ static void looping_rc_track_diag_left_bank_to_25_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15493, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15493), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7517,11 +7604,11 @@ static void looping_rc_track_diag_left_bank_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15490, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15490), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15494, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15494), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7533,8 +7620,8 @@ static void looping_rc_track_diag_left_bank_to_25_deg_up(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15492, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15492), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7550,8 +7637,8 @@ static void looping_rc_track_diag_left_bank_to_25_deg_up(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15491, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15491), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7583,8 +7670,8 @@ static void looping_rc_track_diag_right_bank_to_25_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15498, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15498), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7596,8 +7683,8 @@ static void looping_rc_track_diag_right_bank_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15495, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15495), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7609,11 +7696,11 @@ static void looping_rc_track_diag_right_bank_to_25_deg_up(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15497, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15497), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15499, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15499), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7629,8 +7716,8 @@ static void looping_rc_track_diag_right_bank_to_25_deg_up(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15496, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15496), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7662,8 +7749,8 @@ static void looping_rc_track_diag_25_deg_up_to_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15483, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15483), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7675,11 +7762,11 @@ static void looping_rc_track_diag_25_deg_up_to_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15480, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15480), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15484, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15484), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7691,8 +7778,8 @@ static void looping_rc_track_diag_25_deg_up_to_left_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15482, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15482), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7708,8 +7795,8 @@ static void looping_rc_track_diag_25_deg_up_to_left_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15481, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15481), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7741,8 +7828,8 @@ static void looping_rc_track_diag_25_deg_up_to_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15488, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15488), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7754,8 +7841,8 @@ static void looping_rc_track_diag_25_deg_up_to_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15485, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15485), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7767,11 +7854,11 @@ static void looping_rc_track_diag_25_deg_up_to_right_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15487, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15487), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15489, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15489), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7787,8 +7874,8 @@ static void looping_rc_track_diag_25_deg_up_to_right_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15486, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15486), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7820,8 +7907,8 @@ static void looping_rc_track_diag_left_bank_to_25_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15486, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15486), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7832,11 +7919,11 @@ static void looping_rc_track_diag_left_bank_to_25_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15487, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15487), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15489, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15489), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7847,8 +7934,8 @@ static void looping_rc_track_diag_left_bank_to_25_deg_down(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15485, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15485), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7863,8 +7950,8 @@ static void looping_rc_track_diag_left_bank_to_25_deg_down(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15488, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15488), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7897,8 +7984,8 @@ static void looping_rc_track_diag_right_bank_to_25_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15481, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15481), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7909,8 +7996,8 @@ static void looping_rc_track_diag_right_bank_to_25_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15482, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15482), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7921,11 +8008,11 @@ static void looping_rc_track_diag_right_bank_to_25_deg_down(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15480, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15480), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15484, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15484), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7940,8 +8027,8 @@ static void looping_rc_track_diag_right_bank_to_25_deg_down(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15483, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15483), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7974,8 +8061,8 @@ static void looping_rc_track_diag_25_deg_down_to_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15496, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15496), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7987,11 +8074,11 @@ static void looping_rc_track_diag_25_deg_down_to_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15497, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15497), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15499, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15499), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8003,8 +8090,8 @@ static void looping_rc_track_diag_25_deg_down_to_left_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15495, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15495), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8020,8 +8107,8 @@ static void looping_rc_track_diag_25_deg_down_to_left_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15498, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15498), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8053,8 +8140,8 @@ static void looping_rc_track_diag_25_deg_down_to_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15491, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15491), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8066,8 +8153,8 @@ static void looping_rc_track_diag_25_deg_down_to_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15492, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15492), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8079,11 +8166,11 @@ static void looping_rc_track_diag_25_deg_down_to_right_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15490, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15490), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15494, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15494), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8099,8 +8186,8 @@ static void looping_rc_track_diag_25_deg_down_to_right_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15493, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15493), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8132,8 +8219,8 @@ static void looping_rc_track_diag_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15479, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15479), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8145,8 +8232,8 @@ static void looping_rc_track_diag_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15476, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15476), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8158,8 +8245,8 @@ static void looping_rc_track_diag_left_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15478, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15478), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8175,8 +8262,8 @@ static void looping_rc_track_diag_left_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15477, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15477), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8208,8 +8295,8 @@ static void looping_rc_track_diag_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15477, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15477), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8221,8 +8308,8 @@ static void looping_rc_track_diag_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15478, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15478), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8234,8 +8321,8 @@ static void looping_rc_track_diag_right_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15476, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15476), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8251,8 +8338,8 @@ static void looping_rc_track_diag_right_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15479, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15479), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8282,19 +8369,19 @@ static void looping_rc_track_block_brakes(
         case 0:
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15012, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15012), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15014, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15014), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
         case 1:
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15013, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15013), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15015, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15015), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             break;
     }
@@ -8320,20 +8407,23 @@ static void looping_rc_track_left_banked_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15689, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15689), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15691, { 0, 6, height }, { 32, 1, 34 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15691), { 0, 6, height },
+                        { 32, 1, 34 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15693, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15693), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15687, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15687), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -8356,21 +8446,23 @@ static void looping_rc_track_left_banked_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15688, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15688), { 6, 0, height },
+                        { 20, 32, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15690, { 6, 0, height }, { 1, 32, 34 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15690), { 6, 0, height },
+                        { 1, 32, 34 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15692, { 6, 0, height }, { 1, 32, 34 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15692), { 6, 0, height },
+                        { 1, 32, 34 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15686, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15686), { 6, 0, height },
+                        { 20, 32, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -8402,20 +8494,23 @@ static void looping_rc_track_right_banked_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15678, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15678), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15680, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15680), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15682, { 0, 6, height }, { 32, 1, 34 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15682), { 0, 6, height },
+                        { 32, 1, 34 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15684, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15684), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -8438,27 +8533,29 @@ static void looping_rc_track_right_banked_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15679, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15679), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15681, { 6, 0, height }, { 1, 32, 34 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15681), { 6, 0, height },
+                        { 1, 32, 34 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15683, { 6, 0, height }, { 1, 32, 34 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15683), { 6, 0, height },
+                        { 1, 32, 34 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15685, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15685), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8511,23 +8608,23 @@ static void looping_rc_track_left_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15658, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15658), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15663, { 0, 0, height }, { 32, 1, 34 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15663), { 0, 0, height },
+                        { 32, 1, 34 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15668, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15668), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15673, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15673), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -8547,22 +8644,23 @@ static void looping_rc_track_left_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15659, { 0, 0, height }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15659), { 0, 0, height },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15664, { 0, 0, height }, { 1, 1, 34 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15664), { 0, 0, height }, { 1, 1, 34 },
                         { 30, 30, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15669, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15669), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15674, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15674), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8577,22 +8675,23 @@ static void looping_rc_track_left_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15660, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15660), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15665, { 0, 0, height }, { 1, 1, 34 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15665), { 0, 0, height }, { 1, 1, 34 },
                         { 30, 30, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15670, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15670), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15675, { 0, 0, height }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15675), { 0, 0, height },
+                        { 16, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8607,23 +8706,23 @@ static void looping_rc_track_left_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15661, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15661), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15666, { 0, 0, height }, { 1, 1, 34 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15666), { 0, 0, height }, { 1, 1, 34 },
                         { 30, 30, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15671, { 0, 0, height }, { 1, 32, 34 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15671), { 0, 0, height },
+                        { 1, 32, 34 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15676, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15676), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8638,23 +8737,23 @@ static void looping_rc_track_left_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15662, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15662), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15667, { 0, 0, height }, { 1, 32, 34 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15667), { 0, 0, height },
+                        { 1, 32, 34 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15672, { 0, 0, height }, { 1, 32, 34 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15672), { 0, 0, height },
+                        { 1, 32, 34 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15677, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15677), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -8686,23 +8785,23 @@ static void looping_rc_track_right_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15638, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15638), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15643, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15643), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15648, { 0, 0, height }, { 32, 1, 34 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15648), { 0, 0, height },
+                        { 32, 1, 34 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15653, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15653), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -8722,22 +8821,23 @@ static void looping_rc_track_right_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15639, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15639), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15644, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15644), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15649, { 0, 0, height }, { 1, 1, 34 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15649), { 0, 0, height }, { 1, 1, 34 },
                         { 30, 30, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15654, { 0, 0, height }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15654), { 0, 0, height },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8752,22 +8852,23 @@ static void looping_rc_track_right_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15640, { 0, 0, height }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15640), { 0, 0, height },
+                        { 16, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15645, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15645), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15650, { 0, 0, height }, { 1, 1, 34 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15650), { 0, 0, height }, { 1, 1, 34 },
                         { 30, 30, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15655, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15655), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8782,23 +8883,23 @@ static void looping_rc_track_right_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15641, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15641), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15646, { 0, 0, height }, { 1, 32, 34 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15646), { 0, 0, height },
+                        { 1, 32, 34 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15651, { 0, 0, height }, { 1, 1, 34 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15651), { 0, 0, height }, { 1, 1, 34 },
                         { 30, 30, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15656, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15656), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8813,23 +8914,23 @@ static void looping_rc_track_right_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15642, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15642), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15647, { 0, 0, height }, { 1, 32, 34 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15647), { 0, 0, height },
+                        { 1, 32, 34 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15652, { 0, 0, height }, { 1, 32, 34 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15652), { 0, 0, height },
+                        { 1, 32, 34 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15657, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15657), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -8878,25 +8979,25 @@ static void looping_rc_track_25_deg_up_to_left_banked_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15602, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15602), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15603, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15603), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15610, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15610), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15604, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15604), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15605, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15605), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -8926,25 +9027,25 @@ static void looping_rc_track_25_deg_up_to_right_banked_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15606, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15606), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15607, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15607), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15608, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15608), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15611, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15611), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15609, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15609), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -8974,25 +9075,25 @@ static void looping_rc_track_left_banked_25_deg_up_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15612, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15612), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15613, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15613), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15620, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15620), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15614, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15614), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15615, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15615), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -9022,25 +9123,25 @@ static void looping_rc_track_right_banked_25_deg_up_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15616, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15616), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15617, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15617), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15618, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15618), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15621, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15621), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15619, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15619), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -9106,22 +9207,22 @@ static void looping_rc_track_left_banked_flat_to_left_banked_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15622, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15622), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15623, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15623), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15624, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15624), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15625, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15625), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -9151,22 +9252,22 @@ static void looping_rc_track_right_banked_flat_to_right_banked_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15626, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15626), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15627, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15627), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15628, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15628), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15629, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15629), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -9196,22 +9297,22 @@ static void looping_rc_track_left_banked_25_deg_up_to_left_banked_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15630, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15630), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15631, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15631), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15632, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15632), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15633, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15633), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -9241,22 +9342,22 @@ static void looping_rc_track_right_banked_25_deg_up_to_right_banked_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15634, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15634), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15635, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15635), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15636, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15636), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15637, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15637), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -9322,25 +9423,25 @@ static void looping_rc_track_flat_to_left_banked_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15574, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15574), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15575, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15575), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15582, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15582), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15576, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15576), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15577, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15577), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -9370,25 +9471,25 @@ static void looping_rc_track_flat_to_right_banked_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15578, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15578), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15579, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15579), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15580, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15580), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15583, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15583), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15581, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15581), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -9418,25 +9519,25 @@ static void looping_rc_track_left_banked_25_deg_up_to_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15584, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15584), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15585, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15585), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15592, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15592), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15586, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15586), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15587, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15587), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -9466,25 +9567,25 @@ static void looping_rc_track_right_banked_25_deg_up_to_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15588, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15588), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15589, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15589), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15590, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15590), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15593, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15593), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 15591, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15591), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             break;
     }
@@ -9546,14 +9647,14 @@ static void looping_rc_track_booster(
         case 0:
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | SPR_LOOPING_RC_BOOSTER_NE_SW, { 0, 0, height },
-                { 32, 20, 3 }, { 0, 6, height });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(SPR_LOOPING_RC_BOOSTER_NE_SW),
+                { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
             break;
         case 1:
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | SPR_LOOPING_RC_BOOSTER_NW_SE, { 0, 0, height },
-                { 32, 20, 3 }, { 0, 6, height });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(SPR_LOOPING_RC_BOOSTER_NW_SE),
+                { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
             break;
     }
     if (track_paint_util_should_paint_supports(session.MapPosition))

--- a/src/openrct2/ride/coaster/MineRide.cpp
+++ b/src/openrct2/ride/coaster/MineRide.cpp
@@ -28,7 +28,7 @@ static void mine_ride_track_flat(
         case 0:
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19338, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19338), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -38,7 +38,7 @@ static void mine_ride_track_flat(
         case 1:
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19339, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19339), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -65,10 +65,11 @@ static void mine_ride_track_station(
     };
 
     PaintAddImageAsParentRotated(
-        session, direction, imageIds[direction][0] | session.TrackColours[SCHEME_TRACK], { 0, 0, height }, { 32, 20, 1 },
-        { 0, 6, height + 3 });
+        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]), { 0, 0, height },
+        { 32, 20, 1 }, { 0, 6, height + 3 });
     PaintAddImageAsParentRotated(
-        session, direction, imageIds[direction][1] | session.TrackColours[SCHEME_MISC], { 0, 0, height }, { 32, 32, 1 });
+        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][1]), { 0, 0, height },
+        { 32, 32, 1 });
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], 0);
     track_paint_util_draw_station_2(session, ride, direction, height, trackElement, 9, 11);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -85,7 +86,7 @@ static void mine_ride_track_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19388, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19388), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -95,7 +96,7 @@ static void mine_ride_track_25_deg_up(
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19389, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19389), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -105,7 +106,7 @@ static void mine_ride_track_25_deg_up(
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19390, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19390), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -115,7 +116,7 @@ static void mine_ride_track_25_deg_up(
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19391, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19391), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -146,7 +147,7 @@ static void mine_ride_track_flat_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19380, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19380), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -155,7 +156,7 @@ static void mine_ride_track_flat_to_25_deg_up(
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19381, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19381), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -165,7 +166,7 @@ static void mine_ride_track_flat_to_25_deg_up(
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19382, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19382), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -174,7 +175,7 @@ static void mine_ride_track_flat_to_25_deg_up(
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19383, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19383), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -205,7 +206,7 @@ static void mine_ride_track_25_deg_up_to_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19384, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19384), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -215,7 +216,7 @@ static void mine_ride_track_25_deg_up_to_flat(
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19385, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19385), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -225,7 +226,7 @@ static void mine_ride_track_25_deg_up_to_flat(
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19386, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19386), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -235,7 +236,7 @@ static void mine_ride_track_25_deg_up_to_flat(
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19387, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19387), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -293,29 +294,29 @@ static void mine_ride_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19427, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19427), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19432, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19432), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19437, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19437), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19422, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19422), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -336,23 +337,23 @@ static void mine_ride_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19426, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19426), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19431, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19431), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19436, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19436), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19421, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19421), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -367,23 +368,23 @@ static void mine_ride_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19425, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19425), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19430, { 0, 0, height }, { 16, 16, 3 },
-                        { 6, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19430), { 0, 0, height },
+                        { 16, 16, 3 }, { 6, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19435, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19435), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19420, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19420), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -398,23 +399,23 @@ static void mine_ride_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19424, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19424), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19429, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19429), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19434, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19434), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19419, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19419), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -429,29 +430,29 @@ static void mine_ride_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19423, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19423), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19428, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19428), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19433, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19433), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19418, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19418), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -490,10 +491,10 @@ static void mine_ride_track_flat_to_left_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19340, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19340), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19348, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19348), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -502,10 +503,10 @@ static void mine_ride_track_flat_to_left_bank(
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19341, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19341), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19349, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19349), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -515,7 +516,7 @@ static void mine_ride_track_flat_to_left_bank(
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19342, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19342), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -524,7 +525,7 @@ static void mine_ride_track_flat_to_left_bank(
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19343, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19343), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -548,7 +549,7 @@ static void mine_ride_track_flat_to_right_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19344, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19344), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -557,7 +558,7 @@ static void mine_ride_track_flat_to_right_bank(
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19345, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19345), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -567,10 +568,10 @@ static void mine_ride_track_flat_to_right_bank(
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19346, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19346), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19350, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19350), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -579,10 +580,10 @@ static void mine_ride_track_flat_to_right_bank(
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19347, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19347), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19351, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19351), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -606,10 +607,10 @@ static void mine_ride_track_left_bank_to_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19346, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19346), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19350, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19350), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -618,10 +619,10 @@ static void mine_ride_track_left_bank_to_flat(
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19347, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19347), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19351, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19351), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -631,7 +632,7 @@ static void mine_ride_track_left_bank_to_flat(
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19344, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19344), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -640,7 +641,7 @@ static void mine_ride_track_left_bank_to_flat(
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19345, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19345), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -664,7 +665,7 @@ static void mine_ride_track_right_bank_to_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19342, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19342), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -673,7 +674,7 @@ static void mine_ride_track_right_bank_to_flat(
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19343, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19343), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -683,10 +684,10 @@ static void mine_ride_track_right_bank_to_flat(
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19340, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19340), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19348, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19348), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -695,10 +696,10 @@ static void mine_ride_track_right_bank_to_flat(
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19341, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19341), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19349, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19349), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -725,32 +726,32 @@ static void mine_ride_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19447, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19447), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19458, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19458), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19452, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19452), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19457, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19457), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19442, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19442), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -771,23 +772,23 @@ static void mine_ride_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19446, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19446), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19451, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19451), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19456, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19456), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19441, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19441), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -802,23 +803,23 @@ static void mine_ride_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19445, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19445), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19450, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19450), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19455, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19455), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19440, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19440), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -833,23 +834,23 @@ static void mine_ride_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19444, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19444), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19449, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19449), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19454, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19454), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19439, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19439), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -864,32 +865,32 @@ static void mine_ride_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19443, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19443), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19448, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19448), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19453, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19453), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19459, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19459), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19438, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19438), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -928,10 +929,10 @@ static void mine_ride_track_left_bank_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19352, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19352), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19356, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19356), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -940,10 +941,10 @@ static void mine_ride_track_left_bank_to_25_deg_up(
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19353, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19353), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19357, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19357), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -953,7 +954,7 @@ static void mine_ride_track_left_bank_to_25_deg_up(
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19354, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19354), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -962,7 +963,7 @@ static void mine_ride_track_left_bank_to_25_deg_up(
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19355, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19355), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -993,7 +994,7 @@ static void mine_ride_track_right_bank_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19358, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19358), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1002,7 +1003,7 @@ static void mine_ride_track_right_bank_to_25_deg_up(
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19359, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19359), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1012,10 +1013,10 @@ static void mine_ride_track_right_bank_to_25_deg_up(
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19360, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19360), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19362, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19362), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1024,10 +1025,10 @@ static void mine_ride_track_right_bank_to_25_deg_up(
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19361, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19361), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19363, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19363), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1058,10 +1059,10 @@ static void mine_ride_track_25_deg_up_to_left_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19364, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19364), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19368, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19368), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1071,10 +1072,10 @@ static void mine_ride_track_25_deg_up_to_left_bank(
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19365, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19365), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19369, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19369), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1084,7 +1085,7 @@ static void mine_ride_track_25_deg_up_to_left_bank(
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19366, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19366), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1094,7 +1095,7 @@ static void mine_ride_track_25_deg_up_to_left_bank(
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19367, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19367), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1125,7 +1126,7 @@ static void mine_ride_track_25_deg_up_to_right_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19370, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19370), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1135,7 +1136,7 @@ static void mine_ride_track_25_deg_up_to_right_bank(
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19371, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19371), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1145,10 +1146,10 @@ static void mine_ride_track_25_deg_up_to_right_bank(
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19372, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19372), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19374, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19374), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1158,10 +1159,10 @@ static void mine_ride_track_25_deg_up_to_right_bank(
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19373, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19373), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19375, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19375), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1224,7 +1225,7 @@ static void mine_ride_track_left_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19376, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19376), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1233,7 +1234,7 @@ static void mine_ride_track_left_bank(
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19377, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19377), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1243,7 +1244,7 @@ static void mine_ride_track_left_bank(
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19378, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19378), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1252,7 +1253,7 @@ static void mine_ride_track_left_bank(
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19379, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19379), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1287,29 +1288,29 @@ static void mine_ride_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19460, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19460), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19464, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19464), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19463, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19463), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19467, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19467), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -1327,25 +1328,27 @@ static void mine_ride_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19461, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19461), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 5, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19465, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19465), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 6, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19462, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19462), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19466, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19466), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1360,23 +1363,25 @@ static void mine_ride_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19462, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19462), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19466, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19466), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19461, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19461), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 5, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19465, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19465), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 6, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -1393,29 +1398,29 @@ static void mine_ride_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19463, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19463), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19467, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19467), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19460, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19460), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19464, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19464), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -1448,29 +1453,29 @@ static void mine_ride_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19468, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19468), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19472, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19472), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19471, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19471), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19475, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19475), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -1488,25 +1493,27 @@ static void mine_ride_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19469, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19469), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 8, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19473, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19473), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 7, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19470, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19470), { 0, 0, height },
+                        { 32, 26, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19474, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19474), { 0, 0, height },
+                        { 32, 26, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1521,23 +1528,25 @@ static void mine_ride_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19470, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19470), { 0, 0, height },
+                        { 32, 26, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19474, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19474), { 0, 0, height },
+                        { 32, 26, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19469, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19469), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 8, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19473, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19473), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 7, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -1554,29 +1563,29 @@ static void mine_ride_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19471, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19471), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19475, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19475), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19468, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19468), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19472, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19472), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -1609,29 +1618,29 @@ static void mine_ride_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19397, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19397), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19400, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19400), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19403, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19403), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19394, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19394), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -1652,23 +1661,23 @@ static void mine_ride_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19396, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19396), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19399, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19399), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19402, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19402), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19393, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19393), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1680,29 +1689,29 @@ static void mine_ride_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19395, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19395), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19398, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19398), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19401, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19401), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19392, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19392), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -1744,32 +1753,32 @@ static void mine_ride_track_left_quarter_turn_3_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19409, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19409), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19416, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19416), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19412, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19412), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19415, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19415), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19406, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19406), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -1790,23 +1799,23 @@ static void mine_ride_track_left_quarter_turn_3_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19408, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19408), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19411, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19411), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19414, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19414), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19405, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19405), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1818,32 +1827,32 @@ static void mine_ride_track_left_quarter_turn_3_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19407, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19407), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19410, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19410), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19413, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19413), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19417, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19417), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19404, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19404), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -1885,32 +1894,32 @@ static void mine_ride_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19495, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19495), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19502, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19502), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19498, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19498), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19501, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19501), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19492, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19492), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -1932,23 +1941,23 @@ static void mine_ride_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19494, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19494), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19497, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19497), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19500, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19500), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19491, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19491), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1960,32 +1969,32 @@ static void mine_ride_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19493, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19493), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19496, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19496), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19499, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19499), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19503, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19503), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 15, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19490, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19490), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 8 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2009,32 +2018,32 @@ static void mine_ride_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19492, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19492), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19495, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19495), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19502, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19502), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19498, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19498), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19501, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19501), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2061,23 +2070,23 @@ static void mine_ride_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19491, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19491), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19494, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19494), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19497, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19497), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19500, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19500), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2089,32 +2098,32 @@ static void mine_ride_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19490, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19490), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19493, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19493), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19496, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19496), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19499, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19499), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19503, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19503), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 15, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2143,32 +2152,32 @@ static void mine_ride_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19476, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19476), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19479, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19479), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19482, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19482), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19485, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19485), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19489, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19489), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2190,23 +2199,23 @@ static void mine_ride_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19477, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19477), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19480, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19480), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19483, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19483), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19486, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19486), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2218,32 +2227,32 @@ static void mine_ride_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19478, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19478), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 8 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19481, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19481), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19488, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19488), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 15, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19484, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19484), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19487, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19487), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2267,32 +2276,32 @@ static void mine_ride_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19479, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19479), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19482, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19482), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19485, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19485), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19489, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19489), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19476, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19476), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2319,23 +2328,23 @@ static void mine_ride_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19480, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19480), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19483, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19483), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19486, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19486), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19477, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19477), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2347,32 +2356,32 @@ static void mine_ride_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19481, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19481), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19488, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19488), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 15, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19484, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19484), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19487, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19487), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19478, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19478), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2429,32 +2438,32 @@ static void mine_ride_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19535, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19535), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19546, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19546), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19540, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19540), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19545, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19545), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19530, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19530), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2476,23 +2485,23 @@ static void mine_ride_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19534, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19534), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19539, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19539), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19544, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19544), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19529, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19529), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2507,23 +2516,23 @@ static void mine_ride_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19533, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19533), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19538, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19538), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19543, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19543), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19528, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19528), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2538,23 +2547,23 @@ static void mine_ride_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19532, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19532), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19537, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19537), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19542, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19542), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19527, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19527), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2569,32 +2578,32 @@ static void mine_ride_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19531, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19531), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 13, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19536, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19536), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 13, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19541, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19541), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19547, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19547), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 13, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19526, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19526), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 8 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 13, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2618,32 +2627,32 @@ static void mine_ride_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19530, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19530), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19535, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19535), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19546, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19546), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19540, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19540), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19545, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19545), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2670,23 +2679,23 @@ static void mine_ride_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19529, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19529), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19534, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19534), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19539, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19539), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19544, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19544), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2701,23 +2710,23 @@ static void mine_ride_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19528, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19528), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19533, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19533), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19538, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19538), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19543, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19543), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2732,23 +2741,23 @@ static void mine_ride_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19527, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19527), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19532, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19532), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19537, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19537), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19542, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19542), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2763,32 +2772,32 @@ static void mine_ride_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19526, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19526), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 13, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19531, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19531), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 13, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19536, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19536), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 13, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19541, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19541), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19547, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19547), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 13, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2817,32 +2826,32 @@ static void mine_ride_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19504, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19504), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19509, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19509), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19514, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19514), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19519, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19519), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19525, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19525), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2864,23 +2873,23 @@ static void mine_ride_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19505, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19505), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19510, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19510), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19515, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19515), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19520, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19520), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2895,23 +2904,23 @@ static void mine_ride_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19506, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19506), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19511, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19511), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19516, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19516), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19521, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19521), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2926,23 +2935,23 @@ static void mine_ride_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19507, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19507), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19512, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19512), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19517, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19517), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19522, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19522), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2957,32 +2966,32 @@ static void mine_ride_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19508, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19508), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 8 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 13, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19513, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19513), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19524, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19524), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 13, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19518, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19518), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 13, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19523, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19523), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 13, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3006,32 +3015,32 @@ static void mine_ride_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19509, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19509), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19514, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19514), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19519, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19519), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19525, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19525), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19504, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19504), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3058,23 +3067,23 @@ static void mine_ride_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19510, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19510), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19515, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19515), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19520, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19520), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19505, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19505), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3089,23 +3098,23 @@ static void mine_ride_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19511, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19511), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19516, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19516), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19521, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19521), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19506, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19506), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3120,23 +3129,23 @@ static void mine_ride_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19512, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19512), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19517, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19517), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19522, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19522), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19507, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19507), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3151,32 +3160,32 @@ static void mine_ride_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19513, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19513), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19524, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19524), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 13, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19518, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19518), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 13, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19523, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19523), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 13, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19508, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19508), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 13, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3230,38 +3239,38 @@ static void mine_ride_track_on_ride_photo(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_FORK, 5, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_FORK, 8, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19338, { 0, 0, height }, { 32, 20, 0 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19338), { 0, 0, height }, { 32, 20, 0 },
                 { 0, 6, height + 3 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_FORK_ALT, 6, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_FORK_ALT, 7, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19339, { 0, 0, height }, { 32, 20, 0 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19339), { 0, 0, height }, { 32, 20, 0 },
                 { 0, 6, height + 3 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_FORK, 5, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_FORK, 8, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19338, { 0, 0, height }, { 32, 20, 0 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19338), { 0, 0, height }, { 32, 20, 0 },
                 { 0, 6, height + 3 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_FORK_ALT, 6, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_FORK_ALT, 7, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19339, { 0, 0, height }, { 32, 20, 0 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19339), { 0, 0, height }, { 32, 20, 0 },
                 { 0, 6, height + 3 });
             break;
     }
@@ -3283,29 +3292,29 @@ static void mine_ride_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19564, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19564), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19568, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19568), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19572, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19572), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19576, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19576), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3323,23 +3332,23 @@ static void mine_ride_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19565, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19565), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19569, { 0, 0, height }, { 34, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19569), { 0, 0, height },
+                        { 34, 16, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19573, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19573), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19577, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19577), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3354,23 +3363,23 @@ static void mine_ride_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19566, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19566), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19570, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19570), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19574, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19574), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19578, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19578), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3388,29 +3397,29 @@ static void mine_ride_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19567, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19567), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 3, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19571, { 0, 0, height }, { 16, 18, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19571), { 0, 0, height },
+                        { 16, 18, 3 }, { 0, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 1, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19575, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19575), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19579, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19579), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 2, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3437,29 +3446,29 @@ static void mine_ride_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19548, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19548), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19552, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19552), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19556, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19556), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19560, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19560), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3477,23 +3486,23 @@ static void mine_ride_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19549, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19549), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19553, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19553), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19557, { 0, 0, height }, { 34, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19557), { 0, 0, height },
+                        { 34, 16, 3 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19561, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19561), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3508,23 +3517,23 @@ static void mine_ride_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19550, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19550), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19554, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19554), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19558, { 0, 0, height }, { 28, 28, 3 },
-                        { 4, 4, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19558), { 0, 0, height },
+                        { 28, 28, 3 }, { 4, 4, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19562, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19562), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3542,29 +3551,29 @@ static void mine_ride_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19551, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19551), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 1, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19555, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19555), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19559, { 0, 0, height }, { 16, 18, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19559), { 0, 0, height },
+                        { 16, 18, 3 }, { 0, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 2, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19563, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19563), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 3, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3609,29 +3618,29 @@ static void mine_ride_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19596, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19596), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19600, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19600), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19604, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19604), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19608, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19608), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3649,23 +3658,23 @@ static void mine_ride_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19597, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19597), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19601, { 0, 0, height }, { 34, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19601), { 0, 0, height },
+                        { 34, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19605, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19605), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19609, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19609), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3680,23 +3689,23 @@ static void mine_ride_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19598, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19598), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19602, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19602), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19606, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19606), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19610, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19610), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3714,29 +3723,29 @@ static void mine_ride_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19599, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19599), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 3, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19603, { 0, 0, height }, { 16, 18, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19603), { 0, 0, height },
+                        { 16, 18, 0 }, { 0, 16, height + 27 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 1, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19607, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19607), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19611, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19611), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 2, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3763,29 +3772,29 @@ static void mine_ride_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19580, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19580), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19584, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19584), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19588, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19588), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19592, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19592), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3803,23 +3812,23 @@ static void mine_ride_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19581, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19581), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19585, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19585), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19589, { 0, 0, height }, { 34, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19589), { 0, 0, height },
+                        { 34, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19593, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19593), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3834,23 +3843,23 @@ static void mine_ride_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19582, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19582), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19586, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19586), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19590, { 0, 0, height }, { 28, 28, 0 },
-                        { 4, 4, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19590), { 0, 0, height },
+                        { 28, 28, 0 }, { 4, 4, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19594, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19594), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3868,29 +3877,29 @@ static void mine_ride_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19583, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19583), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 1, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19587, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19587), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19591, { 0, 0, height }, { 16, 18, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19591), { 0, 0, height },
+                        { 16, 18, 0 }, { 0, 16, height + 27 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 2, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19595, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19595), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 3, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3935,8 +3944,8 @@ static void mine_ride_track_diag_flat(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19615, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19615), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3948,8 +3957,8 @@ static void mine_ride_track_diag_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19612, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19612), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3961,8 +3970,8 @@ static void mine_ride_track_diag_flat(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19614, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19614), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3978,8 +3987,8 @@ static void mine_ride_track_diag_flat(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19613, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19613), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -4011,8 +4020,8 @@ static void mine_ride_track_diag_25_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19627, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19627), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4024,8 +4033,8 @@ static void mine_ride_track_diag_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19624, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19624), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4037,8 +4046,8 @@ static void mine_ride_track_diag_25_deg_up(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19626, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19626), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4054,8 +4063,8 @@ static void mine_ride_track_diag_25_deg_up(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19625, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19625), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -4087,8 +4096,8 @@ static void mine_ride_track_diag_flat_to_25_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19619, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19619), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4100,8 +4109,8 @@ static void mine_ride_track_diag_flat_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19616, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19616), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4113,8 +4122,8 @@ static void mine_ride_track_diag_flat_to_25_deg_up(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19618, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19618), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4130,8 +4139,8 @@ static void mine_ride_track_diag_flat_to_25_deg_up(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19617, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19617), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -4163,8 +4172,8 @@ static void mine_ride_track_diag_25_deg_up_to_flat(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19623, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19623), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4176,8 +4185,8 @@ static void mine_ride_track_diag_25_deg_up_to_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19620, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19620), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4189,8 +4198,8 @@ static void mine_ride_track_diag_25_deg_up_to_flat(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19622, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19622), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4206,8 +4215,8 @@ static void mine_ride_track_diag_25_deg_up_to_flat(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19621, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19621), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -4239,8 +4248,8 @@ static void mine_ride_track_diag_25_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19625, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19625), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4252,8 +4261,8 @@ static void mine_ride_track_diag_25_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19626, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19626), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4265,8 +4274,8 @@ static void mine_ride_track_diag_25_deg_down(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19624, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19624), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4282,8 +4291,8 @@ static void mine_ride_track_diag_25_deg_down(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19627, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19627), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -4315,8 +4324,8 @@ static void mine_ride_track_diag_flat_to_25_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19621, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19621), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4327,8 +4336,8 @@ static void mine_ride_track_diag_flat_to_25_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19622, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19622), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4339,8 +4348,8 @@ static void mine_ride_track_diag_flat_to_25_deg_down(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19620, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19620), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4355,8 +4364,8 @@ static void mine_ride_track_diag_flat_to_25_deg_down(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19623, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19623), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -4389,8 +4398,8 @@ static void mine_ride_track_diag_25_deg_down_to_flat(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19617, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19617), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4402,8 +4411,8 @@ static void mine_ride_track_diag_25_deg_down_to_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19618, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19618), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4415,8 +4424,8 @@ static void mine_ride_track_diag_25_deg_down_to_flat(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19616, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19616), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4432,8 +4441,8 @@ static void mine_ride_track_diag_25_deg_down_to_flat(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19619, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19619), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -4465,8 +4474,8 @@ static void mine_ride_track_diag_flat_to_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19635, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19635), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4478,11 +4487,11 @@ static void mine_ride_track_diag_flat_to_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19632, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19632), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19636, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19636), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4494,8 +4503,8 @@ static void mine_ride_track_diag_flat_to_left_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19634, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19634), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4511,8 +4520,8 @@ static void mine_ride_track_diag_flat_to_left_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19633, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19633), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -4544,8 +4553,8 @@ static void mine_ride_track_diag_flat_to_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19640, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19640), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4557,8 +4566,8 @@ static void mine_ride_track_diag_flat_to_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19637, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19637), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4570,11 +4579,11 @@ static void mine_ride_track_diag_flat_to_right_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19639, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19639), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19641, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19641), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4590,8 +4599,8 @@ static void mine_ride_track_diag_flat_to_right_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19638, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19638), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -4623,8 +4632,8 @@ static void mine_ride_track_diag_left_bank_to_flat(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19638, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19638), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4636,11 +4645,11 @@ static void mine_ride_track_diag_left_bank_to_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19639, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19639), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19641, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19641), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4652,8 +4661,8 @@ static void mine_ride_track_diag_left_bank_to_flat(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19637, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19637), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4669,8 +4678,8 @@ static void mine_ride_track_diag_left_bank_to_flat(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19640, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19640), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -4702,8 +4711,8 @@ static void mine_ride_track_diag_right_bank_to_flat(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19633, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19633), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4715,8 +4724,8 @@ static void mine_ride_track_diag_right_bank_to_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19634, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19634), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4728,11 +4737,11 @@ static void mine_ride_track_diag_right_bank_to_flat(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19632, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19632), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19636, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19636), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4748,8 +4757,8 @@ static void mine_ride_track_diag_right_bank_to_flat(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19635, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19635), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -4781,8 +4790,8 @@ static void mine_ride_track_diag_left_bank_to_25_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19655, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19655), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4794,11 +4803,11 @@ static void mine_ride_track_diag_left_bank_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19652, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19652), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19656, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19656), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4810,8 +4819,8 @@ static void mine_ride_track_diag_left_bank_to_25_deg_up(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19654, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19654), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4827,8 +4836,8 @@ static void mine_ride_track_diag_left_bank_to_25_deg_up(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19653, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19653), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -4860,8 +4869,8 @@ static void mine_ride_track_diag_right_bank_to_25_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19660, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19660), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4873,8 +4882,8 @@ static void mine_ride_track_diag_right_bank_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19657, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19657), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4886,11 +4895,11 @@ static void mine_ride_track_diag_right_bank_to_25_deg_up(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19659, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19659), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19661, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19661), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4906,8 +4915,8 @@ static void mine_ride_track_diag_right_bank_to_25_deg_up(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19658, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19658), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -4939,8 +4948,8 @@ static void mine_ride_track_diag_25_deg_up_to_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19645, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19645), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4952,11 +4961,11 @@ static void mine_ride_track_diag_25_deg_up_to_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19642, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19642), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19646, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19646), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4968,8 +4977,8 @@ static void mine_ride_track_diag_25_deg_up_to_left_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19644, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19644), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4985,8 +4994,8 @@ static void mine_ride_track_diag_25_deg_up_to_left_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19643, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19643), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -5018,8 +5027,8 @@ static void mine_ride_track_diag_25_deg_up_to_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19650, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19650), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5031,8 +5040,8 @@ static void mine_ride_track_diag_25_deg_up_to_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19647, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19647), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5044,11 +5053,11 @@ static void mine_ride_track_diag_25_deg_up_to_right_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19649, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19649), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19651, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19651), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5064,8 +5073,8 @@ static void mine_ride_track_diag_25_deg_up_to_right_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19648, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19648), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -5097,8 +5106,8 @@ static void mine_ride_track_diag_left_bank_to_25_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19648, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19648), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5109,11 +5118,11 @@ static void mine_ride_track_diag_left_bank_to_25_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19649, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19649), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19651, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19651), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5124,8 +5133,8 @@ static void mine_ride_track_diag_left_bank_to_25_deg_down(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19647, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19647), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5140,8 +5149,8 @@ static void mine_ride_track_diag_left_bank_to_25_deg_down(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19650, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19650), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -5174,8 +5183,8 @@ static void mine_ride_track_diag_right_bank_to_25_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19643, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19643), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5186,8 +5195,8 @@ static void mine_ride_track_diag_right_bank_to_25_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19644, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19644), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5198,11 +5207,11 @@ static void mine_ride_track_diag_right_bank_to_25_deg_down(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19642, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19642), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19646, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19646), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5217,8 +5226,8 @@ static void mine_ride_track_diag_right_bank_to_25_deg_down(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19645, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19645), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -5251,8 +5260,8 @@ static void mine_ride_track_diag_25_deg_down_to_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19658, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19658), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5264,11 +5273,11 @@ static void mine_ride_track_diag_25_deg_down_to_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19659, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19659), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19661, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19661), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5280,8 +5289,8 @@ static void mine_ride_track_diag_25_deg_down_to_left_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19657, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19657), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5297,8 +5306,8 @@ static void mine_ride_track_diag_25_deg_down_to_left_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19660, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19660), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -5330,8 +5339,8 @@ static void mine_ride_track_diag_25_deg_down_to_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19653, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19653), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5343,8 +5352,8 @@ static void mine_ride_track_diag_25_deg_down_to_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19654, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19654), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5356,11 +5365,11 @@ static void mine_ride_track_diag_25_deg_down_to_right_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19652, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19652), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19656, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19656), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5376,8 +5385,8 @@ static void mine_ride_track_diag_25_deg_down_to_right_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19655, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19655), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -5409,8 +5418,8 @@ static void mine_ride_track_diag_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19631, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19631), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5422,8 +5431,8 @@ static void mine_ride_track_diag_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19628, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19628), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5435,8 +5444,8 @@ static void mine_ride_track_diag_left_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19630, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19630), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5452,8 +5461,8 @@ static void mine_ride_track_diag_left_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19629, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19629), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -5485,8 +5494,8 @@ static void mine_ride_track_diag_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19629, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19629), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5498,8 +5507,8 @@ static void mine_ride_track_diag_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19630, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19630), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5511,8 +5520,8 @@ static void mine_ride_track_diag_right_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19628, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19628), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5528,8 +5537,8 @@ static void mine_ride_track_diag_right_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19631, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19631), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;

--- a/src/openrct2/ride/coaster/MineTrainCoaster.cpp
+++ b/src/openrct2/ride/coaster/MineTrainCoaster.cpp
@@ -41,25 +41,25 @@ static void mine_train_rc_track_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 20054, { 0, 0, height }, { 32, 20, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20054), { 0, 0, height }, { 32, 20, 1 },
                     { 0, 6, height });
                 wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 20055, { 0, 0, height }, { 32, 20, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20055), { 0, 0, height }, { 32, 20, 1 },
                     { 0, 6, height });
                 wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 20056, { 0, 0, height }, { 32, 20, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20056), { 0, 0, height }, { 32, 20, 1 },
                     { 0, 6, height });
                 wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 20057, { 0, 0, height }, { 32, 20, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20057), { 0, 0, height }, { 32, 20, 1 },
                     { 0, 6, height });
                 wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -72,14 +72,14 @@ static void mine_train_rc_track_flat(
             case 0:
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 20052, { 0, 0, height }, { 32, 20, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20052), { 0, 0, height }, { 32, 20, 1 },
                     { 0, 6, height });
                 wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 20053, { 0, 0, height }, { 32, 20, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20053), { 0, 0, height }, { 32, 20, 1 },
                     { 0, 6, height });
                 wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -103,20 +103,20 @@ static void mine_train_rc_track_station(
     };
 
     PaintAddImageAsParentRotated(
-        session, direction, imageIds[direction][1] | session.TrackColours[SCHEME_MISC], { 0, 0, height - 2 }, { 32, 28, 1 },
-        { 0, 2, height });
+        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][1]), { 0, 0, height - 2 },
+        { 32, 28, 1 }, { 0, 2, height });
     if (trackElement.GetTrackType() == TrackElemType::EndStation)
     {
         bool isClosed = trackElement.BlockBrakeClosed();
         PaintAddImageAsChildRotated(
-            session, direction, _MineTrainBlockBrakeImages[direction][isClosed] | session.TrackColours[SCHEME_TRACK],
+            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(_MineTrainBlockBrakeImages[direction][isClosed]),
             { 0, 0, height }, { 32, 20, 1 }, { 0, 0, height });
     }
     else
     {
         PaintAddImageAsChildRotated(
-            session, direction, imageIds[direction][0] | session.TrackColours[SCHEME_TRACK], { 0, 0, height }, { 32, 20, 1 },
-            { 0, 0, height });
+            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]), { 0, 0, height },
+            { 32, 20, 1 }, { 0, 0, height });
     }
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], 3);
     track_paint_util_draw_station(session, ride, direction, height, trackElement);
@@ -136,25 +136,25 @@ static void mine_train_rc_track_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 20102, { 0, 0, height }, { 32, 20, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20102), { 0, 0, height }, { 32, 20, 1 },
                     { 0, 6, height });
                 wooden_a_supports_paint_setup(session, 6, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 20103, { 0, 0, height }, { 32, 20, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20103), { 0, 0, height }, { 32, 20, 1 },
                     { 0, 6, height });
                 wooden_a_supports_paint_setup(session, 7, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 20104, { 0, 0, height }, { 32, 20, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20104), { 0, 0, height }, { 32, 20, 1 },
                     { 0, 6, height });
                 wooden_a_supports_paint_setup(session, 6, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 20105, { 0, 0, height }, { 32, 20, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20105), { 0, 0, height }, { 32, 20, 1 },
                     { 0, 6, height });
                 wooden_a_supports_paint_setup(session, 7, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -166,25 +166,25 @@ static void mine_train_rc_track_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 20074, { 0, 0, height }, { 32, 20, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20074), { 0, 0, height }, { 32, 20, 1 },
                     { 0, 6, height });
                 wooden_a_supports_paint_setup(session, 6, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 20075, { 0, 0, height }, { 32, 20, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20075), { 0, 0, height }, { 32, 20, 1 },
                     { 0, 6, height });
                 wooden_a_supports_paint_setup(session, 7, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 20076, { 0, 0, height }, { 32, 20, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20076), { 0, 0, height }, { 32, 20, 1 },
                     { 0, 6, height });
                 wooden_a_supports_paint_setup(session, 6, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 20077, { 0, 0, height }, { 32, 20, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20077), { 0, 0, height }, { 32, 20, 1 },
                     { 0, 6, height });
                 wooden_a_supports_paint_setup(session, 7, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -211,25 +211,25 @@ static void mine_train_rc_track_60_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20090, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20090), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             wooden_a_supports_paint_setup(session, 6, 21, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20091, { 0, 0, height }, { 1, 32, 98 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20091), { 0, 0, height }, { 1, 32, 98 },
                 { 27, 0, height });
             wooden_a_supports_paint_setup(session, 7, 22, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20092, { 0, 0, height }, { 1, 32, 98 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20092), { 0, 0, height }, { 1, 32, 98 },
                 { 27, 0, height });
             wooden_a_supports_paint_setup(session, 6, 23, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20093, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20093), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             wooden_a_supports_paint_setup(session, 7, 24, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -257,25 +257,25 @@ static void mine_train_rc_track_flat_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 20094, { 0, 0, height }, { 32, 20, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20094), { 0, 0, height }, { 32, 20, 1 },
                     { 0, 6, height });
                 wooden_a_supports_paint_setup(session, 6, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 20095, { 0, 0, height }, { 32, 20, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20095), { 0, 0, height }, { 32, 20, 1 },
                     { 0, 6, height });
                 wooden_a_supports_paint_setup(session, 7, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 20096, { 0, 0, height }, { 32, 20, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20096), { 0, 0, height }, { 32, 20, 1 },
                     { 0, 6, height });
                 wooden_a_supports_paint_setup(session, 6, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 20097, { 0, 0, height }, { 32, 20, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20097), { 0, 0, height }, { 32, 20, 1 },
                     { 0, 6, height });
                 wooden_a_supports_paint_setup(session, 7, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -287,25 +287,25 @@ static void mine_train_rc_track_flat_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 20066, { 0, 0, height }, { 32, 20, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20066), { 0, 0, height }, { 32, 20, 1 },
                     { 0, 6, height });
                 wooden_a_supports_paint_setup(session, 6, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 20067, { 0, 0, height }, { 32, 20, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20067), { 0, 0, height }, { 32, 20, 1 },
                     { 0, 6, height });
                 wooden_a_supports_paint_setup(session, 7, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 20068, { 0, 0, height }, { 32, 20, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20068), { 0, 0, height }, { 32, 20, 1 },
                     { 0, 6, height });
                 wooden_a_supports_paint_setup(session, 6, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 20069, { 0, 0, height }, { 32, 20, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20069), { 0, 0, height }, { 32, 20, 1 },
                     { 0, 6, height });
                 wooden_a_supports_paint_setup(session, 7, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -332,31 +332,31 @@ static void mine_train_rc_track_25_deg_up_to_60_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20078, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20078), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             wooden_a_supports_paint_setup(session, 6, 13, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20079, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20079), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20082, { 0, 0, height }, { 32, 1, 66 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20082), { 0, 0, height }, { 32, 1, 66 },
                 { 0, 27, height });
             wooden_a_supports_paint_setup(session, 7, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20080, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20080), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20083, { 0, 0, height }, { 32, 1, 66 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20083), { 0, 0, height }, { 32, 1, 66 },
                 { 0, 27, height });
             wooden_a_supports_paint_setup(session, 6, 15, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20081, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20081), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             wooden_a_supports_paint_setup(session, 7, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -382,31 +382,31 @@ static void mine_train_rc_track_60_deg_up_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20084, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20084), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             wooden_a_supports_paint_setup(session, 6, 17, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20085, { 0, 0, height }, { 24, 1, 61 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20085), { 0, 0, height }, { 24, 1, 61 },
                 { 4, 29, height - 16 });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20088, { 0, 0, height }, { 32, 2, 66 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20088), { 0, 0, height }, { 32, 2, 66 },
                 { 0, 4, height });
             wooden_a_supports_paint_setup(session, 7, 18, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20086, { 0, 0, height }, { 24, 1, 61 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20086), { 0, 0, height }, { 24, 1, 61 },
                 { 4, 29, height - 16 });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20089, { 0, 0, height }, { 32, 2, 66 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20089), { 0, 0, height }, { 32, 2, 66 },
                 { 0, 4, height });
             wooden_a_supports_paint_setup(session, 6, 19, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20087, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20087), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             wooden_a_supports_paint_setup(session, 7, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -434,25 +434,25 @@ static void mine_train_rc_track_25_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 20098, { 0, 0, height }, { 32, 20, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20098), { 0, 0, height }, { 32, 20, 1 },
                     { 0, 6, height });
                 wooden_a_supports_paint_setup(session, 6, 5, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 20099, { 0, 0, height }, { 32, 20, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20099), { 0, 0, height }, { 32, 20, 1 },
                     { 0, 6, height });
                 wooden_a_supports_paint_setup(session, 7, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 20100, { 0, 0, height }, { 32, 20, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20100), { 0, 0, height }, { 32, 20, 1 },
                     { 0, 6, height });
                 wooden_a_supports_paint_setup(session, 6, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 20101, { 0, 0, height }, { 32, 20, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20101), { 0, 0, height }, { 32, 20, 1 },
                     { 0, 6, height });
                 wooden_a_supports_paint_setup(session, 7, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -464,25 +464,25 @@ static void mine_train_rc_track_25_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 20070, { 0, 0, height }, { 32, 20, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20070), { 0, 0, height }, { 32, 20, 1 },
                     { 0, 6, height });
                 wooden_a_supports_paint_setup(session, 6, 5, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 20071, { 0, 0, height }, { 32, 20, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20071), { 0, 0, height }, { 32, 20, 1 },
                     { 0, 6, height });
                 wooden_a_supports_paint_setup(session, 7, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 20072, { 0, 0, height }, { 32, 20, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20072), { 0, 0, height }, { 32, 20, 1 },
                     { 0, 6, height });
                 wooden_a_supports_paint_setup(session, 6, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 20073, { 0, 0, height }, { 32, 20, 1 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20073), { 0, 0, height }, { 32, 20, 1 },
                     { 0, 6, height });
                 wooden_a_supports_paint_setup(session, 7, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -560,26 +560,26 @@ static void mine_train_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20155, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20155), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20160, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20160), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20165, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20165), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20150, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20150), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -600,24 +600,26 @@ static void mine_train_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20154, { 0, 0, height }, { 32, 16, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20154), { 0, 0, height },
+                        { 32, 16, 1 });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20159, { 0, 0, height }, { 32, 16, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20159), { 0, 0, height },
+                        { 32, 16, 1 });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20164, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20164), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20149, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20149), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -633,25 +635,26 @@ static void mine_train_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20153, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20153), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20158, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20158), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20163, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20163), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20148, { 0, 0, height }, { 16, 16, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20148), { 0, 0, height },
+                        { 16, 16, 1 });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -673,24 +676,26 @@ static void mine_train_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20152, { 0, 0, height }, { 16, 32, 1 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20152), { 0, 0, height },
+                        { 16, 32, 1 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20157, { 0, 0, height }, { 16, 32, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20157), { 0, 0, height },
+                        { 16, 32, 1 });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20162, { 0, 0, height }, { 16, 32, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20162), { 0, 0, height },
+                        { 16, 32, 1 });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20147, { 0, 0, height }, { 16, 32, 1 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20147), { 0, 0, height },
+                        { 16, 32, 1 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -706,26 +711,26 @@ static void mine_train_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20151, { 0, 0, height }, { 20, 32, 1 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20151), { 0, 0, height },
+                        { 20, 32, 1 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20156, { 0, 0, height }, { 20, 32, 1 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20156), { 0, 0, height },
+                        { 20, 32, 1 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20161, { 0, 0, height }, { 20, 32, 1 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20161), { 0, 0, height },
+                        { 20, 32, 1 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20146, { 0, 0, height }, { 20, 32, 1 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20146), { 0, 0, height },
+                        { 20, 32, 1 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -762,31 +767,31 @@ static void mine_train_rc_track_flat_to_left_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20106, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20106), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20114, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20114), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20107, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20107), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20115, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20115), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20108, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20108), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20109, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20109), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -805,31 +810,31 @@ static void mine_train_rc_track_flat_to_right_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20110, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20110), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20111, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20111), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20112, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20112), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20116, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20116), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20113, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20113), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20117, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20117), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -848,31 +853,31 @@ static void mine_train_rc_track_left_bank_to_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20112, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20112), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20116, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20116), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20113, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20113), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20117, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20117), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20110, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20110), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20111, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20111), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -891,31 +896,31 @@ static void mine_train_rc_track_right_bank_to_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20108, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20108), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20109, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20109), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20106, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20106), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20114, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20114), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20107, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20107), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20115, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20115), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -937,29 +942,29 @@ static void mine_train_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20175, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20175), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20186, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20186), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20180, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20180), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20185, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20185), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20170, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20170), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -980,25 +985,26 @@ static void mine_train_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20174, { 0, 0, height }, { 32, 16, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20174), { 0, 0, height },
+                        { 32, 16, 1 });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20179, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20179), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20184, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20184), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20169, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20169), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1014,25 +1020,26 @@ static void mine_train_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20173, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20173), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20178, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20178), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20183, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20183), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20168, { 0, 0, height }, { 16, 16, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20168), { 0, 0, height },
+                        { 16, 16, 1 });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1054,25 +1061,26 @@ static void mine_train_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20172, { 0, 0, height }, { 16, 32, 1 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20172), { 0, 0, height },
+                        { 16, 32, 1 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20177, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20177), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20182, { 0, 0, height }, { 16, 32, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20182), { 0, 0, height },
+                        { 16, 32, 1 });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20167, { 0, 0, height }, { 16, 32, 1 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20167), { 0, 0, height },
+                        { 16, 32, 1 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1088,29 +1096,29 @@ static void mine_train_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20171, { 0, 0, height }, { 20, 32, 1 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20171), { 0, 0, height },
+                        { 20, 32, 1 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20176, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20176), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20181, { 0, 0, height }, { 20, 32, 1 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20181), { 0, 0, height },
+                        { 20, 32, 1 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20187, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20187), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20166, { 0, 0, height }, { 20, 32, 1 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20166), { 0, 0, height },
+                        { 20, 32, 1 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1147,31 +1155,31 @@ static void mine_train_rc_track_left_bank_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20118, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20118), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20122, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20122), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             wooden_a_supports_paint_setup(session, 6, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20119, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20119), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20123, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20123), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             wooden_a_supports_paint_setup(session, 7, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20120, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20120), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             wooden_a_supports_paint_setup(session, 6, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20121, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20121), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             wooden_a_supports_paint_setup(session, 7, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -1197,31 +1205,31 @@ static void mine_train_rc_track_right_bank_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20124, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20124), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             wooden_a_supports_paint_setup(session, 6, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20125, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20125), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             wooden_a_supports_paint_setup(session, 7, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20126, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20126), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20128, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20128), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             wooden_a_supports_paint_setup(session, 6, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20127, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20127), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20129, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20129), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             wooden_a_supports_paint_setup(session, 7, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -1247,31 +1255,31 @@ static void mine_train_rc_track_25_deg_up_to_left_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20130, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20130), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20134, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20134), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             wooden_a_supports_paint_setup(session, 6, 5, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20131, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20131), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20135, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20135), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             wooden_a_supports_paint_setup(session, 7, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20132, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20132), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             wooden_a_supports_paint_setup(session, 6, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20133, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20133), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             wooden_a_supports_paint_setup(session, 7, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -1297,31 +1305,31 @@ static void mine_train_rc_track_25_deg_up_to_right_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20136, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20136), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             wooden_a_supports_paint_setup(session, 6, 5, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20137, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20137), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             wooden_a_supports_paint_setup(session, 7, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20138, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20138), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20140, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20140), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             wooden_a_supports_paint_setup(session, 6, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20139, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20139), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20141, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20141), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             wooden_a_supports_paint_setup(session, 7, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -1379,25 +1387,25 @@ static void mine_train_rc_track_left_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20142, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20142), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20143, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20143), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20144, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20144), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20145, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20145), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -1427,26 +1435,26 @@ static void mine_train_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20250, { 0, 0, height }, { 32, 27, 1 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20250), { 0, 0, height },
+                        { 32, 27, 1 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 6, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20255, { 0, 0, height }, { 32, 27, 1 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20255), { 0, 0, height },
+                        { 32, 27, 1 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 7, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20260, { 0, 0, height }, { 32, 27, 1 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20260), { 0, 0, height },
+                        { 32, 27, 1 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 6, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20265, { 0, 0, height }, { 32, 27, 1 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20265), { 0, 0, height },
+                        { 32, 27, 1 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 7, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1467,26 +1475,26 @@ static void mine_train_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20251, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20251), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20256, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20256), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20261, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20261), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20266, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20266), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1502,26 +1510,26 @@ static void mine_train_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20252, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20252), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20257, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20257), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20262, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20262), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20267, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20267), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1543,26 +1551,26 @@ static void mine_train_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20253, { 0, 0, height }, { 16, 32, 1 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20253), { 0, 0, height },
+                        { 16, 32, 1 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20258, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20258), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20263, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20263), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20268, { 0, 0, height }, { 16, 32, 1 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20268), { 0, 0, height },
+                        { 16, 32, 1 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1578,26 +1586,26 @@ static void mine_train_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20254, { 0, 0, height }, { 27, 32, 1 },
-                        { 2, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20254), { 0, 0, height },
+                        { 27, 32, 1 }, { 2, 0, height });
                     wooden_a_supports_paint_setup(session, 7, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20259, { 0, 0, height }, { 27, 32, 1 },
-                        { 2, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20259), { 0, 0, height },
+                        { 27, 32, 1 }, { 2, 0, height });
                     wooden_a_supports_paint_setup(session, 6, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20264, { 0, 0, height }, { 27, 32, 1 },
-                        { 2, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20264), { 0, 0, height },
+                        { 27, 32, 1 }, { 2, 0, height });
                     wooden_a_supports_paint_setup(session, 7, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20269, { 0, 0, height }, { 27, 32, 1 },
-                        { 2, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20269), { 0, 0, height },
+                        { 27, 32, 1 }, { 2, 0, height });
                     wooden_a_supports_paint_setup(session, 6, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1628,26 +1636,26 @@ static void mine_train_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20230, { 0, 0, height }, { 32, 27, 1 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20230), { 0, 0, height },
+                        { 32, 27, 1 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 6, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20235, { 0, 0, height }, { 32, 27, 1 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20235), { 0, 0, height },
+                        { 32, 27, 1 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 7, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20240, { 0, 0, height }, { 32, 27, 1 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20240), { 0, 0, height },
+                        { 32, 27, 1 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 6, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20245, { 0, 0, height }, { 32, 27, 1 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20245), { 0, 0, height },
+                        { 32, 27, 1 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 7, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1668,26 +1676,26 @@ static void mine_train_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20231, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20231), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20236, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20236), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20241, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20241), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20246, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20246), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1703,26 +1711,26 @@ static void mine_train_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20232, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20232), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20237, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20237), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20242, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20242), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20247, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20247), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1744,26 +1752,26 @@ static void mine_train_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20233, { 0, 0, height }, { 16, 32, 1 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20233), { 0, 0, height },
+                        { 16, 32, 1 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20238, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20238), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20243, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20243), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20248, { 0, 0, height }, { 16, 32, 1 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20248), { 0, 0, height },
+                        { 16, 32, 1 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1779,26 +1787,26 @@ static void mine_train_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20234, { 0, 0, height }, { 27, 32, 1 },
-                        { 2, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20234), { 0, 0, height },
+                        { 27, 32, 1 }, { 2, 0, height });
                     wooden_a_supports_paint_setup(session, 7, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20239, { 0, 0, height }, { 27, 32, 1 },
-                        { 2, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20239), { 0, 0, height },
+                        { 27, 32, 1 }, { 2, 0, height });
                     wooden_a_supports_paint_setup(session, 6, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20244, { 0, 0, height }, { 27, 32, 1 },
-                        { 2, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20244), { 0, 0, height },
+                        { 27, 32, 1 }, { 2, 0, height });
                     wooden_a_supports_paint_setup(session, 7, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20249, { 0, 0, height }, { 27, 32, 1 },
-                        { 2, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20249), { 0, 0, height },
+                        { 27, 32, 1 }, { 2, 0, height });
                     wooden_a_supports_paint_setup(session, 6, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1847,26 +1855,26 @@ static void mine_train_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20270, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20270), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20274, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20274), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20273, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20273), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20277, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20277), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1882,24 +1890,26 @@ static void mine_train_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20271, { 0, 0, height }, { 32, 26, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20271), { 0, 0, height },
+                        { 32, 26, 1 });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20275, { 0, 0, height }, { 32, 26, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20275), { 0, 0, height },
+                        { 32, 26, 1 });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20272, { 0, 0, height }, { 32, 26, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20272), { 0, 0, height },
+                        { 32, 26, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20276, { 0, 0, height }, { 32, 26, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20276), { 0, 0, height },
+                        { 32, 26, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1915,24 +1925,26 @@ static void mine_train_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20272, { 0, 0, height }, { 32, 26, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20272), { 0, 0, height },
+                        { 32, 26, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20276, { 0, 0, height }, { 32, 26, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20276), { 0, 0, height },
+                        { 32, 26, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20271, { 0, 0, height }, { 32, 26, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20271), { 0, 0, height },
+                        { 32, 26, 1 });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20275, { 0, 0, height }, { 32, 26, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20275), { 0, 0, height },
+                        { 32, 26, 1 });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1948,26 +1960,26 @@ static void mine_train_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20273, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20273), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20277, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20277), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20270, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20270), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20274, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20274), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1998,26 +2010,26 @@ static void mine_train_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20278, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20278), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20282, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20282), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20281, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20281), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20285, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20285), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2033,24 +2045,26 @@ static void mine_train_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20279, { 0, 0, height }, { 32, 26, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20279), { 0, 0, height },
+                        { 32, 26, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20283, { 0, 0, height }, { 32, 26, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20283), { 0, 0, height },
+                        { 32, 26, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20280, { 0, 0, height }, { 32, 26, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20280), { 0, 0, height },
+                        { 32, 26, 1 });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20284, { 0, 0, height }, { 32, 26, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20284), { 0, 0, height },
+                        { 32, 26, 1 });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2066,24 +2080,26 @@ static void mine_train_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20280, { 0, 0, height }, { 32, 26, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20280), { 0, 0, height },
+                        { 32, 26, 1 });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20284, { 0, 0, height }, { 32, 26, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20284), { 0, 0, height },
+                        { 32, 26, 1 });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20279, { 0, 0, height }, { 32, 26, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20279), { 0, 0, height },
+                        { 32, 26, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20283, { 0, 0, height }, { 32, 26, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20283), { 0, 0, height },
+                        { 32, 26, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2099,26 +2115,26 @@ static void mine_train_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20281, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20281), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20285, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20285), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20278, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20278), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20282, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20282), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2149,26 +2165,26 @@ static void mine_train_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20193, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20193), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20196, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20196), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20199, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20199), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20190, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20190), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2202,22 +2218,23 @@ static void mine_train_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20192, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20192), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20195, { 0, 0, height }, { 16, 16, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20195), { 0, 0, height },
+                        { 16, 16, 1 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20198, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20198), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20189, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20189), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2229,26 +2246,26 @@ static void mine_train_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20191, { 0, 0, height }, { 20, 32, 1 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20191), { 0, 0, height },
+                        { 20, 32, 1 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20194, { 0, 0, height }, { 20, 32, 1 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20194), { 0, 0, height },
+                        { 20, 32, 1 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20197, { 0, 0, height }, { 20, 32, 1 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20197), { 0, 0, height },
+                        { 20, 32, 1 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20188, { 0, 0, height }, { 20, 32, 1 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20188), { 0, 0, height },
+                        { 20, 32, 1 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2288,29 +2305,29 @@ static void mine_train_rc_track_left_quarter_turn_3_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20205, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20205), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20212, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20212), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20208, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20208), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20211, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20211), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20202, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20202), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2344,23 +2361,23 @@ static void mine_train_rc_track_left_quarter_turn_3_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20204, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20204), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20207, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20207), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20210, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20210), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20201, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20201), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2372,29 +2389,29 @@ static void mine_train_rc_track_left_quarter_turn_3_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20203, { 0, 0, height }, { 20, 32, 1 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20203), { 0, 0, height },
+                        { 20, 32, 1 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20206, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20206), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20209, { 0, 0, height }, { 20, 32, 1 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20209), { 0, 0, height },
+                        { 20, 32, 1 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20213, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20213), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20200, { 0, 0, height }, { 20, 32, 1 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20200), { 0, 0, height },
+                        { 20, 32, 1 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2434,22 +2451,26 @@ static void mine_train_rc_track_left_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20225, { 0, 6, height }, { 32, 20, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20225), { 0, 6, height },
+                        { 32, 20, 1 });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20227, { 0, 6, height }, { 32, 20, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20227), { 0, 6, height },
+                        { 32, 20, 1 });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20229, { 0, 6, height }, { 32, 20, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20229), { 0, 6, height },
+                        { 32, 20, 1 });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20223, { 0, 6, height }, { 32, 20, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20223), { 0, 6, height },
+                        { 32, 20, 1 });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2488,22 +2509,26 @@ static void mine_train_rc_track_left_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20224, { 6, 0, height }, { 20, 32, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20224), { 6, 0, height },
+                        { 20, 32, 1 });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20226, { 6, 0, height }, { 20, 32, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20226), { 6, 0, height },
+                        { 20, 32, 1 });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20228, { 6, 0, height }, { 20, 32, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20228), { 6, 0, height },
+                        { 20, 32, 1 });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20222, { 6, 0, height }, { 20, 32, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20222), { 6, 0, height },
+                        { 20, 32, 1 });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2534,22 +2559,26 @@ static void mine_train_rc_track_right_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20214, { 0, 6, height }, { 32, 20, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20214), { 0, 6, height },
+                        { 32, 20, 1 });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20216, { 0, 6, height }, { 32, 20, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20216), { 0, 6, height },
+                        { 32, 20, 1 });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20218, { 0, 6, height }, { 32, 20, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20218), { 0, 6, height },
+                        { 32, 20, 1 });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20220, { 0, 6, height }, { 32, 20, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20220), { 0, 6, height },
+                        { 32, 20, 1 });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2588,22 +2617,26 @@ static void mine_train_rc_track_right_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20215, { 6, 0, height }, { 20, 32, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20215), { 6, 0, height },
+                        { 20, 32, 1 });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20217, { 6, 0, height }, { 20, 32, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20217), { 6, 0, height },
+                        { 20, 32, 1 });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20219, { 6, 0, height }, { 20, 32, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20219), { 6, 0, height },
+                        { 20, 32, 1 });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20221, { 6, 0, height }, { 20, 32, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20221), { 6, 0, height },
+                        { 20, 32, 1 });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2652,29 +2685,29 @@ static void mine_train_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20305, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20305), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20312, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20312), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20308, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20308), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20311, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20311), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20302, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20302), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2712,23 +2745,23 @@ static void mine_train_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20304, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20304), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20307, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20307), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20310, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20310), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20301, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20301), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2740,29 +2773,29 @@ static void mine_train_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20303, { 0, 0, height }, { 20, 32, 1 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20303), { 0, 0, height },
+                        { 20, 32, 1 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20306, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20306), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20309, { 0, 0, height }, { 20, 32, 1 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20309), { 0, 0, height },
+                        { 20, 32, 1 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20313, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20313), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20300, { 0, 0, height }, { 20, 32, 1 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20300), { 0, 0, height },
+                        { 20, 32, 1 }, { 6, 0, height + 8 });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2787,29 +2820,29 @@ static void mine_train_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20302, { 0, 0, height }, { 20, 32, 1 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20302), { 0, 0, height },
+                        { 20, 32, 1 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20305, { 0, 0, height }, { 20, 32, 1 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20305), { 0, 0, height },
+                        { 20, 32, 1 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20312, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20312), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20308, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20308), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20311, { 0, 0, height }, { 20, 32, 1 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20311), { 0, 0, height },
+                        { 20, 32, 1 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2852,23 +2885,23 @@ static void mine_train_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20301, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20301), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20304, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20304), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20307, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20307), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20310, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20310), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2880,29 +2913,29 @@ static void mine_train_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20300, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20300), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height + 8 });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20303, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20303), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20306, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20306), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20309, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20309), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20313, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20313), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2932,29 +2965,29 @@ static void mine_train_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20286, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20286), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20289, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20289), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20292, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20292), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20295, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20295), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20299, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20299), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2992,23 +3025,23 @@ static void mine_train_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20287, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20287), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20290, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20290), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20293, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20293), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20296, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20296), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3020,29 +3053,29 @@ static void mine_train_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20288, { 0, 0, height }, { 20, 32, 1 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20288), { 0, 0, height },
+                        { 20, 32, 1 }, { 6, 0, height + 8 });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20291, { 0, 0, height }, { 20, 32, 1 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20291), { 0, 0, height },
+                        { 20, 32, 1 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20298, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20298), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20294, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20294), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20297, { 0, 0, height }, { 20, 32, 1 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20297), { 0, 0, height },
+                        { 20, 32, 1 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3067,29 +3100,29 @@ static void mine_train_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20289, { 0, 0, height }, { 20, 32, 1 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20289), { 0, 0, height },
+                        { 20, 32, 1 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20292, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20292), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20295, { 0, 0, height }, { 20, 32, 1 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20295), { 0, 0, height },
+                        { 20, 32, 1 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20299, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20299), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20286, { 0, 0, height }, { 20, 32, 1 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20286), { 0, 0, height },
+                        { 20, 32, 1 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3132,23 +3165,23 @@ static void mine_train_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20290, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20290), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20293, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20293), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20296, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20296), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20287, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20287), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3160,29 +3193,29 @@ static void mine_train_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20291, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20291), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20298, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20298), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20294, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20294), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20297, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20297), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20288, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20288), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height + 8 });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3242,29 +3275,29 @@ static void mine_train_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20345, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20345), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20356, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20356), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20350, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20350), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20355, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20355), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20340, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20340), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3289,26 +3322,26 @@ static void mine_train_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20344, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20344), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20349, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20349), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20354, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20354), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20339, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20339), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3324,29 +3357,29 @@ static void mine_train_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20343, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20343), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20348, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20348), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20178, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20178), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20353, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20353), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20338, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20338), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3366,29 +3399,29 @@ static void mine_train_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20342, { 0, 0, height }, { 16, 32, 1 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20342), { 0, 0, height },
+                        { 16, 32, 1 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20347, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20347), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20177, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20177), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20352, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20352), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20337, { 0, 0, height }, { 16, 32, 1 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20337), { 0, 0, height },
+                        { 16, 32, 1 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3404,29 +3437,29 @@ static void mine_train_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20341, { 0, 0, height }, { 20, 32, 1 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20341), { 0, 0, height },
+                        { 20, 32, 1 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20346, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20346), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20351, { 0, 0, height }, { 20, 32, 1 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20351), { 0, 0, height },
+                        { 20, 32, 1 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20357, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20357), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20336, { 0, 0, height }, { 20, 32, 1 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20336), { 0, 0, height },
+                        { 20, 32, 1 }, { 6, 0, height + 8 });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3451,29 +3484,29 @@ static void mine_train_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20340, { 0, 0, height }, { 20, 32, 1 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20340), { 0, 0, height },
+                        { 20, 32, 1 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20345, { 0, 0, height }, { 20, 32, 1 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20345), { 0, 0, height },
+                        { 20, 32, 1 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20356, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20356), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20350, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20350), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20355, { 0, 0, height }, { 20, 32, 1 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20355), { 0, 0, height },
+                        { 20, 32, 1 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3503,26 +3536,26 @@ static void mine_train_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20339, { 0, 0, height }, { 16, 32, 1 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20339), { 0, 0, height },
+                        { 16, 32, 1 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20344, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20344), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20349, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20349), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20354, { 0, 0, height }, { 16, 32, 1 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20354), { 0, 0, height },
+                        { 16, 32, 1 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3538,29 +3571,29 @@ static void mine_train_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20338, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20338), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20343, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20343), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20348, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20348), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20178, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20178), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20353, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20353), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3580,29 +3613,29 @@ static void mine_train_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20337, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20337), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20342, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20342), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20347, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20347), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20177, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20177), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20352, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20352), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3618,29 +3651,29 @@ static void mine_train_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20336, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20336), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height + 8 });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20341, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20341), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20346, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20346), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20351, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20351), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20357, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20357), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3670,29 +3703,29 @@ static void mine_train_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20314, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20314), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20319, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20319), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20324, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20324), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20329, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20329), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20335, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20335), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3717,26 +3750,26 @@ static void mine_train_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20315, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20315), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20320, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20320), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20325, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20325), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20330, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20330), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3752,26 +3785,26 @@ static void mine_train_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20316, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20316), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20321, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20321), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20326, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20326), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20331, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20331), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3791,26 +3824,26 @@ static void mine_train_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20317, { 0, 0, height }, { 16, 32, 1 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20317), { 0, 0, height },
+                        { 16, 32, 1 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20322, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20322), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20327, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20327), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20332, { 0, 0, height }, { 16, 32, 1 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20332), { 0, 0, height },
+                        { 16, 32, 1 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3826,29 +3859,29 @@ static void mine_train_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20318, { 0, 0, height }, { 20, 32, 1 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20318), { 0, 0, height },
+                        { 20, 32, 1 }, { 6, 0, height + 8 });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20323, { 0, 0, height }, { 20, 32, 1 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20323), { 0, 0, height },
+                        { 20, 32, 1 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20334, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20334), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20328, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20328), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20333, { 0, 0, height }, { 20, 32, 1 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20333), { 0, 0, height },
+                        { 20, 32, 1 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3873,29 +3906,29 @@ static void mine_train_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20319, { 0, 0, height }, { 20, 32, 1 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20319), { 0, 0, height },
+                        { 20, 32, 1 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20324, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20324), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20329, { 0, 0, height }, { 20, 32, 1 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20329), { 0, 0, height },
+                        { 20, 32, 1 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20335, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20335), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20314, { 0, 0, height }, { 20, 32, 1 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20314), { 0, 0, height },
+                        { 20, 32, 1 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3925,26 +3958,26 @@ static void mine_train_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20320, { 0, 0, height }, { 16, 32, 1 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20320), { 0, 0, height },
+                        { 16, 32, 1 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20325, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20325), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20330, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20330), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20315, { 0, 0, height }, { 16, 32, 1 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20315), { 0, 0, height },
+                        { 16, 32, 1 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3960,26 +3993,26 @@ static void mine_train_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20321, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20321), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20326, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20326), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20331, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20331), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20316, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20316), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3999,26 +4032,26 @@ static void mine_train_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20322, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20322), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20327, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20327), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20332, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20332), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20317, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20317), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4034,29 +4067,29 @@ static void mine_train_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20323, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20323), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20334, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20334), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20328, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20328), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20333, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20333), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20318, { 0, 0, height }, { 32, 20, 1 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20318), { 0, 0, height },
+                        { 32, 20, 1 }, { 0, 6, height + 8 });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4114,14 +4147,14 @@ static void mine_train_rc_track_brakes(
         case 0:
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20058, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20058), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20059, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20059), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -4140,25 +4173,25 @@ static void mine_train_rc_track_on_ride_photo(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20052, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20052), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20053, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20053), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20052, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20052), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 20053, { 0, 0, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20053), { 0, 0, height }, { 32, 20, 1 },
                 { 0, 6, height });
             wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -4181,26 +4214,26 @@ static void mine_train_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20452, { 0, 0, height }, { 32, 32, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20452), { 0, 0, height },
+                        { 32, 32, 1 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20456, { 0, 0, height }, { 32, 32, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20456), { 0, 0, height },
+                        { 32, 32, 1 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20460, { 0, 0, height }, { 32, 32, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20460), { 0, 0, height },
+                        { 32, 32, 1 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20464, { 0, 0, height }, { 32, 32, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20464), { 0, 0, height },
+                        { 32, 32, 1 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4216,26 +4249,26 @@ static void mine_train_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20453, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20453), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20457, { 0, 0, height }, { 34, 16, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20457), { 0, 0, height },
+                        { 34, 16, 1 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20461, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20461), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20465, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20465), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4247,26 +4280,26 @@ static void mine_train_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20454, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20454), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20458, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20458), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20462, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20462), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20466, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20466), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4297,23 +4330,23 @@ static void mine_train_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20455, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20455), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20459, { 0, 0, height }, { 16, 18, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20459), { 0, 0, height },
+                        { 16, 18, 1 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20463, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20463), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20467, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20467), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -4334,26 +4367,26 @@ static void mine_train_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20436, { 0, 0, height }, { 32, 32, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20436), { 0, 0, height },
+                        { 32, 32, 1 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20440, { 0, 0, height }, { 32, 32, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20440), { 0, 0, height },
+                        { 32, 32, 1 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20444, { 0, 0, height }, { 32, 32, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20444), { 0, 0, height },
+                        { 32, 32, 1 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20448, { 0, 0, height }, { 32, 32, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20448), { 0, 0, height },
+                        { 32, 32, 1 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4369,26 +4402,26 @@ static void mine_train_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20437, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20437), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20441, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20441), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20445, { 0, 0, height }, { 34, 16, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20445), { 0, 0, height },
+                        { 34, 16, 1 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20449, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20449), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4400,26 +4433,26 @@ static void mine_train_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20438, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20438), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20442, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20442), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20446, { 0, 0, height }, { 28, 28, 1 },
-                        { 4, 4, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20446), { 0, 0, height },
+                        { 28, 28, 1 }, { 4, 4, height });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20450, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20450), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4450,23 +4483,23 @@ static void mine_train_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20439, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20439), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20443, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20443), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20447, { 0, 0, height }, { 16, 18, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20447), { 0, 0, height },
+                        { 16, 18, 1 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20451, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20451), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -4505,26 +4538,26 @@ static void mine_train_rc_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20484, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20484), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20488, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20488), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20492, { 0, 0, height }, { 32, 32, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20492), { 0, 0, height },
+                        { 32, 32, 1 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20496, { 0, 0, height }, { 32, 32, 1 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20496), { 0, 0, height },
+                        { 32, 32, 1 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4540,26 +4573,26 @@ static void mine_train_rc_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20485, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20485), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20489, { 0, 0, height }, { 34, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20489), { 0, 0, height },
+                        { 34, 16, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20493, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20493), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20497, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20497), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4571,26 +4604,26 @@ static void mine_train_rc_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20486, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20486), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20490, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20490), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 16, height + 27 });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20494, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20494), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20498, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20498), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4621,23 +4654,23 @@ static void mine_train_rc_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20487, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20487), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20491, { 0, 0, height }, { 16, 18, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20491), { 0, 0, height },
+                        { 16, 18, 0 }, { 0, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20495, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20495), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20499, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20499), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -4658,26 +4691,26 @@ static void mine_train_rc_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20468, { 0, 0, height }, { 32, 32, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20468), { 0, 0, height },
+                        { 32, 32, 1 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20472, { 0, 0, height }, { 32, 32, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20472), { 0, 0, height },
+                        { 32, 32, 1 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20476, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20476), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20480, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20480), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4693,26 +4726,26 @@ static void mine_train_rc_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20469, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20469), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20473, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20473), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20477, { 0, 0, height }, { 34, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20477), { 0, 0, height },
+                        { 34, 16, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20481, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20481), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4724,26 +4757,26 @@ static void mine_train_rc_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20470, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20470), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20474, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20474), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20478, { 0, 0, height }, { 28, 28, 0 },
-                        { 4, 4, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20478), { 0, 0, height },
+                        { 28, 28, 0 }, { 4, 4, height + 27 });
                     wooden_a_supports_paint_setup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20482, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20482), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4774,23 +4807,23 @@ static void mine_train_rc_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20471, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20471), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20475, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20475), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20479, { 0, 0, height }, { 16, 18, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20479), { 0, 0, height },
+                        { 16, 18, 0 }, { 0, 16, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20483, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20483), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -4831,8 +4864,8 @@ static void mine_train_rc_track_diag_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20389, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20389), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         break;
                 }
             }
@@ -4842,8 +4875,8 @@ static void mine_train_rc_track_diag_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20361, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20361), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         break;
                 }
             }
@@ -4857,8 +4890,8 @@ static void mine_train_rc_track_diag_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20386, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20386), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
@@ -4878,8 +4911,8 @@ static void mine_train_rc_track_diag_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20358, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20358), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
@@ -4909,8 +4942,8 @@ static void mine_train_rc_track_diag_flat(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20388, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20388), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
@@ -4930,8 +4963,8 @@ static void mine_train_rc_track_diag_flat(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20360, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20360), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
@@ -4949,8 +4982,8 @@ static void mine_train_rc_track_diag_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20387, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20387), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         break;
                 }
             }
@@ -4960,8 +4993,8 @@ static void mine_train_rc_track_diag_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20359, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20359), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         break;
                 }
             }
@@ -4985,8 +5018,8 @@ static void mine_train_rc_track_diag_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20401, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20401), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         break;
                 }
             }
@@ -4996,8 +5029,8 @@ static void mine_train_rc_track_diag_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20373, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20373), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5011,8 +5044,8 @@ static void mine_train_rc_track_diag_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20398, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20398), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         wooden_b_supports_paint_setup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
@@ -5032,8 +5065,8 @@ static void mine_train_rc_track_diag_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20370, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20370), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         wooden_b_supports_paint_setup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
@@ -5063,8 +5096,8 @@ static void mine_train_rc_track_diag_25_deg_up(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20400, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20400), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         wooden_b_supports_paint_setup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
@@ -5084,8 +5117,8 @@ static void mine_train_rc_track_diag_25_deg_up(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20372, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20372), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         wooden_b_supports_paint_setup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
@@ -5103,8 +5136,8 @@ static void mine_train_rc_track_diag_25_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20399, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20399), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5114,8 +5147,8 @@ static void mine_train_rc_track_diag_25_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20371, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20371), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5137,8 +5170,8 @@ static void mine_train_rc_track_diag_60_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20385, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20385), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -5149,8 +5182,8 @@ static void mine_train_rc_track_diag_60_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20382, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20382), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     wooden_b_supports_paint_setup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -5177,8 +5210,8 @@ static void mine_train_rc_track_diag_60_deg_up(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20384, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20384), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     wooden_b_supports_paint_setup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -5193,8 +5226,8 @@ static void mine_train_rc_track_diag_60_deg_up(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20383, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20383), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -5217,8 +5250,8 @@ static void mine_train_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20393, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20393), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5228,8 +5261,8 @@ static void mine_train_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20365, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20365), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5243,8 +5276,8 @@ static void mine_train_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20390, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20390), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
@@ -5264,8 +5297,8 @@ static void mine_train_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20362, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20362), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
@@ -5295,8 +5328,8 @@ static void mine_train_rc_track_diag_flat_to_25_deg_up(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20392, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20392), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
@@ -5316,8 +5349,8 @@ static void mine_train_rc_track_diag_flat_to_25_deg_up(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20364, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20364), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
@@ -5335,8 +5368,8 @@ static void mine_train_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20391, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20391), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5346,8 +5379,8 @@ static void mine_train_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20363, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20363), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5369,8 +5402,8 @@ static void mine_train_rc_track_diag_25_deg_up_to_60_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20377, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20377), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -5381,8 +5414,8 @@ static void mine_train_rc_track_diag_25_deg_up_to_60_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20374, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20374), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     wooden_b_supports_paint_setup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -5409,8 +5442,8 @@ static void mine_train_rc_track_diag_25_deg_up_to_60_deg_up(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20376, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20376), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     wooden_b_supports_paint_setup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -5425,8 +5458,8 @@ static void mine_train_rc_track_diag_25_deg_up_to_60_deg_up(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20375, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20375), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -5447,8 +5480,8 @@ static void mine_train_rc_track_diag_60_deg_up_to_25_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20381, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20381), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -5459,8 +5492,8 @@ static void mine_train_rc_track_diag_60_deg_up_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20378, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20378), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     wooden_b_supports_paint_setup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -5487,8 +5520,8 @@ static void mine_train_rc_track_diag_60_deg_up_to_25_deg_up(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20380, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20380), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     wooden_b_supports_paint_setup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -5503,8 +5536,8 @@ static void mine_train_rc_track_diag_60_deg_up_to_25_deg_up(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20379, { -16, -16, height }, { 16, 16, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20379), { -16, -16, height },
+                        { 16, 16, 1 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -5527,8 +5560,8 @@ static void mine_train_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20397, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20397), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5538,8 +5571,8 @@ static void mine_train_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20369, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20369), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5553,8 +5586,8 @@ static void mine_train_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20394, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20394), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         wooden_b_supports_paint_setup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
@@ -5574,8 +5607,8 @@ static void mine_train_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20366, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20366), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         wooden_b_supports_paint_setup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
@@ -5605,8 +5638,8 @@ static void mine_train_rc_track_diag_25_deg_up_to_flat(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20396, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20396), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         wooden_b_supports_paint_setup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
@@ -5626,8 +5659,8 @@ static void mine_train_rc_track_diag_25_deg_up_to_flat(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20368, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20368), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         wooden_b_supports_paint_setup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
@@ -5645,8 +5678,8 @@ static void mine_train_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20395, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20395), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5656,8 +5689,8 @@ static void mine_train_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20367, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20367), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5681,8 +5714,8 @@ static void mine_train_rc_track_diag_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20399, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20399), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5692,8 +5725,8 @@ static void mine_train_rc_track_diag_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20371, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20371), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5707,8 +5740,8 @@ static void mine_train_rc_track_diag_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20400, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20400), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         wooden_b_supports_paint_setup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
@@ -5728,8 +5761,8 @@ static void mine_train_rc_track_diag_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20372, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20372), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         wooden_b_supports_paint_setup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
@@ -5759,8 +5792,8 @@ static void mine_train_rc_track_diag_25_deg_down(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20398, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20398), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         wooden_b_supports_paint_setup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
@@ -5780,8 +5813,8 @@ static void mine_train_rc_track_diag_25_deg_down(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20370, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20370), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         wooden_b_supports_paint_setup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
@@ -5799,8 +5832,8 @@ static void mine_train_rc_track_diag_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20401, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20401), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5810,8 +5843,8 @@ static void mine_train_rc_track_diag_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20373, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20373), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5833,8 +5866,8 @@ static void mine_train_rc_track_diag_60_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20383, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20383), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -5845,8 +5878,8 @@ static void mine_train_rc_track_diag_60_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20384, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20384), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     wooden_b_supports_paint_setup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -5873,8 +5906,8 @@ static void mine_train_rc_track_diag_60_deg_down(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20382, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20382), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     wooden_b_supports_paint_setup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -5889,8 +5922,8 @@ static void mine_train_rc_track_diag_60_deg_down(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20385, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20385), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -5913,8 +5946,8 @@ static void mine_train_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20395, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20395), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5924,8 +5957,8 @@ static void mine_train_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20367, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20367), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5938,8 +5971,8 @@ static void mine_train_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20396, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20396), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         wooden_b_supports_paint_setup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
@@ -5959,8 +5992,8 @@ static void mine_train_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20368, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20368), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         wooden_b_supports_paint_setup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
@@ -5989,8 +6022,8 @@ static void mine_train_rc_track_diag_flat_to_25_deg_down(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20394, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20394), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         wooden_b_supports_paint_setup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
@@ -6010,8 +6043,8 @@ static void mine_train_rc_track_diag_flat_to_25_deg_down(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20366, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20366), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         wooden_b_supports_paint_setup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
@@ -6028,8 +6061,8 @@ static void mine_train_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20397, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20397), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6039,8 +6072,8 @@ static void mine_train_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20369, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20369), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6063,8 +6096,8 @@ static void mine_train_rc_track_diag_25_deg_down_to_60_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20379, { -16, -16, height }, { 16, 16, 1 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20379), { -16, -16, height },
+                        { 16, 16, 1 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6075,8 +6108,8 @@ static void mine_train_rc_track_diag_25_deg_down_to_60_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20380, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20380), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     wooden_b_supports_paint_setup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -6103,8 +6136,8 @@ static void mine_train_rc_track_diag_25_deg_down_to_60_deg_down(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20378, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20378), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     wooden_b_supports_paint_setup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -6119,8 +6152,8 @@ static void mine_train_rc_track_diag_25_deg_down_to_60_deg_down(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20381, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20381), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6141,8 +6174,8 @@ static void mine_train_rc_track_diag_60_deg_down_to_25_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20375, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20375), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6153,8 +6186,8 @@ static void mine_train_rc_track_diag_60_deg_down_to_25_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20376, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20376), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     wooden_b_supports_paint_setup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -6181,8 +6214,8 @@ static void mine_train_rc_track_diag_60_deg_down_to_25_deg_down(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20374, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20374), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     wooden_b_supports_paint_setup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -6197,8 +6230,8 @@ static void mine_train_rc_track_diag_60_deg_down_to_25_deg_down(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20377, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20377), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6221,8 +6254,8 @@ static void mine_train_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20391, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20391), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6232,8 +6265,8 @@ static void mine_train_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20363, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20363), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6247,8 +6280,8 @@ static void mine_train_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20392, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20392), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
@@ -6268,8 +6301,8 @@ static void mine_train_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20364, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20364), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
@@ -6299,8 +6332,8 @@ static void mine_train_rc_track_diag_25_deg_down_to_flat(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20390, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20390), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
@@ -6320,8 +6353,8 @@ static void mine_train_rc_track_diag_25_deg_down_to_flat(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20362, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20362), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
@@ -6339,8 +6372,8 @@ static void mine_train_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20393, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20393), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6350,8 +6383,8 @@ static void mine_train_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 20365, { -16, -16, height }, { 32, 32, 1 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20365), { -16, -16, height },
+                            { 32, 32, 1 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6373,8 +6406,8 @@ static void mine_train_rc_track_diag_flat_to_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20409, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20409), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6385,11 +6418,11 @@ static void mine_train_rc_track_diag_flat_to_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20406, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20406), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20410, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20410), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -6416,8 +6449,8 @@ static void mine_train_rc_track_diag_flat_to_left_bank(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20408, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20408), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -6432,8 +6465,8 @@ static void mine_train_rc_track_diag_flat_to_left_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20407, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20407), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6454,8 +6487,8 @@ static void mine_train_rc_track_diag_flat_to_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20414, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20414), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6466,8 +6499,8 @@ static void mine_train_rc_track_diag_flat_to_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20411, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20411), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -6494,11 +6527,11 @@ static void mine_train_rc_track_diag_flat_to_right_bank(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20413, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20413), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20415, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20415), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -6513,8 +6546,8 @@ static void mine_train_rc_track_diag_flat_to_right_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20412, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20412), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6535,8 +6568,8 @@ static void mine_train_rc_track_diag_left_bank_to_flat(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20412, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20412), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6547,11 +6580,11 @@ static void mine_train_rc_track_diag_left_bank_to_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20413, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20413), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20415, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20415), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -6578,8 +6611,8 @@ static void mine_train_rc_track_diag_left_bank_to_flat(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20411, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20411), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -6594,8 +6627,8 @@ static void mine_train_rc_track_diag_left_bank_to_flat(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20414, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20414), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6616,8 +6649,8 @@ static void mine_train_rc_track_diag_right_bank_to_flat(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20407, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20407), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6628,8 +6661,8 @@ static void mine_train_rc_track_diag_right_bank_to_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20408, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20408), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -6656,11 +6689,11 @@ static void mine_train_rc_track_diag_right_bank_to_flat(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20406, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20406), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20410, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20410), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -6675,8 +6708,8 @@ static void mine_train_rc_track_diag_right_bank_to_flat(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20409, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20409), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6697,8 +6730,8 @@ static void mine_train_rc_track_diag_left_bank_to_25_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20429, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20429), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6709,11 +6742,11 @@ static void mine_train_rc_track_diag_left_bank_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20426, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20426), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20430, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20430), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -6740,8 +6773,8 @@ static void mine_train_rc_track_diag_left_bank_to_25_deg_up(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20428, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20428), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -6756,8 +6789,8 @@ static void mine_train_rc_track_diag_left_bank_to_25_deg_up(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20427, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20427), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6778,8 +6811,8 @@ static void mine_train_rc_track_diag_right_bank_to_25_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20434, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20434), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6790,8 +6823,8 @@ static void mine_train_rc_track_diag_right_bank_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20431, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20431), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -6818,11 +6851,11 @@ static void mine_train_rc_track_diag_right_bank_to_25_deg_up(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20433, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20433), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20435, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20435), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -6837,8 +6870,8 @@ static void mine_train_rc_track_diag_right_bank_to_25_deg_up(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20432, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20432), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6859,8 +6892,8 @@ static void mine_train_rc_track_diag_25_deg_up_to_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20419, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20419), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6871,11 +6904,11 @@ static void mine_train_rc_track_diag_25_deg_up_to_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20416, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20416), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20420, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20420), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     wooden_b_supports_paint_setup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -6902,8 +6935,8 @@ static void mine_train_rc_track_diag_25_deg_up_to_left_bank(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20418, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20418), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     wooden_b_supports_paint_setup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -6918,8 +6951,8 @@ static void mine_train_rc_track_diag_25_deg_up_to_left_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20417, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20417), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6940,8 +6973,8 @@ static void mine_train_rc_track_diag_25_deg_up_to_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20424, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20424), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6952,8 +6985,8 @@ static void mine_train_rc_track_diag_25_deg_up_to_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20421, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20421), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     wooden_b_supports_paint_setup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -6980,11 +7013,11 @@ static void mine_train_rc_track_diag_25_deg_up_to_right_bank(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20423, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20423), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20425, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20425), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     wooden_b_supports_paint_setup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -6999,8 +7032,8 @@ static void mine_train_rc_track_diag_25_deg_up_to_right_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20422, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20422), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -7021,8 +7054,8 @@ static void mine_train_rc_track_diag_left_bank_to_25_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20422, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20422), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     break;
             }
             break;
@@ -7031,11 +7064,11 @@ static void mine_train_rc_track_diag_left_bank_to_25_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20423, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20423), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20425, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20425), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     wooden_b_supports_paint_setup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -7060,8 +7093,8 @@ static void mine_train_rc_track_diag_left_bank_to_25_deg_down(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20421, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20421), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     wooden_b_supports_paint_setup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -7074,8 +7107,8 @@ static void mine_train_rc_track_diag_left_bank_to_25_deg_down(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20424, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20424), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     break;
             }
             break;
@@ -7097,8 +7130,8 @@ static void mine_train_rc_track_diag_right_bank_to_25_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20417, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20417), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     break;
             }
             break;
@@ -7107,8 +7140,8 @@ static void mine_train_rc_track_diag_right_bank_to_25_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20418, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20418), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     wooden_b_supports_paint_setup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -7133,11 +7166,11 @@ static void mine_train_rc_track_diag_right_bank_to_25_deg_down(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20416, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20416), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20420, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20420), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     wooden_b_supports_paint_setup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -7150,8 +7183,8 @@ static void mine_train_rc_track_diag_right_bank_to_25_deg_down(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20419, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20419), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     break;
             }
             break;
@@ -7173,8 +7206,8 @@ static void mine_train_rc_track_diag_25_deg_down_to_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20432, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20432), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -7185,11 +7218,11 @@ static void mine_train_rc_track_diag_25_deg_down_to_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20433, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20433), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20435, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20435), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -7216,8 +7249,8 @@ static void mine_train_rc_track_diag_25_deg_down_to_left_bank(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20431, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20431), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -7232,8 +7265,8 @@ static void mine_train_rc_track_diag_25_deg_down_to_left_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20434, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20434), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -7254,8 +7287,8 @@ static void mine_train_rc_track_diag_25_deg_down_to_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20427, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20427), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -7266,8 +7299,8 @@ static void mine_train_rc_track_diag_25_deg_down_to_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20428, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20428), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -7294,11 +7327,11 @@ static void mine_train_rc_track_diag_25_deg_down_to_right_bank(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20426, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20426), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20430, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20430), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -7313,8 +7346,8 @@ static void mine_train_rc_track_diag_25_deg_down_to_right_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20429, { -16, -16, height }, { 32, 32, 1 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20429), { -16, -16, height },
+                        { 32, 32, 1 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -7335,8 +7368,8 @@ static void mine_train_rc_track_diag_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20405, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20405), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7348,8 +7381,8 @@ static void mine_train_rc_track_diag_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20402, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20402), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -7377,8 +7410,8 @@ static void mine_train_rc_track_diag_left_bank(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20404, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20404), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -7394,8 +7427,8 @@ static void mine_train_rc_track_diag_left_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20403, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20403), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7417,8 +7450,8 @@ static void mine_train_rc_track_diag_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20403, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20403), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7430,8 +7463,8 @@ static void mine_train_rc_track_diag_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20404, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20404), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -7459,8 +7492,8 @@ static void mine_train_rc_track_diag_right_bank(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20402, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20402), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     wooden_a_supports_paint_setup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -7476,8 +7509,8 @@ static void mine_train_rc_track_diag_right_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 20405, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20405), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7494,7 +7527,7 @@ static void mine_train_rc_track_block_brakes(
 {
     bool isClosed = trackElement.BlockBrakeClosed();
     PaintAddImageAsParentRotated(
-        session, direction, session.TrackColours[SCHEME_TRACK] | _MineTrainBlockBrakeImages[direction][isClosed],
+        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(_MineTrainBlockBrakeImages[direction][isClosed]),
         { 0, 0, height }, { 32, 20, 1 }, { 0, 6, height });
     wooden_a_supports_paint_setup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);

--- a/src/openrct2/ride/coaster/MiniRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/MiniRollerCoaster.cpp
@@ -41,7 +41,7 @@ static void mini_rc_track_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 19044, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19044), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 if (track_paint_util_should_paint_supports(session.MapPosition))
                 {
@@ -51,7 +51,7 @@ static void mini_rc_track_flat(
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 19045, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19045), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 if (track_paint_util_should_paint_supports(session.MapPosition))
                 {
@@ -61,7 +61,7 @@ static void mini_rc_track_flat(
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 19046, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19046), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 if (track_paint_util_should_paint_supports(session.MapPosition))
                 {
@@ -71,7 +71,7 @@ static void mini_rc_track_flat(
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 19047, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19047), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 if (track_paint_util_should_paint_supports(session.MapPosition))
                 {
@@ -88,7 +88,7 @@ static void mini_rc_track_flat(
             case 0:
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18738, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18738), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 if (track_paint_util_should_paint_supports(session.MapPosition))
                 {
@@ -99,7 +99,7 @@ static void mini_rc_track_flat(
             case 1:
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18739, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18739), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 if (track_paint_util_should_paint_supports(session.MapPosition))
                 {
@@ -130,17 +130,18 @@ static void mini_rc_track_station(
     {
         bool isClosed = trackElement.BlockBrakeClosed();
         PaintAddImageAsParentRotated(
-            session, direction, _MiniRCBlockBrakeImages[direction][isClosed] | session.TrackColours[SCHEME_TRACK],
+            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(_MiniRCBlockBrakeImages[direction][isClosed]),
             { 0, 0, height }, { 32, 20, 1 }, { 0, 6, height + 3 });
     }
     else
     {
         PaintAddImageAsParentRotated(
-            session, direction, imageIds[direction][0] | session.TrackColours[SCHEME_TRACK], { 0, 0, height }, { 32, 20, 1 },
-            { 0, 6, height + 3 });
+            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]), { 0, 0, height },
+            { 32, 20, 1 }, { 0, 6, height + 3 });
     }
     PaintAddImageAsParentRotated(
-        session, direction, imageIds[direction][1] | session.TrackColours[SCHEME_MISC], { 0, 0, height }, { 32, 32, 1 });
+        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][1]), { 0, 0, height },
+        { 32, 32, 1 });
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], 0);
     track_paint_util_draw_station_2(session, ride, direction, height, trackElement, 9, 11);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -159,7 +160,7 @@ static void mini_rc_track_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 19056, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19056), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 if (track_paint_util_should_paint_supports(session.MapPosition))
                 {
@@ -169,7 +170,7 @@ static void mini_rc_track_25_deg_up(
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 19057, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19057), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 if (track_paint_util_should_paint_supports(session.MapPosition))
                 {
@@ -179,7 +180,7 @@ static void mini_rc_track_25_deg_up(
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 19058, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19058), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 if (track_paint_util_should_paint_supports(session.MapPosition))
                 {
@@ -189,7 +190,7 @@ static void mini_rc_track_25_deg_up(
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 19059, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19059), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 if (track_paint_util_should_paint_supports(session.MapPosition))
                 {
@@ -205,7 +206,7 @@ static void mini_rc_track_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18796, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18796), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 if (track_paint_util_should_paint_supports(session.MapPosition))
                 {
@@ -215,7 +216,7 @@ static void mini_rc_track_25_deg_up(
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18797, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18797), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 if (track_paint_util_should_paint_supports(session.MapPosition))
                 {
@@ -225,7 +226,7 @@ static void mini_rc_track_25_deg_up(
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18798, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18798), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 if (track_paint_util_should_paint_supports(session.MapPosition))
                 {
@@ -235,7 +236,7 @@ static void mini_rc_track_25_deg_up(
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18799, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18799), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 if (track_paint_util_should_paint_supports(session.MapPosition))
                 {
@@ -267,7 +268,7 @@ static void mini_rc_track_60_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18812, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18812), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -277,7 +278,7 @@ static void mini_rc_track_60_deg_up(
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18813, { 0, 0, height }, { 32, 1, 98 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18813), { 0, 0, height }, { 32, 1, 98 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -287,7 +288,7 @@ static void mini_rc_track_60_deg_up(
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18814, { 0, 0, height }, { 32, 1, 98 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18814), { 0, 0, height }, { 32, 1, 98 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -297,7 +298,7 @@ static void mini_rc_track_60_deg_up(
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18815, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18815), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -330,7 +331,7 @@ static void mini_rc_track_flat_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 19048, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19048), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 if (track_paint_util_should_paint_supports(session.MapPosition))
                 {
@@ -340,7 +341,7 @@ static void mini_rc_track_flat_to_25_deg_up(
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 19049, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19049), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 if (track_paint_util_should_paint_supports(session.MapPosition))
                 {
@@ -350,7 +351,7 @@ static void mini_rc_track_flat_to_25_deg_up(
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 19050, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19050), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 if (track_paint_util_should_paint_supports(session.MapPosition))
                 {
@@ -360,7 +361,7 @@ static void mini_rc_track_flat_to_25_deg_up(
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 19051, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19051), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 if (track_paint_util_should_paint_supports(session.MapPosition))
                 {
@@ -376,7 +377,7 @@ static void mini_rc_track_flat_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18788, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18788), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 if (track_paint_util_should_paint_supports(session.MapPosition))
                 {
@@ -386,7 +387,7 @@ static void mini_rc_track_flat_to_25_deg_up(
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18789, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18789), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 if (track_paint_util_should_paint_supports(session.MapPosition))
                 {
@@ -396,7 +397,7 @@ static void mini_rc_track_flat_to_25_deg_up(
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18790, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18790), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 if (track_paint_util_should_paint_supports(session.MapPosition))
                 {
@@ -406,7 +407,7 @@ static void mini_rc_track_flat_to_25_deg_up(
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18791, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18791), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 if (track_paint_util_should_paint_supports(session.MapPosition))
                 {
@@ -438,7 +439,7 @@ static void mini_rc_track_25_deg_up_to_60_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18800, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18800), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -448,10 +449,10 @@ static void mini_rc_track_25_deg_up_to_60_deg_up(
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18801, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18801), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18804, { 0, 0, height }, { 32, 1, 66 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18804), { 0, 0, height }, { 32, 1, 66 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -461,10 +462,10 @@ static void mini_rc_track_25_deg_up_to_60_deg_up(
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18802, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18802), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18805, { 0, 0, height }, { 32, 1, 66 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18805), { 0, 0, height }, { 32, 1, 66 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -474,7 +475,7 @@ static void mini_rc_track_25_deg_up_to_60_deg_up(
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18803, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18803), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -505,7 +506,7 @@ static void mini_rc_track_60_deg_up_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18806, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18806), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -515,10 +516,10 @@ static void mini_rc_track_60_deg_up_to_25_deg_up(
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18807, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18807), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18810, { 0, 0, height }, { 32, 1, 66 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18810), { 0, 0, height }, { 32, 1, 66 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -528,10 +529,10 @@ static void mini_rc_track_60_deg_up_to_25_deg_up(
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18808, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18808), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18811, { 0, 0, height }, { 32, 1, 66 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18811), { 0, 0, height }, { 32, 1, 66 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -541,7 +542,7 @@ static void mini_rc_track_60_deg_up_to_25_deg_up(
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18809, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18809), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -574,7 +575,7 @@ static void mini_rc_track_25_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 19052, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19052), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 if (track_paint_util_should_paint_supports(session.MapPosition))
                 {
@@ -584,7 +585,7 @@ static void mini_rc_track_25_deg_up_to_flat(
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 19053, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19053), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 if (track_paint_util_should_paint_supports(session.MapPosition))
                 {
@@ -594,7 +595,7 @@ static void mini_rc_track_25_deg_up_to_flat(
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 19054, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19054), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 if (track_paint_util_should_paint_supports(session.MapPosition))
                 {
@@ -604,7 +605,7 @@ static void mini_rc_track_25_deg_up_to_flat(
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 19055, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19055), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 if (track_paint_util_should_paint_supports(session.MapPosition))
                 {
@@ -620,7 +621,7 @@ static void mini_rc_track_25_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18792, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18792), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 if (track_paint_util_should_paint_supports(session.MapPosition))
                 {
@@ -630,7 +631,7 @@ static void mini_rc_track_25_deg_up_to_flat(
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18793, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18793), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 if (track_paint_util_should_paint_supports(session.MapPosition))
                 {
@@ -640,7 +641,7 @@ static void mini_rc_track_25_deg_up_to_flat(
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18794, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18794), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 if (track_paint_util_should_paint_supports(session.MapPosition))
                 {
@@ -650,7 +651,7 @@ static void mini_rc_track_25_deg_up_to_flat(
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 18795, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18795), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 if (track_paint_util_should_paint_supports(session.MapPosition))
                 {
@@ -733,29 +734,29 @@ static void mini_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18851, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18851), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18856, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18856), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18861, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18861), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18846, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18846), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -776,23 +777,23 @@ static void mini_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18850, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18850), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18855, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18855), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18860, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18860), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18845, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18845), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -807,23 +808,23 @@ static void mini_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18849, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18849), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18854, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18854), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18859, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18859), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18844, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18844), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -838,23 +839,23 @@ static void mini_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18848, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18848), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18853, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18853), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18858, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18858), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18843, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18843), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -869,29 +870,29 @@ static void mini_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18847, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18847), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18852, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18852), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18857, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18857), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18842, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18842), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -930,10 +931,10 @@ static void mini_rc_track_flat_to_left_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18748, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18748), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18756, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18756), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -942,10 +943,10 @@ static void mini_rc_track_flat_to_left_bank(
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18749, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18749), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18757, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18757), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -955,7 +956,7 @@ static void mini_rc_track_flat_to_left_bank(
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18750, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18750), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -964,7 +965,7 @@ static void mini_rc_track_flat_to_left_bank(
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18751, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18751), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -988,7 +989,7 @@ static void mini_rc_track_flat_to_right_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18752, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18752), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -997,7 +998,7 @@ static void mini_rc_track_flat_to_right_bank(
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18753, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18753), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1007,10 +1008,10 @@ static void mini_rc_track_flat_to_right_bank(
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18754, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18754), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18758, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18758), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1019,10 +1020,10 @@ static void mini_rc_track_flat_to_right_bank(
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18755, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18755), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18759, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18759), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1046,10 +1047,10 @@ static void mini_rc_track_left_bank_to_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18754, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18754), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18758, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18758), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1058,10 +1059,10 @@ static void mini_rc_track_left_bank_to_flat(
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18755, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18755), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18759, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18759), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1071,7 +1072,7 @@ static void mini_rc_track_left_bank_to_flat(
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18752, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18752), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1080,7 +1081,7 @@ static void mini_rc_track_left_bank_to_flat(
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18753, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18753), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1104,7 +1105,7 @@ static void mini_rc_track_right_bank_to_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18750, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18750), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1113,7 +1114,7 @@ static void mini_rc_track_right_bank_to_flat(
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18751, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18751), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1123,10 +1124,10 @@ static void mini_rc_track_right_bank_to_flat(
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18748, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18748), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18756, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18756), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1135,10 +1136,10 @@ static void mini_rc_track_right_bank_to_flat(
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18749, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18749), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18757, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18757), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1165,32 +1166,32 @@ static void mini_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18871, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18871), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18882, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18882), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18876, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18876), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18881, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18881), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18866, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18866), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -1211,23 +1212,23 @@ static void mini_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18870, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18870), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18875, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18875), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18880, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18880), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18865, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18865), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1242,23 +1243,23 @@ static void mini_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18869, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18869), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18874, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18874), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18879, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18879), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18864, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18864), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1273,23 +1274,23 @@ static void mini_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18868, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18868), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18873, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18873), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18878, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18878), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18863, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18863), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1304,32 +1305,32 @@ static void mini_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18867, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18867), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18872, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18872), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18877, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18877), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18883, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18883), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18862, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18862), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -1368,10 +1369,10 @@ static void mini_rc_track_left_bank_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18760, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18760), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18764, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18764), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1380,10 +1381,10 @@ static void mini_rc_track_left_bank_to_25_deg_up(
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18761, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18761), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18765, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18765), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1393,7 +1394,7 @@ static void mini_rc_track_left_bank_to_25_deg_up(
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18762, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18762), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1402,7 +1403,7 @@ static void mini_rc_track_left_bank_to_25_deg_up(
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18763, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18763), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1433,7 +1434,7 @@ static void mini_rc_track_right_bank_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18766, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18766), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1442,7 +1443,7 @@ static void mini_rc_track_right_bank_to_25_deg_up(
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18767, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18767), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1452,10 +1453,10 @@ static void mini_rc_track_right_bank_to_25_deg_up(
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18768, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18768), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18770, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18770), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1464,10 +1465,10 @@ static void mini_rc_track_right_bank_to_25_deg_up(
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18769, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18769), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18771, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18771), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1498,10 +1499,10 @@ static void mini_rc_track_25_deg_up_to_left_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18772, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18772), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18776, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18776), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1511,10 +1512,10 @@ static void mini_rc_track_25_deg_up_to_left_bank(
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18773, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18773), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18777, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18777), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1524,7 +1525,7 @@ static void mini_rc_track_25_deg_up_to_left_bank(
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18774, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18774), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1534,7 +1535,7 @@ static void mini_rc_track_25_deg_up_to_left_bank(
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18775, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18775), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1565,7 +1566,7 @@ static void mini_rc_track_25_deg_up_to_right_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18778, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18778), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1575,7 +1576,7 @@ static void mini_rc_track_25_deg_up_to_right_bank(
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18779, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18779), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1585,10 +1586,10 @@ static void mini_rc_track_25_deg_up_to_right_bank(
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18780, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18780), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18782, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18782), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1598,10 +1599,10 @@ static void mini_rc_track_25_deg_up_to_right_bank(
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18781, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18781), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18783, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18783), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1664,7 +1665,7 @@ static void mini_rc_track_left_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18784, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18784), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1673,7 +1674,7 @@ static void mini_rc_track_left_bank(
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18785, { 0, 0, height }, { 32, 1, 26 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18785), { 0, 0, height }, { 32, 1, 26 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1683,7 +1684,7 @@ static void mini_rc_track_left_bank(
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18786, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18786), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1692,7 +1693,7 @@ static void mini_rc_track_left_bank(
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18787, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18787), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -1727,29 +1728,29 @@ static void mini_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18936, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18936), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18941, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18941), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18946, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18946), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18951, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18951), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -1770,21 +1771,23 @@ static void mini_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18937, { 0, 0, height }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18937), { 0, 0, height },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18942, { 0, 0, height }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18942), { 0, 0, height },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18947, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18947), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18952, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18952), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1799,22 +1802,23 @@ static void mini_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18938, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18938), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18943, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18943), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18948, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18948), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18953, { 0, 0, height }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18953), { 0, 0, height },
+                        { 16, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1829,21 +1833,23 @@ static void mini_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18939, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18939), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18944, { 0, 0, height }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18944), { 0, 0, height },
+                        { 16, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18949, { 0, 0, height }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18949), { 0, 0, height },
+                        { 16, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18954, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18954), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1858,29 +1864,29 @@ static void mini_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18940, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18940), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18945, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18945), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18950, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18950), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18955, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18955), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -1913,29 +1919,29 @@ static void mini_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18916, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18916), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18921, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18921), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18926, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18926), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18931, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18931), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -1956,21 +1962,23 @@ static void mini_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18917, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18917), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18922, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18922), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18927, { 0, 0, height }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18927), { 0, 0, height },
+                        { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18932, { 0, 0, height }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18932), { 0, 0, height },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1985,22 +1993,23 @@ static void mini_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18918, { 0, 0, height }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18918), { 0, 0, height },
+                        { 16, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18923, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18923), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18928, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18928), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18933, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18933), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2015,21 +2024,23 @@ static void mini_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18919, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18919), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18924, { 0, 0, height }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18924), { 0, 0, height },
+                        { 16, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18929, { 0, 0, height }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18929), { 0, 0, height },
+                        { 16, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18934, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18934), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2044,29 +2055,29 @@ static void mini_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18920, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18920), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18925, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18925), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18930, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18930), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18935, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18935), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2117,29 +2128,29 @@ static void mini_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18900, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18900), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18904, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18904), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18903, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18903), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18907, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18907), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2157,25 +2168,27 @@ static void mini_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18901, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18901), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 5, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18905, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18905), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 6, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18902, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18902), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18906, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18906), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2190,23 +2203,25 @@ static void mini_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18902, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18902), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18906, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18906), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18901, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18901), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 5, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18905, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18905), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 6, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2223,29 +2238,29 @@ static void mini_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18903, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18903), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18907, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18907), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18900, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18900), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18904, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18904), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2278,29 +2293,29 @@ static void mini_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18908, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18908), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18912, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18912), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18911, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18911), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18915, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18915), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2318,25 +2333,27 @@ static void mini_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18909, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18909), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 8, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18913, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18913), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 7, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18910, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18910), { 0, 0, height },
+                        { 32, 26, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18914, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18914), { 0, 0, height },
+                        { 32, 26, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2351,23 +2368,25 @@ static void mini_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18910, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18910), { 0, 0, height },
+                        { 32, 26, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18914, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18914), { 0, 0, height },
+                        { 32, 26, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18909, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18909), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 8, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18913, { 0, 0, height }, { 32, 26, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18913), { 0, 0, height },
+                        { 32, 26, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 7, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2384,29 +2403,29 @@ static void mini_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18911, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18911), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18915, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18915), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18908, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18908), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18912, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18912), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2439,29 +2458,29 @@ static void mini_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18821, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18821), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18824, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18824), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18827, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18827), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18818, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18818), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2482,23 +2501,23 @@ static void mini_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18820, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18820), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18823, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18823), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18826, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18826), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18817, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18817), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2510,29 +2529,29 @@ static void mini_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18819, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18819), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18822, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18822), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18825, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18825), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18816, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18816), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2574,32 +2593,32 @@ static void mini_rc_track_left_quarter_turn_3_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18833, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18833), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18840, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18840), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18836, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18836), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18839, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18839), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18830, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18830), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2620,23 +2639,23 @@ static void mini_rc_track_left_quarter_turn_3_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18832, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18832), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18835, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18835), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18838, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18838), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18829, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18829), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2648,32 +2667,32 @@ static void mini_rc_track_left_quarter_turn_3_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18831, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18831), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18834, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18834), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18837, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18837), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18841, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18841), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18828, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18828), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2715,25 +2734,29 @@ static void mini_rc_track_left_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18967, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18967), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18969, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18969), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18971, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18971), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18965, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18965), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2757,25 +2780,29 @@ static void mini_rc_track_left_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18966, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18966), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18968, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18968), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18970, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18970), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18964, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18964), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2808,25 +2835,29 @@ static void mini_rc_track_right_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18956, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18956), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18958, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18958), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18960, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18960), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18962, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18962), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2850,25 +2881,29 @@ static void mini_rc_track_right_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18957, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18957), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18959, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18959), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18961, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18961), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18963, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18963), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2919,32 +2954,32 @@ static void mini_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18991, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18991), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18998, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18998), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18994, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18994), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18997, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18997), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18988, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18988), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2966,23 +3001,23 @@ static void mini_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18990, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18990), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18993, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18993), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18996, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18996), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18987, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18987), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2994,32 +3029,32 @@ static void mini_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18989, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18989), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18992, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18992), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18995, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18995), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18999, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18999), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 15, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18986, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18986), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 8 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3043,32 +3078,32 @@ static void mini_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18988, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18988), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18991, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18991), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18998, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18998), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18994, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18994), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18997, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18997), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3095,23 +3130,23 @@ static void mini_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18987, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18987), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18990, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18990), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18993, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18993), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18996, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18996), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3123,32 +3158,32 @@ static void mini_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18986, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18986), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18989, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18989), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18992, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18992), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18995, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18995), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18999, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18999), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 15, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3177,32 +3212,32 @@ static void mini_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18972, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18972), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18975, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18975), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18978, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18978), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18981, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18981), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18985, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18985), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3224,23 +3259,23 @@ static void mini_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18973, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18973), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18976, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18976), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18979, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18979), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18982, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18982), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3252,32 +3287,32 @@ static void mini_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18974, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18974), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 8 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18977, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18977), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18984, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18984), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 15, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18980, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18980), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18983, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18983), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3301,32 +3336,32 @@ static void mini_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18975, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18975), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18978, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18978), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18981, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18981), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18985, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18985), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18972, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18972), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3353,23 +3388,23 @@ static void mini_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18976, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18976), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18979, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18979), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18982, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18982), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18973, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18973), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3381,32 +3416,32 @@ static void mini_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18977, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18977), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18984, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18984), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 15, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18980, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18980), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18983, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18983), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 18974, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18974), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3463,32 +3498,32 @@ static void mini_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19031, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19031), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19042, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19042), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19036, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19036), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19041, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19041), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19026, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19026), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3510,23 +3545,23 @@ static void mini_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19030, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19030), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19035, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19035), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19040, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19040), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19025, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19025), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3541,23 +3576,23 @@ static void mini_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19029, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19029), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19034, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19034), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19039, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19039), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19024, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19024), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3572,23 +3607,23 @@ static void mini_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19028, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19028), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19033, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19033), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19038, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19038), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19023, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19023), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3603,32 +3638,32 @@ static void mini_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19027, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19027), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 13, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19032, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19032), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 13, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19037, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19037), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19043, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19043), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 13, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19022, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19022), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 8 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 13, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3652,32 +3687,32 @@ static void mini_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19026, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19026), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19031, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19031), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19042, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19042), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19036, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19036), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19041, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19041), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3704,23 +3739,23 @@ static void mini_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19025, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19025), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19030, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19030), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19035, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19035), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19040, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19040), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3735,23 +3770,23 @@ static void mini_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19024, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19024), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19029, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19029), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19034, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19034), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19039, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19039), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3766,23 +3801,23 @@ static void mini_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19023, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19023), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19028, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19028), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19033, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19033), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19038, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19038), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3797,32 +3832,32 @@ static void mini_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19022, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19022), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 13, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19027, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19027), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 13, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19032, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19032), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 13, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19037, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19037), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19043, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19043), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 13, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3851,32 +3886,32 @@ static void mini_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19000, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19000), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19005, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19005), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19010, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19010), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19015, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19015), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19021, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19021), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3898,23 +3933,23 @@ static void mini_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19001, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19001), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19006, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19006), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19011, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19011), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19016, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19016), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3929,23 +3964,23 @@ static void mini_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19002, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19002), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19007, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19007), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19012, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19012), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19017, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19017), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3960,23 +3995,23 @@ static void mini_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19003, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19003), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19008, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19008), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19013, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19013), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19018, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19018), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3991,32 +4026,32 @@ static void mini_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19004, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19004), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 8 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 13, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19009, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19009), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19020, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19020), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 13, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19014, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19014), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 13, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19019, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19019), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 13, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -4040,32 +4075,32 @@ static void mini_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19005, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19005), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19010, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19010), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19015, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19015), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19021, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19021), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19000, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19000), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -4092,23 +4127,23 @@ static void mini_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19006, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19006), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19011, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19011), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19016, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19016), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19001, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19001), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4123,23 +4158,23 @@ static void mini_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19007, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19007), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19012, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19012), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19017, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19017), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19002, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19002), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4154,23 +4189,23 @@ static void mini_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19008, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19008), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19013, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19013), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19018, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19018), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19003, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19003), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4185,32 +4220,32 @@ static void mini_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19009, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19009), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19020, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19020), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 13, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19014, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19014), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 13, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19019, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19019), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 13, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19004, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19004), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 13, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -4264,34 +4299,34 @@ static void mini_rc_track_left_quarter_turn_1_60_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18893, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18893), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18897, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18897), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18894, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18894), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18898, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18898), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18895, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18895), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18899, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18899), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18892, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18892), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18896, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18896), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
     }
@@ -4309,34 +4344,34 @@ static void mini_rc_track_right_quarter_turn_1_60_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18884, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18884), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18888, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18888), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18885, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18885), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18889, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18889), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18886, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18886), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18890, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18890), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18887, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18887), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18891, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18891), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
     }
@@ -4371,7 +4406,7 @@ static void mini_rc_track_brakes(
         case 0:
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18740, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18740), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -4381,7 +4416,7 @@ static void mini_rc_track_brakes(
         case 1:
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18741, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18741), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -4405,7 +4440,7 @@ static void mini_rc_track_25_deg_up_left_banked(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19222, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19222), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -4415,7 +4450,7 @@ static void mini_rc_track_25_deg_up_left_banked(
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19223, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19223), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -4425,7 +4460,7 @@ static void mini_rc_track_25_deg_up_left_banked(
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19224, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19224), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -4435,7 +4470,7 @@ static void mini_rc_track_25_deg_up_left_banked(
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19225, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19225), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -4466,7 +4501,7 @@ static void mini_rc_track_25_deg_up_right_banked(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19226, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19226), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -4476,7 +4511,7 @@ static void mini_rc_track_25_deg_up_right_banked(
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19227, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19227), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -4486,7 +4521,7 @@ static void mini_rc_track_25_deg_up_right_banked(
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19228, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19228), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -4496,7 +4531,7 @@ static void mini_rc_track_25_deg_up_right_banked(
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19229, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19229), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -4527,38 +4562,38 @@ static void mini_rc_track_on_ride_photo(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_FORK, 5, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_FORK, 8, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18738, { 0, 0, height }, { 32, 20, 0 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18738), { 0, 0, height }, { 32, 20, 0 },
                 { 0, 6, height + 3 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_FORK_ALT, 6, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_FORK_ALT, 7, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18739, { 0, 0, height }, { 32, 20, 0 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18739), { 0, 0, height }, { 32, 20, 0 },
                 { 0, 6, height + 3 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_FORK, 5, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_FORK, 8, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18738, { 0, 0, height }, { 32, 20, 0 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18738), { 0, 0, height }, { 32, 20, 0 },
                 { 0, 6, height + 3 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_FORK_ALT, 6, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_FORK_ALT, 7, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 18739, { 0, 0, height }, { 32, 20, 0 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(18739), { 0, 0, height }, { 32, 20, 0 },
                 { 0, 6, height + 3 });
             break;
     }
@@ -4596,29 +4631,29 @@ static void mini_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19076, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19076), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19080, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19080), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19084, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19084), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19088, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19088), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -4636,23 +4671,23 @@ static void mini_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19077, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19077), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19081, { 0, 0, height }, { 34, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19081), { 0, 0, height },
+                        { 34, 16, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19085, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19085), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19089, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19089), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4667,23 +4702,23 @@ static void mini_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19078, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19078), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19082, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19082), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19086, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19086), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19090, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19090), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4701,29 +4736,29 @@ static void mini_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19079, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19079), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 3, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19083, { 0, 0, height }, { 16, 18, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19083), { 0, 0, height },
+                        { 16, 18, 3 }, { 0, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 1, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19087, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19087), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19091, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19091), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 2, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -4750,29 +4785,29 @@ static void mini_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19060, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19060), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19064, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19064), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19068, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19068), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19072, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19072), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -4790,23 +4825,23 @@ static void mini_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19061, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19061), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19065, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19065), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19069, { 0, 0, height }, { 34, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19069), { 0, 0, height },
+                        { 34, 16, 3 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19073, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19073), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4821,23 +4856,23 @@ static void mini_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19062, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19062), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19066, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19066), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19070, { 0, 0, height }, { 28, 28, 3 },
-                        { 4, 4, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19070), { 0, 0, height },
+                        { 28, 28, 3 }, { 4, 4, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19074, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19074), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4855,29 +4890,29 @@ static void mini_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19063, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19063), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 1, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19067, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19067), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19071, { 0, 0, height }, { 16, 18, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19071), { 0, 0, height },
+                        { 16, 18, 3 }, { 0, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 2, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19075, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19075), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 3, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -4922,29 +4957,29 @@ static void mini_rc_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19108, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19108), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19112, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19112), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19116, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19116), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19120, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19120), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -4962,23 +4997,23 @@ static void mini_rc_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19109, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19109), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19113, { 0, 0, height }, { 34, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19113), { 0, 0, height },
+                        { 34, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19117, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19117), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19121, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19121), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4993,23 +5028,23 @@ static void mini_rc_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19110, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19110), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19114, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19114), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19118, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19118), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19122, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19122), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5027,29 +5062,29 @@ static void mini_rc_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19111, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19111), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 3, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19115, { 0, 0, height }, { 16, 18, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19115), { 0, 0, height },
+                        { 16, 18, 0 }, { 0, 16, height + 27 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 1, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19119, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19119), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19123, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19123), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 2, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -5076,29 +5111,29 @@ static void mini_rc_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19092, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19092), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19096, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19096), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19100, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19100), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19104, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19104), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -5116,23 +5151,23 @@ static void mini_rc_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19093, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19093), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19097, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19097), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19101, { 0, 0, height }, { 34, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19101), { 0, 0, height },
+                        { 34, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19105, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19105), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5147,23 +5182,23 @@ static void mini_rc_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19094, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19094), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19098, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19098), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19102, { 0, 0, height }, { 28, 28, 0 },
-                        { 4, 4, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19102), { 0, 0, height },
+                        { 28, 28, 0 }, { 4, 4, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19106, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19106), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5181,29 +5216,29 @@ static void mini_rc_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19095, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19095), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 1, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19099, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19099), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19103, { 0, 0, height }, { 16, 18, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19103), { 0, 0, height },
+                        { 16, 18, 0 }, { 0, 16, height + 27 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 2, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19107, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19107), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 3, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -5250,8 +5285,8 @@ static void mini_rc_track_diag_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19189, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19189), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5261,8 +5296,8 @@ static void mini_rc_track_diag_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19127, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19127), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5277,8 +5312,8 @@ static void mini_rc_track_diag_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19186, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19186), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5288,8 +5323,8 @@ static void mini_rc_track_diag_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19124, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19124), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5304,8 +5339,8 @@ static void mini_rc_track_diag_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19188, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19188), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5315,8 +5350,8 @@ static void mini_rc_track_diag_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19126, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19126), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5335,8 +5370,8 @@ static void mini_rc_track_diag_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19187, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19187), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5360,8 +5395,8 @@ static void mini_rc_track_diag_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19125, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19125), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5396,8 +5431,8 @@ static void mini_rc_track_diag_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19201, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19201), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5407,8 +5442,8 @@ static void mini_rc_track_diag_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19139, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19139), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5423,8 +5458,8 @@ static void mini_rc_track_diag_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19198, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19198), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5434,8 +5469,8 @@ static void mini_rc_track_diag_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19136, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19136), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5450,8 +5485,8 @@ static void mini_rc_track_diag_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19200, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19200), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5461,8 +5496,8 @@ static void mini_rc_track_diag_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19138, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19138), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5481,8 +5516,8 @@ static void mini_rc_track_diag_25_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19199, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19199), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 0, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5506,8 +5541,8 @@ static void mini_rc_track_diag_25_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19137, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19137), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 0, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5540,8 +5575,8 @@ static void mini_rc_track_diag_60_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19151, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19151), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5553,8 +5588,8 @@ static void mini_rc_track_diag_60_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19148, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19148), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5566,8 +5601,8 @@ static void mini_rc_track_diag_60_deg_up(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19150, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19150), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5583,8 +5618,8 @@ static void mini_rc_track_diag_60_deg_up(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19149, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19149), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 42, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -5618,8 +5653,8 @@ static void mini_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19193, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19193), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5629,8 +5664,8 @@ static void mini_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19131, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19131), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5645,8 +5680,8 @@ static void mini_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19190, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19190), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5656,8 +5691,8 @@ static void mini_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19128, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19128), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5672,8 +5707,8 @@ static void mini_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19192, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19192), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5683,8 +5718,8 @@ static void mini_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19130, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19130), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5703,8 +5738,8 @@ static void mini_rc_track_diag_flat_to_25_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19191, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19191), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5728,8 +5763,8 @@ static void mini_rc_track_diag_flat_to_25_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19129, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19129), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5762,8 +5797,8 @@ static void mini_rc_track_diag_25_deg_up_to_60_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19143, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19143), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5775,8 +5810,8 @@ static void mini_rc_track_diag_25_deg_up_to_60_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19140, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19140), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5788,8 +5823,8 @@ static void mini_rc_track_diag_25_deg_up_to_60_deg_up(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19142, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19142), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5805,8 +5840,8 @@ static void mini_rc_track_diag_25_deg_up_to_60_deg_up(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19141, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19141), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 22, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -5838,8 +5873,8 @@ static void mini_rc_track_diag_60_deg_up_to_25_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19147, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19147), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5851,8 +5886,8 @@ static void mini_rc_track_diag_60_deg_up_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19144, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19144), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5864,8 +5899,8 @@ static void mini_rc_track_diag_60_deg_up_to_25_deg_up(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19146, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19146), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5881,8 +5916,8 @@ static void mini_rc_track_diag_60_deg_up_to_25_deg_up(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19145, { -16, -16, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19145), { -16, -16, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 27, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -5916,8 +5951,8 @@ static void mini_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19197, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19197), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5927,8 +5962,8 @@ static void mini_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19135, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19135), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5943,8 +5978,8 @@ static void mini_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19194, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19194), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5954,8 +5989,8 @@ static void mini_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19132, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19132), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5970,8 +6005,8 @@ static void mini_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19196, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19196), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5981,8 +6016,8 @@ static void mini_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19134, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19134), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6001,8 +6036,8 @@ static void mini_rc_track_diag_25_deg_up_to_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19195, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19195), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 0, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6026,8 +6061,8 @@ static void mini_rc_track_diag_25_deg_up_to_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19133, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19133), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 0, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6062,8 +6097,8 @@ static void mini_rc_track_diag_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19199, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19199), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6073,8 +6108,8 @@ static void mini_rc_track_diag_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19137, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19137), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6089,8 +6124,8 @@ static void mini_rc_track_diag_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19200, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19200), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6100,8 +6135,8 @@ static void mini_rc_track_diag_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19138, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19138), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6116,8 +6151,8 @@ static void mini_rc_track_diag_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19198, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19198), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6127,8 +6162,8 @@ static void mini_rc_track_diag_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19136, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19136), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6147,8 +6182,8 @@ static void mini_rc_track_diag_25_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19201, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19201), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 0, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6172,8 +6207,8 @@ static void mini_rc_track_diag_25_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19139, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19139), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 0, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6206,8 +6241,8 @@ static void mini_rc_track_diag_60_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19149, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19149), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6219,8 +6254,8 @@ static void mini_rc_track_diag_60_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19150, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19150), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6232,8 +6267,8 @@ static void mini_rc_track_diag_60_deg_down(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19148, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19148), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6249,8 +6284,8 @@ static void mini_rc_track_diag_60_deg_down(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19151, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19151), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 34, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -6284,8 +6319,8 @@ static void mini_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19195, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19195), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6295,8 +6330,8 @@ static void mini_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19133, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19133), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6310,8 +6345,8 @@ static void mini_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19196, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19196), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6321,8 +6356,8 @@ static void mini_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19134, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19134), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6336,8 +6371,8 @@ static void mini_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19194, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19194), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6347,8 +6382,8 @@ static void mini_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19132, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19132), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6366,8 +6401,8 @@ static void mini_rc_track_diag_flat_to_25_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19197, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19197), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 0, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6391,8 +6426,8 @@ static void mini_rc_track_diag_flat_to_25_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19135, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19135), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 0, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6426,8 +6461,8 @@ static void mini_rc_track_diag_25_deg_down_to_60_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19145, { -16, -16, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19145), { -16, -16, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6439,8 +6474,8 @@ static void mini_rc_track_diag_25_deg_down_to_60_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19146, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19146), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6452,8 +6487,8 @@ static void mini_rc_track_diag_25_deg_down_to_60_deg_down(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19144, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19144), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6469,8 +6504,8 @@ static void mini_rc_track_diag_25_deg_down_to_60_deg_down(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19147, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19147), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 23, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -6502,8 +6537,8 @@ static void mini_rc_track_diag_60_deg_down_to_25_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19141, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19141), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6515,8 +6550,8 @@ static void mini_rc_track_diag_60_deg_down_to_25_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19142, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19142), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6528,8 +6563,8 @@ static void mini_rc_track_diag_60_deg_down_to_25_deg_down(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19140, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19140), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6545,8 +6580,8 @@ static void mini_rc_track_diag_60_deg_down_to_25_deg_down(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19143, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19143), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -6580,8 +6615,8 @@ static void mini_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19191, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19191), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6591,8 +6626,8 @@ static void mini_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19129, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19129), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6607,8 +6642,8 @@ static void mini_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19192, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19192), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6618,8 +6653,8 @@ static void mini_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19130, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19130), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6634,8 +6669,8 @@ static void mini_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19190, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19190), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6645,8 +6680,8 @@ static void mini_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19128, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19128), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6665,8 +6700,8 @@ static void mini_rc_track_diag_25_deg_down_to_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19193, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19193), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6690,8 +6725,8 @@ static void mini_rc_track_diag_25_deg_down_to_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 19131, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19131), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_FORK_ALT, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6724,8 +6759,8 @@ static void mini_rc_track_diag_flat_to_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19159, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19159), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6737,11 +6772,11 @@ static void mini_rc_track_diag_flat_to_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19156, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19156), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19160, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19160), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6753,8 +6788,8 @@ static void mini_rc_track_diag_flat_to_left_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19158, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19158), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6770,8 +6805,8 @@ static void mini_rc_track_diag_flat_to_left_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19157, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19157), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -6803,8 +6838,8 @@ static void mini_rc_track_diag_flat_to_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19164, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19164), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6816,8 +6851,8 @@ static void mini_rc_track_diag_flat_to_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19161, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19161), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6829,11 +6864,11 @@ static void mini_rc_track_diag_flat_to_right_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19163, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19163), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19165, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19165), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6849,8 +6884,8 @@ static void mini_rc_track_diag_flat_to_right_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19162, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19162), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -6882,8 +6917,8 @@ static void mini_rc_track_diag_left_bank_to_flat(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19162, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19162), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6895,11 +6930,11 @@ static void mini_rc_track_diag_left_bank_to_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19163, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19163), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19165, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19165), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6911,8 +6946,8 @@ static void mini_rc_track_diag_left_bank_to_flat(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19161, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19161), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6928,8 +6963,8 @@ static void mini_rc_track_diag_left_bank_to_flat(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19164, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19164), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -6961,8 +6996,8 @@ static void mini_rc_track_diag_right_bank_to_flat(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19157, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19157), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6974,8 +7009,8 @@ static void mini_rc_track_diag_right_bank_to_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19158, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19158), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -6987,11 +7022,11 @@ static void mini_rc_track_diag_right_bank_to_flat(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19156, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19156), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19160, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19160), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7007,8 +7042,8 @@ static void mini_rc_track_diag_right_bank_to_flat(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19159, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19159), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7040,8 +7075,8 @@ static void mini_rc_track_diag_left_bank_to_25_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19179, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19179), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7053,11 +7088,11 @@ static void mini_rc_track_diag_left_bank_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19176, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19176), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19180, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19180), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7069,8 +7104,8 @@ static void mini_rc_track_diag_left_bank_to_25_deg_up(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19178, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19178), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7086,8 +7121,8 @@ static void mini_rc_track_diag_left_bank_to_25_deg_up(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19177, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19177), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7119,8 +7154,8 @@ static void mini_rc_track_diag_right_bank_to_25_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19184, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19184), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7132,8 +7167,8 @@ static void mini_rc_track_diag_right_bank_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19181, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19181), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7145,11 +7180,11 @@ static void mini_rc_track_diag_right_bank_to_25_deg_up(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19183, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19183), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19185, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19185), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7165,8 +7200,8 @@ static void mini_rc_track_diag_right_bank_to_25_deg_up(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19182, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19182), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7198,8 +7233,8 @@ static void mini_rc_track_diag_25_deg_up_to_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19169, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19169), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7211,11 +7246,11 @@ static void mini_rc_track_diag_25_deg_up_to_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19166, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19166), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19170, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19170), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7227,8 +7262,8 @@ static void mini_rc_track_diag_25_deg_up_to_left_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19168, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19168), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7244,8 +7279,8 @@ static void mini_rc_track_diag_25_deg_up_to_left_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19167, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19167), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7277,8 +7312,8 @@ static void mini_rc_track_diag_25_deg_up_to_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19174, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19174), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7290,8 +7325,8 @@ static void mini_rc_track_diag_25_deg_up_to_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19171, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19171), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7303,11 +7338,11 @@ static void mini_rc_track_diag_25_deg_up_to_right_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19173, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19173), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19175, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19175), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7323,8 +7358,8 @@ static void mini_rc_track_diag_25_deg_up_to_right_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19172, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19172), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7356,8 +7391,8 @@ static void mini_rc_track_diag_left_bank_to_25_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19172, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19172), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7368,11 +7403,11 @@ static void mini_rc_track_diag_left_bank_to_25_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19173, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19173), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19175, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19175), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7383,8 +7418,8 @@ static void mini_rc_track_diag_left_bank_to_25_deg_down(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19171, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19171), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7399,8 +7434,8 @@ static void mini_rc_track_diag_left_bank_to_25_deg_down(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19174, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19174), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7433,8 +7468,8 @@ static void mini_rc_track_diag_right_bank_to_25_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19167, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19167), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7445,8 +7480,8 @@ static void mini_rc_track_diag_right_bank_to_25_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19168, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19168), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7457,11 +7492,11 @@ static void mini_rc_track_diag_right_bank_to_25_deg_down(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19166, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19166), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19170, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19170), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7476,8 +7511,8 @@ static void mini_rc_track_diag_right_bank_to_25_deg_down(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19169, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19169), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7510,8 +7545,8 @@ static void mini_rc_track_diag_25_deg_down_to_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19182, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19182), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7523,11 +7558,11 @@ static void mini_rc_track_diag_25_deg_down_to_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19183, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19183), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19185, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19185), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7539,8 +7574,8 @@ static void mini_rc_track_diag_25_deg_down_to_left_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19181, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19181), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7556,8 +7591,8 @@ static void mini_rc_track_diag_25_deg_down_to_left_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19184, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19184), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7589,8 +7624,8 @@ static void mini_rc_track_diag_25_deg_down_to_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19177, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19177), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7602,8 +7637,8 @@ static void mini_rc_track_diag_25_deg_down_to_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19178, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19178), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7615,11 +7650,11 @@ static void mini_rc_track_diag_25_deg_down_to_right_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19176, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19176), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19180, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19180), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7635,8 +7670,8 @@ static void mini_rc_track_diag_25_deg_down_to_right_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19179, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19179), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7668,8 +7703,8 @@ static void mini_rc_track_diag_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19155, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19155), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7681,8 +7716,8 @@ static void mini_rc_track_diag_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19152, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19152), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7694,8 +7729,8 @@ static void mini_rc_track_diag_left_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19154, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19154), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7711,8 +7746,8 @@ static void mini_rc_track_diag_left_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19153, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19153), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7744,8 +7779,8 @@ static void mini_rc_track_diag_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19153, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19153), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7757,8 +7792,8 @@ static void mini_rc_track_diag_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19154, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19154), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7770,8 +7805,8 @@ static void mini_rc_track_diag_right_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19152, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19152), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7787,8 +7822,8 @@ static void mini_rc_track_diag_right_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19155, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19155), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7815,8 +7850,8 @@ static void mini_rc_track_block_brakes(
 {
     bool isClosed = trackElement.BlockBrakeClosed();
     PaintAddImageAsParentRotated(
-        session, direction, session.TrackColours[SCHEME_TRACK] | _MiniRCBlockBrakeImages[direction][isClosed], { 0, 0, height },
-        { 32, 20, 3 }, { 0, 6, height });
+        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(_MiniRCBlockBrakeImages[direction][isClosed]),
+        { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
     switch (direction)
     {
         case 0:
@@ -7853,26 +7888,29 @@ static void mini_rc_track_left_banked_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19317, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19317), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19319, { 0, 6, height }, { 32, 1, 34 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19319), { 0, 6, height },
+                        { 32, 1, 34 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19321, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19321), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19315, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19315), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7896,27 +7934,29 @@ static void mini_rc_track_left_banked_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19316, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19316), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19318, { 6, 0, height }, { 1, 32, 34 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19318), { 6, 0, height },
+                        { 1, 32, 34 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19320, { 6, 0, height }, { 1, 32, 34 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19320), { 6, 0, height },
+                        { 1, 32, 34 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19314, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19314), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7949,26 +7989,29 @@ static void mini_rc_track_right_banked_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19306, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19306), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19308, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19308), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19310, { 0, 6, height }, { 32, 1, 34 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19310), { 0, 6, height },
+                        { 32, 1, 34 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19312, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19312), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7992,27 +8035,29 @@ static void mini_rc_track_right_banked_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19307, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19307), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19309, { 6, 0, height }, { 1, 32, 34 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19309), { 6, 0, height },
+                        { 1, 32, 34 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19311, { 6, 0, height }, { 1, 32, 34 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19311), { 6, 0, height },
+                        { 1, 32, 34 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19313, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19313), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8064,29 +8109,29 @@ static void mini_rc_track_left_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19286, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19286), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19291, { 0, 0, height }, { 32, 1, 34 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19291), { 0, 0, height },
+                        { 32, 1, 34 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19296, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19296), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19301, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19301), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8107,22 +8152,23 @@ static void mini_rc_track_left_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19287, { 0, 0, height }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19287), { 0, 0, height },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19292, { 0, 0, height }, { 1, 1, 34 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19292), { 0, 0, height }, { 1, 1, 34 },
                         { 30, 30, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19297, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19297), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19302, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19302), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8137,22 +8183,23 @@ static void mini_rc_track_left_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19288, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19288), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19293, { 0, 0, height }, { 1, 1, 34 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19293), { 0, 0, height }, { 1, 1, 34 },
                         { 30, 30, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19298, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19298), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19303, { 0, 0, height }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19303), { 0, 0, height },
+                        { 16, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8167,23 +8214,23 @@ static void mini_rc_track_left_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19289, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19289), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19294, { 0, 0, height }, { 1, 1, 34 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19294), { 0, 0, height }, { 1, 1, 34 },
                         { 30, 30, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19299, { 0, 0, height }, { 1, 32, 34 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19299), { 0, 0, height },
+                        { 1, 32, 34 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19304, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19304), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8198,29 +8245,29 @@ static void mini_rc_track_left_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19290, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19290), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19295, { 0, 0, height }, { 1, 32, 34 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19295), { 0, 0, height },
+                        { 1, 32, 34 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19300, { 0, 0, height }, { 1, 32, 34 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19300), { 0, 0, height },
+                        { 1, 32, 34 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19305, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19305), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8253,29 +8300,29 @@ static void mini_rc_track_right_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19266, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19266), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19271, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19271), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19276, { 0, 0, height }, { 32, 1, 34 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19276), { 0, 0, height },
+                        { 32, 1, 34 }, { 0, 27, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19281, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19281), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8296,22 +8343,23 @@ static void mini_rc_track_right_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19267, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19267), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19272, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19272), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19277, { 0, 0, height }, { 1, 1, 34 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19277), { 0, 0, height }, { 1, 1, 34 },
                         { 30, 30, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19282, { 0, 0, height }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19282), { 0, 0, height },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8326,22 +8374,23 @@ static void mini_rc_track_right_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19268, { 0, 0, height }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19268), { 0, 0, height },
+                        { 16, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19273, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19273), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19278, { 0, 0, height }, { 1, 1, 34 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19278), { 0, 0, height }, { 1, 1, 34 },
                         { 30, 30, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19283, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19283), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8356,23 +8405,23 @@ static void mini_rc_track_right_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19269, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19269), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19274, { 0, 0, height }, { 1, 32, 34 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19274), { 0, 0, height },
+                        { 1, 32, 34 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19279, { 0, 0, height }, { 1, 1, 34 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19279), { 0, 0, height }, { 1, 1, 34 },
                         { 30, 30, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19284, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19284), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8387,29 +8436,29 @@ static void mini_rc_track_right_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19270, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19270), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19275, { 0, 0, height }, { 1, 32, 34 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19275), { 0, 0, height },
+                        { 1, 32, 34 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19280, { 0, 0, height }, { 1, 32, 34 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19280), { 0, 0, height },
+                        { 1, 32, 34 }, { 27, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19285, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19285), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8458,7 +8507,7 @@ static void mini_rc_track_25_deg_up_to_left_banked_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19230, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19230), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -8468,10 +8517,10 @@ static void mini_rc_track_25_deg_up_to_left_banked_25_deg_up(
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19231, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19231), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19238, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19238), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -8481,7 +8530,7 @@ static void mini_rc_track_25_deg_up_to_left_banked_25_deg_up(
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19232, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19232), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -8491,7 +8540,7 @@ static void mini_rc_track_25_deg_up_to_left_banked_25_deg_up(
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19233, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19233), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -8522,7 +8571,7 @@ static void mini_rc_track_25_deg_up_to_right_banked_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19234, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19234), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -8532,7 +8581,7 @@ static void mini_rc_track_25_deg_up_to_right_banked_25_deg_up(
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19235, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19235), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -8542,10 +8591,10 @@ static void mini_rc_track_25_deg_up_to_right_banked_25_deg_up(
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19236, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19236), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19239, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19239), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -8555,7 +8604,7 @@ static void mini_rc_track_25_deg_up_to_right_banked_25_deg_up(
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19237, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19237), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -8586,7 +8635,7 @@ static void mini_rc_track_left_banked_25_deg_up_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19240, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19240), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -8596,10 +8645,10 @@ static void mini_rc_track_left_banked_25_deg_up_to_25_deg_up(
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19241, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19241), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19248, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19248), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -8609,7 +8658,7 @@ static void mini_rc_track_left_banked_25_deg_up_to_25_deg_up(
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19242, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19242), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -8619,7 +8668,7 @@ static void mini_rc_track_left_banked_25_deg_up_to_25_deg_up(
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19243, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19243), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -8650,7 +8699,7 @@ static void mini_rc_track_right_banked_25_deg_up_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19244, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19244), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -8660,7 +8709,7 @@ static void mini_rc_track_right_banked_25_deg_up_to_25_deg_up(
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19245, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19245), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -8670,10 +8719,10 @@ static void mini_rc_track_right_banked_25_deg_up_to_25_deg_up(
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19246, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19246), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19249, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19249), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -8683,7 +8732,7 @@ static void mini_rc_track_right_banked_25_deg_up_to_25_deg_up(
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19247, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19247), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -8746,7 +8795,7 @@ static void mini_rc_track_left_banked_flat_to_left_banked_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19250, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19250), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -8755,7 +8804,7 @@ static void mini_rc_track_left_banked_flat_to_left_banked_25_deg_up(
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19251, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19251), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -8765,7 +8814,7 @@ static void mini_rc_track_left_banked_flat_to_left_banked_25_deg_up(
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19252, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19252), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -8774,7 +8823,7 @@ static void mini_rc_track_left_banked_flat_to_left_banked_25_deg_up(
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19253, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19253), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -8805,7 +8854,7 @@ static void mini_rc_track_right_banked_flat_to_right_banked_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19254, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19254), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -8814,7 +8863,7 @@ static void mini_rc_track_right_banked_flat_to_right_banked_25_deg_up(
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19255, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19255), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -8824,7 +8873,7 @@ static void mini_rc_track_right_banked_flat_to_right_banked_25_deg_up(
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19256, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19256), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -8833,7 +8882,7 @@ static void mini_rc_track_right_banked_flat_to_right_banked_25_deg_up(
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19257, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19257), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -8864,7 +8913,7 @@ static void mini_rc_track_left_banked_25_deg_up_to_left_banked_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19258, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19258), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -8874,7 +8923,7 @@ static void mini_rc_track_left_banked_25_deg_up_to_left_banked_flat(
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19259, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19259), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -8884,7 +8933,7 @@ static void mini_rc_track_left_banked_25_deg_up_to_left_banked_flat(
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19260, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19260), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -8894,7 +8943,7 @@ static void mini_rc_track_left_banked_25_deg_up_to_left_banked_flat(
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19261, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19261), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -8925,7 +8974,7 @@ static void mini_rc_track_right_banked_25_deg_up_to_right_banked_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19262, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19262), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -8935,7 +8984,7 @@ static void mini_rc_track_right_banked_25_deg_up_to_right_banked_flat(
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19263, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19263), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -8945,7 +8994,7 @@ static void mini_rc_track_right_banked_25_deg_up_to_right_banked_flat(
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19264, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19264), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -8955,7 +9004,7 @@ static void mini_rc_track_right_banked_25_deg_up_to_right_banked_flat(
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19265, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19265), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -9022,7 +9071,7 @@ static void mini_rc_track_flat_to_left_banked_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19202, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19202), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -9031,10 +9080,10 @@ static void mini_rc_track_flat_to_left_banked_25_deg_up(
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19203, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19203), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19210, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19210), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -9044,7 +9093,7 @@ static void mini_rc_track_flat_to_left_banked_25_deg_up(
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19204, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19204), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -9053,7 +9102,7 @@ static void mini_rc_track_flat_to_left_banked_25_deg_up(
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19205, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19205), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -9084,7 +9133,7 @@ static void mini_rc_track_flat_to_right_banked_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19206, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19206), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -9093,7 +9142,7 @@ static void mini_rc_track_flat_to_right_banked_25_deg_up(
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19207, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19207), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -9103,10 +9152,10 @@ static void mini_rc_track_flat_to_right_banked_25_deg_up(
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19208, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19208), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19211, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19211), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -9115,7 +9164,7 @@ static void mini_rc_track_flat_to_right_banked_25_deg_up(
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19209, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19209), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -9146,7 +9195,7 @@ static void mini_rc_track_left_banked_25_deg_up_to_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19212, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19212), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -9156,10 +9205,10 @@ static void mini_rc_track_left_banked_25_deg_up_to_flat(
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19213, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19213), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19220, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19220), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -9169,7 +9218,7 @@ static void mini_rc_track_left_banked_25_deg_up_to_flat(
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19214, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19214), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -9179,7 +9228,7 @@ static void mini_rc_track_left_banked_25_deg_up_to_flat(
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19215, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19215), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -9210,7 +9259,7 @@ static void mini_rc_track_right_banked_25_deg_up_to_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19216, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19216), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -9220,7 +9269,7 @@ static void mini_rc_track_right_banked_25_deg_up_to_flat(
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19217, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19217), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -9230,10 +9279,10 @@ static void mini_rc_track_right_banked_25_deg_up_to_flat(
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19218, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19218), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19221, { 0, 0, height }, { 32, 1, 34 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19221), { 0, 0, height }, { 32, 1, 34 },
                 { 0, 27, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -9243,7 +9292,7 @@ static void mini_rc_track_right_banked_25_deg_up_to_flat(
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 19219, { 0, 0, height }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19219), { 0, 0, height }, { 32, 20, 3 },
                 { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -9308,25 +9357,29 @@ static void mini_rc_track_left_curved_lift_hill(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19333, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19333), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19335, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19335), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19337, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19337), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19331, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19331), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -9350,25 +9403,29 @@ static void mini_rc_track_left_curved_lift_hill(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19332, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19332), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 17, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19334, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19334), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 17, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19336, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19336), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 17, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19330, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19330), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 17, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -9400,25 +9457,29 @@ static void mini_rc_track_right_curved_lift_hill(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19322, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19322), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19324, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19324), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19326, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19326), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19328, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19328), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -9442,25 +9503,29 @@ static void mini_rc_track_right_curved_lift_hill(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19323, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19323), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 17, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19325, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19325), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 17, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19327, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19327), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK_ALT, 4, 17, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 19329, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(19329), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_FORK, 4, 17, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -9496,7 +9561,7 @@ static void mini_rc_track_booster(
         case 0:
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | SPR_G2_MINI_RC_BOOSTER_NE_SW,
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(SPR_G2_MINI_RC_BOOSTER_NE_SW),
                 { ne_sw_offsetX, ne_sw_offsetY, height }, { 32, 20, 3 }, { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {
@@ -9506,7 +9571,7 @@ static void mini_rc_track_booster(
         case 1:
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | SPR_G2_MINI_RC_BOOSTER_NW_SE,
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(SPR_G2_MINI_RC_BOOSTER_NW_SE),
                 { nw_se_offsetX, nw_se_offsetY, height }, { 32, 20, 3 }, { 0, 6, height });
             if (track_paint_util_should_paint_supports(session.MapPosition))
             {

--- a/src/openrct2/ride/coaster/MiniSuspendedCoaster.cpp
+++ b/src/openrct2/ride/coaster/MiniSuspendedCoaster.cpp
@@ -30,12 +30,14 @@ static void mini_suspended_rc_track_flat(
             case 0:
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28433, { 0, 6, height + 24 }, { 32, 20, 1 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28433), { 0, 6, height + 24 },
+                    { 32, 20, 1 });
                 break;
             case 1:
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28434, { 0, 6, height + 24 }, { 32, 20, 1 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28434), { 0, 6, height + 24 },
+                    { 32, 20, 1 });
                 break;
         }
     }
@@ -46,12 +48,14 @@ static void mini_suspended_rc_track_flat(
             case 0:
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28383, { 0, 6, height + 24 }, { 32, 20, 1 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28383), { 0, 6, height + 24 },
+                    { 32, 20, 1 });
                 break;
             case 1:
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28384, { 0, 6, height + 24 }, { 32, 20, 1 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28384), { 0, 6, height + 24 },
+                    { 32, 20, 1 });
                 break;
         }
     }
@@ -92,12 +96,13 @@ static void mini_suspended_rc_track_station(
     };
 
     PaintAddImageAsParentRotated(
-        session, direction, imageIds[direction][0] | session.TrackColours[SCHEME_MISC], { 0, 0, height }, { 32, 28, 1 },
-        { 0, 2, height });
+        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][0]), { 0, 0, height },
+        { 32, 28, 1 }, { 0, 2, height });
     PaintAddImageAsParentRotated(
-        session, direction, imageIds[direction][1] | session.TrackColours[SCHEME_TRACK], { 0, 6, height + 24 }, { 32, 20, 1 });
+        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][1]), { 0, 6, height + 24 },
+        { 32, 20, 1 });
     PaintAddImageAsChildRotated(
-        session, direction, imageIds[direction][2] | session.TrackColours[SCHEME_SUPPORTS], { 0, 6, height + 24 },
+        session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(imageIds[direction][2]), { 0, 6, height + 24 },
         { 32, 20, 1 }, { 0, 2, height });
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], 3);
     track_paint_util_draw_station_inverted(session, ride, direction, height, trackElement, STATION_VARIANT_1);
@@ -117,23 +122,23 @@ static void mini_suspended_rc_track_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28435, { 0, 6, height + 24 }, { 32, 20, 1 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28435), { 0, 6, height + 24 },
+                    { 32, 20, 1 }, { 0, 6, height + 40 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28441, { 0, 6, height + 24 }, { 32, 20, 1 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28441), { 0, 6, height + 24 },
+                    { 32, 20, 1 }, { 0, 6, height + 40 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28437, { 0, 6, height + 24 }, { 32, 20, 1 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28437), { 0, 6, height + 24 },
+                    { 32, 20, 1 }, { 0, 6, height + 40 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28442, { 0, 6, height + 24 }, { 32, 20, 1 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28442), { 0, 6, height + 24 },
+                    { 32, 20, 1 }, { 0, 6, height + 40 });
                 break;
         }
     }
@@ -143,23 +148,23 @@ static void mini_suspended_rc_track_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28385, { 0, 6, height + 24 }, { 32, 20, 1 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28385), { 0, 6, height + 24 },
+                    { 32, 20, 1 }, { 0, 6, height + 40 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28391, { 0, 6, height + 24 }, { 32, 20, 1 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28391), { 0, 6, height + 24 },
+                    { 32, 20, 1 }, { 0, 6, height + 40 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28387, { 0, 6, height + 24 }, { 32, 20, 1 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28387), { 0, 6, height + 24 },
+                    { 32, 20, 1 }, { 0, 6, height + 40 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28392, { 0, 6, height + 24 }, { 32, 20, 1 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28392), { 0, 6, height + 24 },
+                    { 32, 20, 1 }, { 0, 6, height + 40 });
                 break;
         }
     }
@@ -211,23 +216,23 @@ static void mini_suspended_rc_track_flat_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28436, { 0, 6, height + 24 }, { 32, 20, 1 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28436), { 0, 6, height + 24 },
+                    { 32, 20, 1 }, { 0, 6, height + 32 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28443, { 0, 6, height + 24 }, { 32, 20, 1 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28443), { 0, 6, height + 24 },
+                    { 32, 20, 1 }, { 0, 6, height + 32 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28438, { 0, 6, height + 24 }, { 32, 20, 1 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28438), { 0, 6, height + 24 },
+                    { 32, 20, 1 }, { 0, 6, height + 32 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28444, { 0, 6, height + 24 }, { 32, 20, 1 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28444), { 0, 6, height + 24 },
+                    { 32, 20, 1 }, { 0, 6, height + 32 });
                 break;
         }
     }
@@ -237,23 +242,23 @@ static void mini_suspended_rc_track_flat_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28386, { 0, 6, height + 24 }, { 32, 20, 1 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28386), { 0, 6, height + 24 },
+                    { 32, 20, 1 }, { 0, 6, height + 32 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28393, { 0, 6, height + 24 }, { 32, 20, 1 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28393), { 0, 6, height + 24 },
+                    { 32, 20, 1 }, { 0, 6, height + 32 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28388, { 0, 6, height + 24 }, { 32, 20, 1 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28388), { 0, 6, height + 24 },
+                    { 32, 20, 1 }, { 0, 6, height + 32 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28394, { 0, 6, height + 24 }, { 32, 20, 1 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28394), { 0, 6, height + 24 },
+                    { 32, 20, 1 }, { 0, 6, height + 32 });
                 break;
         }
     }
@@ -305,23 +310,23 @@ static void mini_suspended_rc_track_25_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28440, { 0, 6, height + 24 }, { 32, 20, 1 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28440), { 0, 6, height + 24 },
+                    { 32, 20, 1 }, { 0, 6, height + 32 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28446, { 0, 6, height + 24 }, { 32, 20, 1 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28446), { 0, 6, height + 24 },
+                    { 32, 20, 1 }, { 0, 6, height + 32 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28439, { 0, 6, height + 24 }, { 32, 20, 1 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28439), { 0, 6, height + 24 },
+                    { 32, 20, 1 }, { 0, 6, height + 32 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28445, { 0, 6, height + 24 }, { 32, 20, 1 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28445), { 0, 6, height + 24 },
+                    { 32, 20, 1 }, { 0, 6, height + 32 });
                 break;
         }
     }
@@ -331,23 +336,23 @@ static void mini_suspended_rc_track_25_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28390, { 0, 6, height + 24 }, { 32, 20, 1 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28390), { 0, 6, height + 24 },
+                    { 32, 20, 1 }, { 0, 6, height + 32 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28396, { 0, 6, height + 24 }, { 32, 20, 1 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28396), { 0, 6, height + 24 },
+                    { 32, 20, 1 }, { 0, 6, height + 32 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28389, { 0, 6, height + 24 }, { 32, 20, 1 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28389), { 0, 6, height + 24 },
+                    { 32, 20, 1 }, { 0, 6, height + 32 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28395, { 0, 6, height + 24 }, { 32, 20, 1 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28395), { 0, 6, height + 24 },
+                    { 32, 20, 1 }, { 0, 6, height + 32 });
                 break;
         }
     }
@@ -424,19 +429,23 @@ static void mini_suspended_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28406, { 0, 6, height + 24 }, { 32, 20, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28406), { 0, 6, height + 24 },
+                        { 32, 20, 1 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28411, { 0, 6, height + 24 }, { 32, 20, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28411), { 0, 6, height + 24 },
+                        { 32, 20, 1 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28416, { 0, 6, height + 24 }, { 32, 20, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28416), { 0, 6, height + 24 },
+                        { 32, 20, 1 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28401, { 0, 6, height + 24 }, { 32, 20, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28401), { 0, 6, height + 24 },
+                        { 32, 20, 1 });
                     break;
             }
 
@@ -471,19 +480,23 @@ static void mini_suspended_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28405, { 0, 0, height + 24 }, { 32, 16, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28405), { 0, 0, height + 24 },
+                        { 32, 16, 1 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28410, { 0, 0, height + 24 }, { 32, 16, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28410), { 0, 0, height + 24 },
+                        { 32, 16, 1 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28415, { 0, 16, height + 24 }, { 32, 16, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28415), { 0, 16, height + 24 },
+                        { 32, 16, 1 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28400, { 0, 16, height + 24 }, { 32, 16, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28400), { 0, 16, height + 24 },
+                        { 32, 16, 1 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -498,19 +511,23 @@ static void mini_suspended_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28404, { 0, 16, height + 24 }, { 16, 16, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28404), { 0, 16, height + 24 },
+                        { 16, 16, 1 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28409, { 16, 16, height + 24 }, { 16, 16, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28409), { 16, 16, height + 24 },
+                        { 16, 16, 1 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28414, { 16, 0, height + 24 }, { 16, 16, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28414), { 16, 0, height + 24 },
+                        { 16, 16, 1 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28399, { 0, 0, height + 24 }, { 16, 16, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28399), { 0, 0, height + 24 },
+                        { 16, 16, 1 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -525,19 +542,23 @@ static void mini_suspended_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28403, { 16, 0, height + 24 }, { 16, 32, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28403), { 16, 0, height + 24 },
+                        { 16, 32, 1 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28408, { 0, 0, height + 24 }, { 16, 32, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28408), { 0, 0, height + 24 },
+                        { 16, 32, 1 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28413, { 0, 0, height + 24 }, { 16, 32, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28413), { 0, 0, height + 24 },
+                        { 16, 32, 1 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28398, { 16, 0, height + 24 }, { 16, 32, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28398), { 16, 0, height + 24 },
+                        { 16, 32, 1 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -552,19 +573,23 @@ static void mini_suspended_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28402, { 6, 0, height + 24 }, { 20, 32, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28402), { 6, 0, height + 24 },
+                        { 20, 32, 1 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28407, { 6, 0, height + 24 }, { 20, 32, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28407), { 6, 0, height + 24 },
+                        { 20, 32, 1 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28412, { 6, 0, height + 24 }, { 20, 32, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28412), { 6, 0, height + 24 },
+                        { 20, 32, 1 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28397, { 6, 0, height + 24 }, { 20, 32, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28397), { 6, 0, height + 24 },
+                        { 20, 32, 1 });
                     break;
             }
 
@@ -620,19 +645,23 @@ static void mini_suspended_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28421, { 0, 6, height + 24 }, { 32, 20, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28421), { 0, 6, height + 24 },
+                        { 32, 20, 1 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28428, { 0, 6, height + 24 }, { 32, 20, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28428), { 0, 6, height + 24 },
+                        { 32, 20, 1 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28424, { 0, 6, height + 24 }, { 32, 20, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28424), { 0, 6, height + 24 },
+                        { 32, 20, 1 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28425, { 0, 6, height + 24 }, { 32, 20, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28425), { 0, 6, height + 24 },
+                        { 32, 20, 1 });
                     break;
             }
 
@@ -663,19 +692,23 @@ static void mini_suspended_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28422, { 0, 0, height + 24 }, { 32, 26, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28422), { 0, 0, height + 24 },
+                        { 32, 26, 1 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28427, { 0, 0, height + 24 }, { 32, 26, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28427), { 0, 0, height + 24 },
+                        { 32, 26, 1 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28423, { 0, 6, height + 24 }, { 32, 26, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28423), { 0, 6, height + 24 },
+                        { 32, 26, 1 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28426, { 0, 6, height + 24 }, { 32, 26, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28426), { 0, 6, height + 24 },
+                        { 32, 26, 1 });
                     break;
             }
 
@@ -703,19 +736,23 @@ static void mini_suspended_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28423, { 0, 6, height + 24 }, { 32, 26, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28423), { 0, 6, height + 24 },
+                        { 32, 26, 1 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28426, { 0, 6, height + 24 }, { 32, 26, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28426), { 0, 6, height + 24 },
+                        { 32, 26, 1 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28422, { 0, 0, height + 24 }, { 32, 26, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28422), { 0, 0, height + 24 },
+                        { 32, 26, 1 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28427, { 0, 0, height + 24 }, { 32, 26, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28427), { 0, 0, height + 24 },
+                        { 32, 26, 1 });
                     break;
             }
 
@@ -743,19 +780,23 @@ static void mini_suspended_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28424, { 0, 6, height + 24 }, { 32, 20, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28424), { 0, 6, height + 24 },
+                        { 32, 20, 1 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28425, { 0, 6, height + 24 }, { 32, 20, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28425), { 0, 6, height + 24 },
+                        { 32, 20, 1 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28421, { 0, 6, height + 24 }, { 32, 20, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28421), { 0, 6, height + 24 },
+                        { 32, 20, 1 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28428, { 0, 6, height + 24 }, { 32, 20, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28428), { 0, 6, height + 24 },
+                        { 32, 20, 1 });
                     break;
             }
 
@@ -801,19 +842,23 @@ static void mini_suspended_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28417, { 0, 6, height + 24 }, { 32, 20, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28417), { 0, 6, height + 24 },
+                        { 32, 20, 1 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28432, { 0, 6, height + 24 }, { 32, 20, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28432), { 0, 6, height + 24 },
+                        { 32, 20, 1 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28420, { 0, 6, height + 24 }, { 32, 20, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28420), { 0, 6, height + 24 },
+                        { 32, 20, 1 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28429, { 0, 6, height + 24 }, { 32, 20, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28429), { 0, 6, height + 24 },
+                        { 32, 20, 1 });
                     break;
             }
 
@@ -844,19 +889,23 @@ static void mini_suspended_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28418, { 0, 6, height + 24 }, { 32, 26, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28418), { 0, 6, height + 24 },
+                        { 32, 26, 1 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28431, { 0, 6, height + 24 }, { 32, 26, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28431), { 0, 6, height + 24 },
+                        { 32, 26, 1 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28419, { 0, 0, height + 24 }, { 32, 26, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28419), { 0, 0, height + 24 },
+                        { 32, 26, 1 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28430, { 0, 0, height + 24 }, { 32, 26, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28430), { 0, 0, height + 24 },
+                        { 32, 26, 1 });
                     break;
             }
 
@@ -884,19 +933,23 @@ static void mini_suspended_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28419, { 0, 0, height + 24 }, { 32, 26, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28419), { 0, 0, height + 24 },
+                        { 32, 26, 1 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28430, { 0, 0, height + 24 }, { 32, 26, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28430), { 0, 0, height + 24 },
+                        { 32, 26, 1 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28418, { 0, 6, height + 24 }, { 32, 26, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28418), { 0, 6, height + 24 },
+                        { 32, 26, 1 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28431, { 0, 6, height + 24 }, { 32, 26, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28431), { 0, 6, height + 24 },
+                        { 32, 26, 1 });
                     break;
             }
 
@@ -924,19 +977,23 @@ static void mini_suspended_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28420, { 0, 6, height + 24 }, { 32, 20, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28420), { 0, 6, height + 24 },
+                        { 32, 20, 1 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28429, { 0, 6, height + 24 }, { 32, 20, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28429), { 0, 6, height + 24 },
+                        { 32, 20, 1 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28417, { 0, 6, height + 24 }, { 32, 20, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28417), { 0, 6, height + 24 },
+                        { 32, 20, 1 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28432, { 0, 6, height + 24 }, { 32, 20, 1 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28432), { 0, 6, height + 24 },
+                        { 32, 20, 1 });
                     break;
             }
 
@@ -982,19 +1039,23 @@ static void mini_suspended_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28452, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28452), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28455, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28455), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28458, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28458), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28449, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28449), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
             }
 
@@ -1029,19 +1090,23 @@ static void mini_suspended_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28451, { 16, 0, height + 24 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28451), { 16, 0, height + 24 },
+                        { 16, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28454, { 0, 0, height + 24 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28454), { 0, 0, height + 24 },
+                        { 16, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28457, { 0, 16, height + 24 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28457), { 0, 16, height + 24 },
+                        { 16, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28448, { 16, 16, height + 24 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28448), { 16, 16, height + 24 },
+                        { 16, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1053,19 +1118,23 @@ static void mini_suspended_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28450, { 6, 0, height + 24 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28450), { 6, 0, height + 24 },
+                        { 20, 32, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28453, { 6, 0, height + 24 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28453), { 6, 0, height + 24 },
+                        { 20, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28456, { 6, 0, height + 24 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28456), { 6, 0, height + 24 },
+                        { 20, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28447, { 6, 0, height + 24 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28447), { 6, 0, height + 24 },
+                        { 20, 32, 3 });
                     break;
             }
 
@@ -1121,23 +1190,23 @@ static void mini_suspended_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28475, { 0, 0, height + 24 }, { 32, 20, 1 },
-                        { 0, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28475), { 0, 0, height + 24 },
+                        { 32, 20, 1 }, { 0, 6, height + 24 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28479, { 0, 0, height + 24 }, { 32, 20, 1 },
-                        { 0, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28479), { 0, 0, height + 24 },
+                        { 32, 20, 1 }, { 0, 6, height + 24 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28483, { 0, 0, height + 24 }, { 32, 20, 1 },
-                        { 0, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28483), { 0, 0, height + 24 },
+                        { 32, 20, 1 }, { 0, 6, height + 24 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28487, { 0, 0, height + 24 }, { 32, 20, 1 },
-                        { 0, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28487), { 0, 0, height + 24 },
+                        { 32, 20, 1 }, { 0, 6, height + 24 });
                     break;
             }
 
@@ -1168,23 +1237,23 @@ static void mini_suspended_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28476, { 0, 0, height + 24 }, { 32, 16, 1 },
-                        { 0, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28476), { 0, 0, height + 24 },
+                        { 32, 16, 1 }, { 0, 0, height + 24 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28480, { 0, 0, height + 24 }, { 34, 16, 1 },
-                        { 0, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28480), { 0, 0, height + 24 },
+                        { 34, 16, 1 }, { 0, 0, height + 24 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28484, { 0, 0, height + 24 }, { 32, 16, 1 },
-                        { 0, 16, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28484), { 0, 0, height + 24 },
+                        { 32, 16, 1 }, { 0, 16, height + 24 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28488, { 0, 0, height + 24 }, { 32, 16, 1 },
-                        { 0, 16, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28488), { 0, 0, height + 24 },
+                        { 32, 16, 1 }, { 0, 16, height + 24 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1199,23 +1268,23 @@ static void mini_suspended_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28477, { 0, 0, height + 24 }, { 16, 16, 1 },
-                        { 0, 16, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28477), { 0, 0, height + 24 },
+                        { 16, 16, 1 }, { 0, 16, height + 24 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28481, { 0, 0, height + 24 }, { 16, 16, 1 },
-                        { 16, 16, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28481), { 0, 0, height + 24 },
+                        { 16, 16, 1 }, { 16, 16, height + 24 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28485, { 0, 0, height + 24 }, { 16, 16, 1 },
-                        { 16, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28485), { 0, 0, height + 24 },
+                        { 16, 16, 1 }, { 16, 0, height + 24 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28489, { 0, 0, height + 24 }, { 16, 16, 1 },
-                        { 0, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28489), { 0, 0, height + 24 },
+                        { 16, 16, 1 }, { 0, 0, height + 24 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1233,23 +1302,23 @@ static void mini_suspended_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28478, { 0, 0, height + 24 }, { 16, 16, 1 },
-                        { 16, 16, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28478), { 0, 0, height + 24 },
+                        { 16, 16, 1 }, { 16, 16, height + 24 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28482, { 0, 0, height + 24 }, { 16, 18, 1 },
-                        { 0, 16, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28482), { 0, 0, height + 24 },
+                        { 16, 18, 1 }, { 0, 16, height + 24 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28486, { 0, 0, height + 24 }, { 16, 16, 1 },
-                        { 0, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28486), { 0, 0, height + 24 },
+                        { 16, 16, 1 }, { 0, 0, height + 24 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28490, { 0, 0, height + 24 }, { 16, 16, 1 },
-                        { 16, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28490), { 0, 0, height + 24 },
+                        { 16, 16, 1 }, { 16, 0, height + 24 });
                     break;
             }
 
@@ -1295,23 +1364,23 @@ static void mini_suspended_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28459, { 0, 0, height + 24 }, { 32, 20, 1 },
-                        { 0, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28459), { 0, 0, height + 24 },
+                        { 32, 20, 1 }, { 0, 6, height + 24 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28463, { 0, 0, height + 24 }, { 32, 20, 1 },
-                        { 0, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28463), { 0, 0, height + 24 },
+                        { 32, 20, 1 }, { 0, 6, height + 24 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28467, { 0, 0, height + 24 }, { 32, 20, 1 },
-                        { 0, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28467), { 0, 0, height + 24 },
+                        { 32, 20, 1 }, { 0, 6, height + 24 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28471, { 0, 0, height + 24 }, { 32, 20, 1 },
-                        { 0, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28471), { 0, 0, height + 24 },
+                        { 32, 20, 1 }, { 0, 6, height + 24 });
                     break;
             }
 
@@ -1342,23 +1411,23 @@ static void mini_suspended_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28460, { 0, 0, height + 24 }, { 32, 16, 1 },
-                        { 0, 16, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28460), { 0, 0, height + 24 },
+                        { 32, 16, 1 }, { 0, 16, height + 24 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28464, { 0, 0, height + 24 }, { 32, 16, 1 },
-                        { 0, 16, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28464), { 0, 0, height + 24 },
+                        { 32, 16, 1 }, { 0, 16, height + 24 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28468, { 0, 0, height + 24 }, { 34, 16, 1 },
-                        { 0, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28468), { 0, 0, height + 24 },
+                        { 34, 16, 1 }, { 0, 0, height + 24 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28472, { 0, 0, height + 24 }, { 32, 16, 1 },
-                        { 0, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28472), { 0, 0, height + 24 },
+                        { 32, 16, 1 }, { 0, 0, height + 24 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1373,23 +1442,23 @@ static void mini_suspended_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28461, { 0, 0, height + 24 }, { 16, 16, 1 },
-                        { 0, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28461), { 0, 0, height + 24 },
+                        { 16, 16, 1 }, { 0, 0, height + 24 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28465, { 0, 0, height + 24 }, { 16, 16, 1 },
-                        { 16, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28465), { 0, 0, height + 24 },
+                        { 16, 16, 1 }, { 16, 0, height + 24 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28469, { 0, 0, height + 24 }, { 28, 28, 1 },
-                        { 4, 2, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28469), { 0, 0, height + 24 },
+                        { 28, 28, 1 }, { 4, 2, height + 24 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28473, { 0, 0, height + 24 }, { 16, 16, 1 },
-                        { 0, 16, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28473), { 0, 0, height + 24 },
+                        { 16, 16, 1 }, { 0, 16, height + 24 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1407,23 +1476,23 @@ static void mini_suspended_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28462, { 0, 0, height + 24 }, { 16, 16, 1 },
-                        { 16, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28462), { 0, 0, height + 24 },
+                        { 16, 16, 1 }, { 16, 0, height + 24 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28466, { 0, 0, height + 24 }, { 16, 16, 1 },
-                        { 0, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28466), { 0, 0, height + 24 },
+                        { 16, 16, 1 }, { 0, 0, height + 24 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28470, { 0, 0, height + 24 }, { 16, 18, 1 },
-                        { 0, 16, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28470), { 0, 0, height + 24 },
+                        { 16, 18, 1 }, { 0, 16, height + 24 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28474, { 0, 0, height + 24 }, { 16, 16, 1 },
-                        { 16, 16, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28474), { 0, 0, height + 24 },
+                        { 16, 16, 1 }, { 16, 16, height + 24 });
                     break;
             }
 
@@ -1489,7 +1558,7 @@ static void mini_suspended_rc_track_diag_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28510, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28510), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 24 });
                         break;
                 }
@@ -1500,7 +1569,7 @@ static void mini_suspended_rc_track_diag_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28494, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28494), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 24 });
                         break;
                 }
@@ -1516,7 +1585,7 @@ static void mini_suspended_rc_track_diag_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28507, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28507), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 24 });
                         break;
                 }
@@ -1527,7 +1596,7 @@ static void mini_suspended_rc_track_diag_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28491, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28491), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 24 });
                         break;
                 }
@@ -1543,7 +1612,7 @@ static void mini_suspended_rc_track_diag_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28509, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28509), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 24 });
                         break;
                 }
@@ -1554,7 +1623,7 @@ static void mini_suspended_rc_track_diag_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28493, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28493), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 24 });
                         break;
                 }
@@ -1570,7 +1639,7 @@ static void mini_suspended_rc_track_diag_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28508, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28508), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 24 });
                         break;
                 }
@@ -1581,7 +1650,7 @@ static void mini_suspended_rc_track_diag_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28492, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28492), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 24 });
                         break;
                 }
@@ -1628,7 +1697,7 @@ static void mini_suspended_rc_track_diag_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28522, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28522), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 40 });
                         break;
                 }
@@ -1639,7 +1708,7 @@ static void mini_suspended_rc_track_diag_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28506, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28506), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 40 });
                         break;
                 }
@@ -1655,7 +1724,7 @@ static void mini_suspended_rc_track_diag_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28519, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28519), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 40 });
                         break;
                 }
@@ -1666,7 +1735,7 @@ static void mini_suspended_rc_track_diag_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28503, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28503), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 40 });
                         break;
                 }
@@ -1682,7 +1751,7 @@ static void mini_suspended_rc_track_diag_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28521, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28521), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 40 });
                         break;
                 }
@@ -1693,7 +1762,7 @@ static void mini_suspended_rc_track_diag_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28505, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28505), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 40 });
                         break;
                 }
@@ -1709,7 +1778,7 @@ static void mini_suspended_rc_track_diag_25_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28520, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28520), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 40 });
                         break;
                 }
@@ -1720,7 +1789,7 @@ static void mini_suspended_rc_track_diag_25_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28504, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28504), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 40 });
                         break;
                 }
@@ -1767,7 +1836,7 @@ static void mini_suspended_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28514, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28514), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -1778,7 +1847,7 @@ static void mini_suspended_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28498, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28498), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -1794,7 +1863,7 @@ static void mini_suspended_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28511, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28511), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -1805,7 +1874,7 @@ static void mini_suspended_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28495, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28495), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -1821,7 +1890,7 @@ static void mini_suspended_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28513, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28513), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -1832,7 +1901,7 @@ static void mini_suspended_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28497, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28497), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -1848,7 +1917,7 @@ static void mini_suspended_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28512, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28512), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -1859,7 +1928,7 @@ static void mini_suspended_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28496, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28496), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -1906,7 +1975,7 @@ static void mini_suspended_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28518, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28518), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -1917,7 +1986,7 @@ static void mini_suspended_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28502, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28502), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -1933,7 +2002,7 @@ static void mini_suspended_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28515, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28515), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -1944,7 +2013,7 @@ static void mini_suspended_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28499, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28499), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -1960,7 +2029,7 @@ static void mini_suspended_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28517, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28517), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -1971,7 +2040,7 @@ static void mini_suspended_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28501, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28501), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -1987,7 +2056,7 @@ static void mini_suspended_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28516, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28516), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -1998,7 +2067,7 @@ static void mini_suspended_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28500, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28500), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -2045,7 +2114,7 @@ static void mini_suspended_rc_track_diag_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28520, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28520), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 40 });
                         break;
                 }
@@ -2056,7 +2125,7 @@ static void mini_suspended_rc_track_diag_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28504, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28504), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 40 });
                         break;
                 }
@@ -2072,7 +2141,7 @@ static void mini_suspended_rc_track_diag_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28521, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28521), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 40 });
                         break;
                 }
@@ -2083,7 +2152,7 @@ static void mini_suspended_rc_track_diag_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28505, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28505), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 40 });
                         break;
                 }
@@ -2099,7 +2168,7 @@ static void mini_suspended_rc_track_diag_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28519, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28519), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 40 });
                         break;
                 }
@@ -2110,7 +2179,7 @@ static void mini_suspended_rc_track_diag_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28503, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28503), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 40 });
                         break;
                 }
@@ -2126,7 +2195,7 @@ static void mini_suspended_rc_track_diag_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28522, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28522), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 40 });
                         break;
                 }
@@ -2137,7 +2206,7 @@ static void mini_suspended_rc_track_diag_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28506, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28506), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 40 });
                         break;
                 }
@@ -2184,7 +2253,7 @@ static void mini_suspended_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28516, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28516), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -2195,7 +2264,7 @@ static void mini_suspended_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28500, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28500), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -2210,7 +2279,7 @@ static void mini_suspended_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28517, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28517), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -2221,7 +2290,7 @@ static void mini_suspended_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28501, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28501), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -2236,7 +2305,7 @@ static void mini_suspended_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28515, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28515), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -2247,7 +2316,7 @@ static void mini_suspended_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28499, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28499), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -2262,7 +2331,7 @@ static void mini_suspended_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28518, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28518), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -2273,7 +2342,7 @@ static void mini_suspended_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28502, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28502), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -2320,7 +2389,7 @@ static void mini_suspended_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28512, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28512), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -2331,7 +2400,7 @@ static void mini_suspended_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28496, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28496), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -2347,7 +2416,7 @@ static void mini_suspended_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28513, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28513), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -2358,7 +2427,7 @@ static void mini_suspended_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28497, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28497), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -2374,7 +2443,7 @@ static void mini_suspended_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28511, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28511), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -2385,7 +2454,7 @@ static void mini_suspended_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28495, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28495), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -2401,7 +2470,7 @@ static void mini_suspended_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28514, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28514), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -2412,7 +2481,7 @@ static void mini_suspended_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28498, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28498), { -16, -16, height + 24 },
                             { 32, 32, 1 }, { -16, -16, height + 32 });
                         break;
                 }

--- a/src/openrct2/ride/coaster/MultiDimensionRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/MultiDimensionRollerCoaster.cpp
@@ -47,14 +47,14 @@ static void multi_dimension_rc_track_flat(
                 case 0:
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15808, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15808), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15809, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15809), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -70,14 +70,14 @@ static void multi_dimension_rc_track_flat(
                 case 0:
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15806, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15806), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15807, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15807), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -97,14 +97,14 @@ static void multi_dimension_rc_track_flat(
             case 0:
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26227, { 0, 0, height + 24 }, { 32, 20, 1 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26227), { 0, 0, height + 24 },
+                    { 32, 20, 1 }, { 0, 6, height + 22 });
                 break;
             case 1:
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26228, { 0, 0, height + 24 }, { 32, 20, 1 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26228), { 0, 0, height + 24 },
+                    { 32, 20, 1 }, { 0, 6, height + 22 });
                 break;
         }
 
@@ -138,14 +138,14 @@ static void multi_dimension_rc_track_station(
         bool isClosed = trackElement.BlockBrakeClosed();
         uint8_t offset = isClosed ? 2 : 1;
         PaintAddImageAsParentRotated(
-            session, direction, imageIds[direction][offset] | session.TrackColours[SCHEME_TRACK], { 0, 0, height },
+            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][offset]), { 0, 0, height },
             { 32, 26, 1 }, { 0, 3, height + 3 });
     }
     else
     {
         PaintAddImageAsParentRotated(
-            session, direction, imageIds[direction][0] | session.TrackColours[SCHEME_TRACK], { 0, 0, height }, { 32, 26, 1 },
-            { 0, 3, height + 3 });
+            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]), { 0, 0, height },
+            { 32, 26, 1 }, { 0, 3, height + 3 });
     }
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], 11);
 
@@ -191,23 +191,23 @@ static void multi_dimension_rc_track_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15908, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15908), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15909, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15909), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15910, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15910), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15911, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15911), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -222,23 +222,23 @@ static void multi_dimension_rc_track_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15880, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15880), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15881, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15881), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15882, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15882), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15883, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15883), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -264,23 +264,23 @@ static void multi_dimension_rc_track_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26253, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26253), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 40 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26254, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26254), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 40 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26255, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26255), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 40 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26256, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 40 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26256), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 40 });
                 break;
         }
 
@@ -332,22 +332,22 @@ static void multi_dimension_rc_track_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15896, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15896), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15897, { 0, 0, height }, { 32, 1, 98 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15897), { 0, 0, height }, { 32, 1, 98 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15898, { 0, 0, height }, { 32, 1, 98 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15898), { 0, 0, height }, { 32, 1, 98 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15899, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15899), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -373,23 +373,23 @@ static void multi_dimension_rc_track_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26269, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 88 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26269), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 88 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26270, { 0, 0, height + 24 }, { 32, 2, 81 },
-                    { 0, 4, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26270), { 0, 0, height + 24 },
+                    { 32, 2, 81 }, { 0, 4, height + 6 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26271, { 0, 0, height + 24 }, { 32, 2, 81 },
-                    { 0, 4, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26271), { 0, 0, height + 24 },
+                    { 32, 2, 81 }, { 0, 4, height + 6 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26272, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 88 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26272), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 88 });
                 break;
         }
         if (direction == 0 || direction == 3)
@@ -419,23 +419,23 @@ static void multi_dimension_rc_track_flat_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15900, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15900), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15901, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15901), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15902, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15902), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15903, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15903), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -450,23 +450,23 @@ static void multi_dimension_rc_track_flat_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15872, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15872), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15873, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15873), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15874, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15874), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15875, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15875), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -492,23 +492,23 @@ static void multi_dimension_rc_track_flat_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26245, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26245), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26246, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26246), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26247, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26247), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26248, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26248), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
         }
 
@@ -560,28 +560,28 @@ static void multi_dimension_rc_track_25_deg_up_to_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15884, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15884), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15885, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15885), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15888, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15888), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15886, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15886), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15889, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15889), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15887, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15887), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -607,29 +607,29 @@ static void multi_dimension_rc_track_25_deg_up_to_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26257, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 56 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26257), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 56 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26261, { 0, 0, height + 24 }, { 32, 10, 49 },
-                    { 0, 10, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26261), { 0, 0, height + 24 },
+                    { 32, 10, 49 }, { 0, 10, height + 6 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26258, { 0, 0, height + 24 }, { 32, 2, 49 },
-                    { 0, 4, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26258), { 0, 0, height + 24 },
+                    { 32, 2, 49 }, { 0, 4, height + 6 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26262, { 0, 0, height + 24 }, { 32, 10, 49 },
-                    { 0, 10, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26262), { 0, 0, height + 24 },
+                    { 32, 10, 49 }, { 0, 10, height + 6 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26259, { 0, 0, height + 24 }, { 32, 2, 49 },
-                    { 0, 4, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26259), { 0, 0, height + 24 },
+                    { 32, 2, 49 }, { 0, 4, height + 6 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26260, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 56 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26260), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 56 });
                 break;
         }
         if (direction == 0 || direction == 3)
@@ -657,28 +657,28 @@ static void multi_dimension_rc_track_60_deg_up_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15890, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15890), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15891, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15891), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15894, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15894), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15892, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15892), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15895, { 0, 0, height }, { 32, 1, 66 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15895), { 0, 0, height }, { 32, 1, 66 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15893, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15893), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -704,29 +704,29 @@ static void multi_dimension_rc_track_60_deg_up_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26263, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 56 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26263), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 56 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26267, { 0, 0, height + 24 }, { 32, 10, 49 },
-                    { 0, 10, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26267), { 0, 0, height + 24 },
+                    { 32, 10, 49 }, { 0, 10, height + 6 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26264, { 0, 0, height + 24 }, { 32, 2, 49 },
-                    { 0, 4, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26264), { 0, 0, height + 24 },
+                    { 32, 2, 49 }, { 0, 4, height + 6 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26268, { 0, 0, height + 24 }, { 32, 10, 49 },
-                    { 0, 10, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26268), { 0, 0, height + 24 },
+                    { 32, 10, 49 }, { 0, 10, height + 6 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26265, { 0, 0, height + 24 }, { 32, 2, 49 },
-                    { 0, 4, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26265), { 0, 0, height + 24 },
+                    { 32, 2, 49 }, { 0, 4, height + 6 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26266, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 56 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26266), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 56 });
                 break;
         }
 
@@ -780,23 +780,23 @@ static void multi_dimension_rc_track_25_deg_up_to_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15904, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15904), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15905, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15905), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15906, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15906), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15907, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15907), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -811,23 +811,23 @@ static void multi_dimension_rc_track_25_deg_up_to_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15876, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15876), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15877, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15877), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15878, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15878), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 15879, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15879), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -853,23 +853,23 @@ static void multi_dimension_rc_track_25_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26249, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26249), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26250, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26250), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26251, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26251), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26252, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26252), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
         }
 
@@ -972,23 +972,23 @@ static void multi_dimension_rc_track_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15921, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15921), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15926, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15926), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15931, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15931), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15916, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15916), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -1008,23 +1008,23 @@ static void multi_dimension_rc_track_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15920, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15920), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15925, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15925), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15930, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15930), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15915, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15915), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -1039,23 +1039,23 @@ static void multi_dimension_rc_track_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15919, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15919), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15924, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15924), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 16, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15929, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15929), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15914, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15914), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -1071,23 +1071,23 @@ static void multi_dimension_rc_track_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15918, { 0, 0, height }, { 16, 32, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15918), { 0, 0, height },
+                            { 16, 32, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15923, { 0, 0, height }, { 16, 32, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15923), { 0, 0, height },
+                            { 16, 32, 3 }, { 0, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15928, { 0, 0, height }, { 16, 32, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15928), { 0, 0, height },
+                            { 16, 32, 3 }, { 0, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15913, { 0, 0, height }, { 16, 32, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15913), { 0, 0, height },
+                            { 16, 32, 3 }, { 16, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -1102,23 +1102,23 @@ static void multi_dimension_rc_track_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15917, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15917), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15922, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15922), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15927, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15927), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15912, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15912), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -1148,22 +1148,22 @@ static void multi_dimension_rc_track_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26310, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26310), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26315, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26315), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26320, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26320), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26305, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26305), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                 }
@@ -1189,22 +1189,22 @@ static void multi_dimension_rc_track_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26309, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26309), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26314, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26314), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26319, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26319), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 16, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26304, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26304), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 16, height + 22 });
                         break;
                 }
@@ -1220,22 +1220,22 @@ static void multi_dimension_rc_track_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26308, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26308), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 16, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26313, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26313), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 16, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26318, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26318), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 0, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26303, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26303), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 0, height + 22 });
                         break;
                 }
@@ -1252,22 +1252,22 @@ static void multi_dimension_rc_track_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26307, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26307), { 0, 0, height + 24 },
                             { 16, 32, 3 }, { 16, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26312, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26312), { 0, 0, height + 24 },
                             { 16, 32, 3 }, { 0, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26317, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26317), { 0, 0, height + 24 },
                             { 16, 32, 3 }, { 0, 0, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26302, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26302), { 0, 0, height + 24 },
                             { 16, 32, 3 }, { 16, 0, height + 22 });
                         break;
                 }
@@ -1283,22 +1283,22 @@ static void multi_dimension_rc_track_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26306, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26306), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26311, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26311), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26316, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26316), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26301, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26301), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 22 });
                         break;
                 }
@@ -1345,28 +1345,28 @@ static void multi_dimension_rc_track_flat_to_left_bank(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15832, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15832), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15840, { 0, 0, height }, { 32, 1, 26 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15840), { 0, 0, height }, { 32, 1, 26 },
                     { 0, 27, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15833, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15833), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15841, { 0, 0, height }, { 32, 1, 26 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15841), { 0, 0, height }, { 32, 1, 26 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15834, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15834), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15835, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15835), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -1385,23 +1385,23 @@ static void multi_dimension_rc_track_flat_to_left_bank(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26273, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26273), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26274, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26274), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26275, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26275), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26276, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26276), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
         }
 
@@ -1431,28 +1431,28 @@ static void multi_dimension_rc_track_flat_to_right_bank(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15836, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15836), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15837, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15837), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15838, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15838), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15842, { 0, 0, height }, { 32, 1, 26 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15842), { 0, 0, height }, { 32, 1, 26 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15839, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15839), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15843, { 0, 0, height }, { 32, 1, 26 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15843), { 0, 0, height }, { 32, 1, 26 },
                     { 0, 27, height });
                 break;
         }
@@ -1471,23 +1471,23 @@ static void multi_dimension_rc_track_flat_to_right_bank(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26277, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26277), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26278, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26278), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26279, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26279), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26280, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26280), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
         }
 
@@ -1517,28 +1517,28 @@ static void multi_dimension_rc_track_left_bank_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15838, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15838), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15842, { 0, 0, height }, { 32, 1, 26 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15842), { 0, 0, height }, { 32, 1, 26 },
                     { 0, 27, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15839, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15839), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15843, { 0, 0, height }, { 32, 1, 26 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15843), { 0, 0, height }, { 32, 1, 26 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15836, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15836), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15837, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15837), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -1557,23 +1557,23 @@ static void multi_dimension_rc_track_left_bank_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26279, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26279), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26280, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26280), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26277, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26277), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26278, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26278), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
         }
 
@@ -1603,28 +1603,28 @@ static void multi_dimension_rc_track_right_bank_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15834, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15834), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15835, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15835), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15832, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15832), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15840, { 0, 0, height }, { 32, 1, 26 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15840), { 0, 0, height }, { 32, 1, 26 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15833, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15833), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15841, { 0, 0, height }, { 32, 1, 26 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15841), { 0, 0, height }, { 32, 1, 26 },
                     { 0, 27, height });
                 break;
         }
@@ -1643,23 +1643,23 @@ static void multi_dimension_rc_track_right_bank_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26275, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26275), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26276, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26276), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26273, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26273), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26274, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26274), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
         }
 
@@ -1692,26 +1692,26 @@ static void multi_dimension_rc_track_banked_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15941, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15941), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15952, { 0, 0, height }, { 32, 1, 26 },
-                            { 0, 27, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15952), { 0, 0, height },
+                            { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15946, { 0, 0, height }, { 32, 1, 26 },
-                            { 0, 27, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15946), { 0, 0, height },
+                            { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15951, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15951), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15936, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15936), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -1731,23 +1731,23 @@ static void multi_dimension_rc_track_banked_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15940, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15940), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15945, { 0, 0, height }, { 32, 16, 1 },
-                            { 0, 0, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15945), { 0, 0, height },
+                            { 32, 16, 1 }, { 0, 0, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15950, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15950), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15935, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15935), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -1762,23 +1762,23 @@ static void multi_dimension_rc_track_banked_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15939, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15939), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15944, { 0, 0, height }, { 16, 16, 1 },
-                            { 16, 16, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15944), { 0, 0, height },
+                            { 16, 16, 1 }, { 16, 16, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15949, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15949), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15934, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15934), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -1794,23 +1794,23 @@ static void multi_dimension_rc_track_banked_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15938, { 0, 0, height }, { 16, 32, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15938), { 0, 0, height },
+                            { 16, 32, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15943, { 0, 0, height }, { 16, 32, 1 },
-                            { 0, 0, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15943), { 0, 0, height },
+                            { 16, 32, 1 }, { 0, 0, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15948, { 0, 0, height }, { 16, 32, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15948), { 0, 0, height },
+                            { 16, 32, 3 }, { 0, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15933, { 0, 0, height }, { 16, 32, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15933), { 0, 0, height },
+                            { 16, 32, 3 }, { 16, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -1825,26 +1825,26 @@ static void multi_dimension_rc_track_banked_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15937, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15937), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15942, { 0, 0, height }, { 1, 32, 26 },
-                            { 27, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15942), { 0, 0, height },
+                            { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15947, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15947), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15953, { 0, 0, height }, { 1, 32, 26 },
-                            { 27, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15953), { 0, 0, height },
+                            { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15932, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15932), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -1874,22 +1874,22 @@ static void multi_dimension_rc_track_banked_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26354, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26354), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 24 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26359, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26359), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 24 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26364, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26364), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 24 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26349, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26349), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 24 });
                         break;
                 }
@@ -1915,22 +1915,22 @@ static void multi_dimension_rc_track_banked_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26353, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26353), { 0, 0, height + 24 },
                             { 32, 16, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26358, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26358), { 0, 0, height + 24 },
                             { 32, 16, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26363, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26363), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 16, height + 24 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26348, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26348), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 16, height + 24 });
                         break;
                 }
@@ -1946,22 +1946,22 @@ static void multi_dimension_rc_track_banked_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26352, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26352), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 16, height + 24 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26357, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26357), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 16, height + 24 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26362, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26362), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 0, height + 24 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26347, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26347), { 0, 0, height + 24 },
                             { 16, 16, 3 });
                         break;
                 }
@@ -1978,22 +1978,22 @@ static void multi_dimension_rc_track_banked_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26351, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26351), { 0, 0, height + 24 },
                             { 16, 32, 3 }, { 16, 0, height + 24 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26356, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26356), { 0, 0, height + 24 },
                             { 16, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26361, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26361), { 0, 0, height + 24 },
                             { 16, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26346, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26346), { 0, 0, height + 24 },
                             { 16, 32, 3 }, { 16, 0, height + 24 });
                         break;
                 }
@@ -2009,22 +2009,22 @@ static void multi_dimension_rc_track_banked_left_quarter_turn_5(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26350, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26350), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 24 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26355, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26355), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 24 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26360, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26360), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 24 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26345, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26345), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 24 });
                         break;
                 }
@@ -2072,28 +2072,28 @@ static void multi_dimension_rc_track_left_bank_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15844, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15844), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15848, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15848), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15845, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15845), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15849, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15849), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15846, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15846), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15847, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15847), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -2119,23 +2119,23 @@ static void multi_dimension_rc_track_left_bank_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26281, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26281), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26282, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26282), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26283, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26283), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26284, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26284), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
         }
 
@@ -2189,28 +2189,28 @@ static void multi_dimension_rc_track_right_bank_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15850, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15850), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15851, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15851), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15852, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15852), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15854, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15854), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15853, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15853), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15855, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15855), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
         }
@@ -2236,23 +2236,23 @@ static void multi_dimension_rc_track_right_bank_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26285, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26285), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26286, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26286), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26287, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26287), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26288, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26288), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
         }
 
@@ -2306,28 +2306,28 @@ static void multi_dimension_rc_track_25_deg_up_to_left_bank(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15856, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15856), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15860, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15860), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15857, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15857), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15861, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15861), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15858, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15858), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15859, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15859), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -2353,23 +2353,23 @@ static void multi_dimension_rc_track_25_deg_up_to_left_bank(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26289, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26289), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26290, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26290), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26291, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26291), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26292, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26292), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
         }
 
@@ -2423,28 +2423,28 @@ static void multi_dimension_rc_track_25_deg_up_to_right_bank(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15862, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15862), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15863, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15863), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15864, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15864), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15866, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15866), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15865, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15865), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15867, { 0, 0, height }, { 32, 1, 34 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15867), { 0, 0, height }, { 32, 1, 34 },
                     { 0, 27, height });
                 break;
         }
@@ -2470,23 +2470,23 @@ static void multi_dimension_rc_track_25_deg_up_to_right_bank(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26293, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26293), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26294, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26294), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26295, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26295), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26296, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 32 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26296), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 32 });
                 break;
         }
 
@@ -2572,22 +2572,22 @@ static void multi_dimension_rc_track_left_bank(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15868, { 0, 0, height }, { 32, 1, 26 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15868), { 0, 0, height }, { 32, 1, 26 },
                     { 0, 27, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15869, { 0, 0, height }, { 32, 1, 26 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15869), { 0, 0, height }, { 32, 1, 26 },
                     { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15870, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15870), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15871, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15871), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -2606,23 +2606,23 @@ static void multi_dimension_rc_track_left_bank(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26297, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26297), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26298, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26298), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26299, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26299), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26300, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 22 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26300), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 22 });
                 break;
         }
 
@@ -2663,23 +2663,23 @@ static void multi_dimension_rc_track_s_bend_left(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15816, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15816), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15820, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15820), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15819, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15819), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15823, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15823), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -2696,25 +2696,27 @@ static void multi_dimension_rc_track_s_bend_left(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15817, { 0, 0, height }, { 32, 26, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15817), { 0, 0, height },
+                            { 32, 26, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15821, { 0, 0, height }, { 32, 26, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15821), { 0, 0, height },
+                            { 32, 26, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 6, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15818, { 0, 0, height }, { 32, 26, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15818), { 0, 0, height },
+                            { 32, 26, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15822, { 0, 0, height }, { 32, 26, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15822), { 0, 0, height },
+                            { 32, 26, 3 }, { 0, 6, height });
                         break;
                 }
                 paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -2725,23 +2727,25 @@ static void multi_dimension_rc_track_s_bend_left(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15818, { 0, 0, height }, { 32, 26, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15818), { 0, 0, height },
+                            { 32, 26, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15822, { 0, 0, height }, { 32, 26, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15822), { 0, 0, height },
+                            { 32, 26, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15817, { 0, 0, height }, { 32, 26, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15817), { 0, 0, height },
+                            { 32, 26, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15821, { 0, 0, height }, { 32, 26, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15821), { 0, 0, height },
+                            { 32, 26, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 6, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -2754,23 +2758,23 @@ static void multi_dimension_rc_track_s_bend_left(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15819, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15819), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15823, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15823), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15816, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15816), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15820, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15820), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -2798,22 +2802,22 @@ static void multi_dimension_rc_track_s_bend_left(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26229, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26229), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26233, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26233), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26232, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26232), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26236, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26236), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                 }
@@ -2835,22 +2839,22 @@ static void multi_dimension_rc_track_s_bend_left(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26230, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26230), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26234, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26234), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26231, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26231), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 6, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26235, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26235), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 6, height + 22 });
                         break;
                 }
@@ -2879,22 +2883,22 @@ static void multi_dimension_rc_track_s_bend_left(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26231, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26231), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 6, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26235, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26235), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 6, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26230, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26230), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 0, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26234, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26234), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 0, height + 22 });
                         break;
                 }
@@ -2923,22 +2927,22 @@ static void multi_dimension_rc_track_s_bend_left(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26232, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26232), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26236, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26236), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26229, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26229), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26233, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26233), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                 }
@@ -2978,23 +2982,23 @@ static void multi_dimension_rc_track_s_bend_right(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15824, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15824), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15828, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15828), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15827, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15827), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15831, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15831), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -3011,25 +3015,27 @@ static void multi_dimension_rc_track_s_bend_right(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15825, { 0, 0, height }, { 32, 26, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15825), { 0, 0, height },
+                            { 32, 26, 3 }, { 0, 6, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15829, { 0, 0, height }, { 32, 26, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15829), { 0, 0, height },
+                            { 32, 26, 3 }, { 0, 6, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15826, { 0, 0, height }, { 32, 26, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15826), { 0, 0, height },
+                            { 32, 26, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15830, { 0, 0, height }, { 32, 26, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15830), { 0, 0, height },
+                            { 32, 26, 3 });
                         break;
                 }
                 paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -3040,23 +3046,25 @@ static void multi_dimension_rc_track_s_bend_right(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15826, { 0, 0, height }, { 32, 26, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15826), { 0, 0, height },
+                            { 32, 26, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15830, { 0, 0, height }, { 32, 26, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15830), { 0, 0, height },
+                            { 32, 26, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15825, { 0, 0, height }, { 32, 26, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15825), { 0, 0, height },
+                            { 32, 26, 3 }, { 0, 6, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15829, { 0, 0, height }, { 32, 26, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15829), { 0, 0, height },
+                            { 32, 26, 3 }, { 0, 6, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -3069,23 +3077,23 @@ static void multi_dimension_rc_track_s_bend_right(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15827, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15827), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15831, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15831), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15824, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15824), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15828, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15828), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -3113,22 +3121,22 @@ static void multi_dimension_rc_track_s_bend_right(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26237, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26237), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26241, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26241), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26240, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26240), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26244, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26244), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                 }
@@ -3150,22 +3158,22 @@ static void multi_dimension_rc_track_s_bend_right(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26238, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26238), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 6, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26242, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26242), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 6, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26239, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26239), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 0, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26243, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26243), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 0, height + 22 });
                         break;
                 }
@@ -3194,22 +3202,22 @@ static void multi_dimension_rc_track_s_bend_right(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26239, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26239), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26243, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26243), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26238, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26238), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 6, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26242, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26242), { 0, 0, height + 24 },
                             { 32, 26, 3 }, { 0, 6, height + 22 });
                         break;
                 }
@@ -3238,22 +3246,22 @@ static void multi_dimension_rc_track_s_bend_right(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26240, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26240), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26244, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26244), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26237, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26237), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26241, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26241), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                 }
@@ -3293,23 +3301,23 @@ static void multi_dimension_rc_track_left_quarter_turn_3(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15959, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15959), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15962, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15962), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15965, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15965), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15956, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15956), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -3329,23 +3337,23 @@ static void multi_dimension_rc_track_left_quarter_turn_3(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15958, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15958), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15961, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15961), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15964, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15964), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15955, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15955), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -3358,23 +3366,23 @@ static void multi_dimension_rc_track_left_quarter_turn_3(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15957, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15957), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15960, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15960), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15963, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15963), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15954, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15954), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -3404,22 +3412,22 @@ static void multi_dimension_rc_track_left_quarter_turn_3(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26326, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26326), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26329, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26329), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26332, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26332), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26323, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26323), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                 }
@@ -3445,22 +3453,22 @@ static void multi_dimension_rc_track_left_quarter_turn_3(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26325, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26325), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26328, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26328), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26331, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26331), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 16, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26322, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26322), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 16, height + 22 });
                         break;
                 }
@@ -3474,22 +3482,22 @@ static void multi_dimension_rc_track_left_quarter_turn_3(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26324, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26324), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26327, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26327), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26330, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26330), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26321, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26321), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 22 });
                         break;
                 }
@@ -3539,26 +3547,26 @@ static void multi_dimension_rc_track_left_quarter_turn_3_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15971, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15971), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15978, { 0, 0, height }, { 32, 1, 26 },
-                            { 0, 27, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15978), { 0, 0, height },
+                            { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15974, { 0, 0, height }, { 32, 1, 26 },
-                            { 0, 27, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15974), { 0, 0, height },
+                            { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15977, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15977), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15968, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15968), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -3578,23 +3586,23 @@ static void multi_dimension_rc_track_left_quarter_turn_3_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15970, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15970), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15973, { 0, 0, height }, { 16, 16, 1 },
-                            { 0, 0, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15973), { 0, 0, height },
+                            { 16, 16, 1 }, { 0, 0, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15976, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15976), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15967, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15967), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -3607,26 +3615,26 @@ static void multi_dimension_rc_track_left_quarter_turn_3_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15969, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15969), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15972, { 0, 0, height }, { 1, 32, 26 },
-                            { 27, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15972), { 0, 0, height },
+                            { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15975, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15975), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15979, { 0, 0, height }, { 1, 32, 26 },
-                            { 27, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15979), { 0, 0, height },
+                            { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15966, { 0, 0, height }, { 20, 32, 3 },
-                            { 6, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15966), { 0, 0, height },
+                            { 20, 32, 3 }, { 6, 0, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -3656,22 +3664,22 @@ static void multi_dimension_rc_track_left_quarter_turn_3_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26338, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26338), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26341, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26341), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26344, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26344), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26335, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26335), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                 }
@@ -3697,22 +3705,22 @@ static void multi_dimension_rc_track_left_quarter_turn_3_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26337, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26337), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26340, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26340), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26343, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26343), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 16, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26334, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26334), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 16, height + 22 });
                         break;
                 }
@@ -3726,22 +3734,22 @@ static void multi_dimension_rc_track_left_quarter_turn_3_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26336, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26336), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26339, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26339), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26342, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26342), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26333, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26333), { 0, 0, height + 24 },
                             { 20, 32, 3 }, { 6, 0, height + 22 });
                         break;
                 }
@@ -3789,26 +3797,26 @@ static void multi_dimension_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16197, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16197), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16204, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16204), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16200, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16200), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16203, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16203), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16194, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16194), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -3828,23 +3836,23 @@ static void multi_dimension_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16196, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16196), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16199, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16199), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16202, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16202), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16193, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16193), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3856,26 +3864,26 @@ static void multi_dimension_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16195, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16195), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16198, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16198), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16201, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16201), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16205, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16205), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16192, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16192), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 8 });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -3899,26 +3907,26 @@ static void multi_dimension_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16194, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16194), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16197, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16197), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16204, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16204), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16200, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16200), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16203, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16203), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -3943,23 +3951,23 @@ static void multi_dimension_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16193, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16193), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16196, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16196), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16199, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16199), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16202, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16202), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3971,26 +3979,26 @@ static void multi_dimension_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16192, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16192), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16195, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16195), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16198, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16198), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16201, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16201), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16205, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16205), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -4017,26 +4025,26 @@ static void multi_dimension_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16178, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16178), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16181, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16181), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16184, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16184), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16187, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16187), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16191, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16191), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -4056,23 +4064,23 @@ static void multi_dimension_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16179, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16179), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16182, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16182), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16185, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16185), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16188, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16188), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4084,26 +4092,26 @@ static void multi_dimension_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16180, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16180), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16183, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16183), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16190, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16190), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16186, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16186), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16189, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16189), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -4125,26 +4133,26 @@ static void multi_dimension_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16181, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16181), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16184, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16184), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16187, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16187), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16191, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16191), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16178, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16178), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -4171,23 +4179,23 @@ static void multi_dimension_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16182, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16182), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16185, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16185), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16188, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16188), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16179, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16179), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4199,26 +4207,26 @@ static void multi_dimension_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16183, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16183), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16190, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16190), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16186, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16186), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16189, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16189), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16180, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16180), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -4275,26 +4283,26 @@ static void multi_dimension_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16165, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16165), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16176, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16176), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16170, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16170), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16175, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16175), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16160, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16160), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -4314,23 +4322,23 @@ static void multi_dimension_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16164, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16164), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16169, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16169), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16174, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16174), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16159, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16159), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4345,23 +4353,23 @@ static void multi_dimension_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16163, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16163), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16168, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16168), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16173, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16173), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16158, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16158), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4376,23 +4384,23 @@ static void multi_dimension_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16162, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16162), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16167, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16167), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16172, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16172), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16157, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16157), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4407,26 +4415,26 @@ static void multi_dimension_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16161, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16161), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16166, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16166), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16171, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16171), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16177, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16177), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16156, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16156), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 8 });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -4450,26 +4458,26 @@ static void multi_dimension_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16160, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16160), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16165, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16165), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16176, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16176), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16170, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16170), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16175, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16175), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -4494,23 +4502,23 @@ static void multi_dimension_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16159, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16159), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16164, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16164), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16169, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16169), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16174, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16174), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4525,23 +4533,23 @@ static void multi_dimension_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16158, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16158), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16163, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16163), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16168, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16168), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16173, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16173), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4556,23 +4564,23 @@ static void multi_dimension_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16157, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16157), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16162, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16162), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16167, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16167), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16172, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16172), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4587,26 +4595,26 @@ static void multi_dimension_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16156, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16156), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16161, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16161), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16166, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16166), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16171, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16171), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16177, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16177), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -4633,26 +4641,26 @@ static void multi_dimension_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16134, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16134), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16139, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16139), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16144, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16144), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16149, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16149), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16155, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16155), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -4672,23 +4680,23 @@ static void multi_dimension_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16135, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16135), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16140, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16140), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16145, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16145), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16150, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16150), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4703,23 +4711,23 @@ static void multi_dimension_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16136, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16136), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16141, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16141), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16146, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16146), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16151, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16151), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4734,23 +4742,23 @@ static void multi_dimension_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16137, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16137), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16142, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16142), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16147, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16147), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16152, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16152), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4765,26 +4773,26 @@ static void multi_dimension_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16138, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16138), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16143, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16143), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16154, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16154), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16148, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16148), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16153, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16153), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -4806,26 +4814,26 @@ static void multi_dimension_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16139, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16139), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16144, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16144), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16149, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16149), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16155, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16155), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16134, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16134), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -4852,23 +4860,23 @@ static void multi_dimension_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16140, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16140), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16145, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16145), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16150, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16150), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16135, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16135), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4883,23 +4891,23 @@ static void multi_dimension_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16141, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16141), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16146, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16146), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16151, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16151), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16136, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16136), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4914,23 +4922,23 @@ static void multi_dimension_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16142, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16142), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16147, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16147), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16152, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16152), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16137, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16137), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4945,26 +4953,26 @@ static void multi_dimension_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16143, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16143), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16154, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16154), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16148, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16148), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16153, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16153), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16138, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16138), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -5021,13 +5029,13 @@ static void multi_dimension_rc_track_brakes(
             case 0:
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16218, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16218), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
             case 1:
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16219, { 0, 0, height }, { 32, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16219), { 0, 0, height }, { 32, 20, 3 },
                     { 0, 6, height });
                 break;
         }
@@ -5047,14 +5055,14 @@ static void multi_dimension_rc_track_brakes(
             case 0:
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26549, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 24 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26549), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 24 });
                 break;
             case 1:
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26550, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 24 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26550), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 24 });
                 break;
         }
 
@@ -5082,46 +5090,46 @@ static void multi_dimension_rc_track_on_ride_photo(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                    session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15806, { 0, 0, height }, { 32, 20, 0 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15806), { 0, 0, height }, { 32, 20, 0 },
                     { 0, 6, height + 3 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                    session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15807, { 0, 0, height }, { 32, 20, 0 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15807), { 0, 0, height }, { 32, 20, 0 },
                     { 0, 6, height + 3 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                    session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15806, { 0, 0, height }, { 32, 20, 0 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15806), { 0, 0, height }, { 32, 20, 0 },
                     { 0, 6, height + 3 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                    session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 15807, { 0, 0, height }, { 32, 20, 0 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15807), { 0, 0, height }, { 32, 20, 0 },
                     { 0, 6, height + 3 });
                 break;
         }
@@ -5136,47 +5144,47 @@ static void multi_dimension_rc_track_on_ride_photo(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                    session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26227, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 24 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26227), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 24 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                    session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26228, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 24 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26228), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 24 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                    session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26227, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 24 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26227), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 24 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                    session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES_INVERTED, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26228, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 24 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26228), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 24 });
                 break;
         }
         track_paint_util_onride_photo_paint(session, direction, height + 3, trackElement);
@@ -5200,23 +5208,23 @@ static void multi_dimension_rc_track_90_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16130, { 0, 0, height }, { 2, 20, 31 },
-                            { 4, 6, height + 8 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16130), { 0, 0, height },
+                            { 2, 20, 31 }, { 4, 6, height + 8 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16131, { 0, 0, height }, { 2, 20, 31 },
-                            { 24, 6, height + 8 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16131), { 0, 0, height },
+                            { 2, 20, 31 }, { 24, 6, height + 8 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16132, { 0, 0, height }, { 2, 20, 31 },
-                            { 24, 6, height + 8 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16132), { 0, 0, height },
+                            { 2, 20, 31 }, { 24, 6, height + 8 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16133, { 0, 0, height }, { 2, 20, 31 },
-                            { 4, 6, height + 8 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16133), { 0, 0, height },
+                            { 2, 20, 31 }, { 4, 6, height + 8 });
                         break;
                 }
                 paint_util_set_vertical_tunnel(session, height + 32);
@@ -5237,22 +5245,22 @@ static void multi_dimension_rc_track_90_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26533, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26533), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 56 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26534, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26534), { 0, 0, height + 24 },
                             { 32, 2, 31 }, { 0, 4, height + 6 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26535, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26535), { 0, 0, height + 24 },
                             { 32, 2, 31 }, { 0, 4, height + 6 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26536, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26536), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 56 });
                         break;
                 }
@@ -5289,23 +5297,23 @@ static void multi_dimension_rc_track_60_deg_up_to_90_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16122, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16122), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16123, { 0, 0, height }, { 2, 20, 55 },
-                            { 24, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16123), { 0, 0, height },
+                            { 2, 20, 55 }, { 24, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16124, { 0, 0, height }, { 2, 20, 55 },
-                            { 24, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16124), { 0, 0, height },
+                            { 2, 20, 55 }, { 24, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16125, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16125), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 if (direction == 0 || direction == 3)
@@ -5330,22 +5338,22 @@ static void multi_dimension_rc_track_60_deg_up_to_90_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26525, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26525), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 80 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26526, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26526), { 0, 0, height + 24 },
                             { 32, 2, 55 }, { 0, 4, height + 6 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26527, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26527), { 0, 0, height + 24 },
                             { 32, 2, 55 }, { 0, 4, height + 6 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26528, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26528), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 80 });
                         break;
                 }
@@ -5383,22 +5391,22 @@ static void multi_dimension_rc_track_90_deg_up_to_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16126, { 0, 0, height }, { 6, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16126), { 0, 0, height }, { 6, 20, 3 },
                     { 0, 6, height + 2 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16127, { 0, 0, height }, { 2, 20, 31 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16127), { 0, 0, height }, { 2, 20, 31 },
                     { 39, 6, height + 8 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16128, { 0, 0, height }, { 2, 20, 31 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16128), { 0, 0, height }, { 2, 20, 31 },
                     { 39, 6, height + 8 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 16129, { 0, 0, height }, { 6, 20, 3 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16129), { 0, 0, height }, { 6, 20, 3 },
                     { 0, 6, height + 2 });
                 break;
         }
@@ -5421,23 +5429,23 @@ static void multi_dimension_rc_track_90_deg_up_to_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26529, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 80 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26529), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 80 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26530, { 0, 0, height + 24 }, { 32, 2, 55 },
-                    { 0, 4, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26530), { 0, 0, height + 24 },
+                    { 32, 2, 55 }, { 0, 4, height + 6 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26531, { 0, 0, height + 24 }, { 32, 2, 55 },
-                    { 0, 4, height + 6 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26531), { 0, 0, height + 24 },
+                    { 32, 2, 55 }, { 0, 4, height + 6 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26532, { 0, 0, height + 24 }, { 32, 20, 3 },
-                    { 0, 6, height + 80 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26532), { 0, 0, height + 24 },
+                    { 32, 20, 3 }, { 0, 6, height + 80 });
                 break;
         }
         switch (direction)
@@ -5469,23 +5477,23 @@ static void multi_dimension_rc_track_60_deg_down_to_90_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16128, { 0, 0, height }, { 2, 20, 31 },
-                            { 39, 6, height + 8 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16128), { 0, 0, height },
+                            { 2, 20, 31 }, { 39, 6, height + 8 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16129, { 0, 0, height }, { 6, 20, 3 },
-                            { 0, 6, height + 2 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16129), { 0, 0, height },
+                            { 6, 20, 3 }, { 0, 6, height + 2 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16126, { 0, 0, height }, { 6, 20, 3 },
-                            { 0, 6, height + 2 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16126), { 0, 0, height },
+                            { 6, 20, 3 }, { 0, 6, height + 2 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16127, { 0, 0, height }, { 2, 20, 31 },
-                            { 39, 6, height + 8 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16127), { 0, 0, height },
+                            { 2, 20, 31 }, { 39, 6, height + 8 });
                         break;
                 }
                 if (direction == 0 || direction == 3)
@@ -5509,22 +5517,22 @@ static void multi_dimension_rc_track_60_deg_down_to_90_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26531, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26531), { 0, 0, height + 24 },
                             { 32, 2, 55 }, { 0, 4, height + 6 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26532, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26532), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 80 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26529, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26529), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 80 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26530, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26530), { 0, 0, height + 24 },
                             { 32, 2, 55 }, { 0, 4, height + 6 });
                         break;
                 }
@@ -5556,23 +5564,23 @@ static void multi_dimension_rc_track_left_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15996, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15996), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16000, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16000), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16004, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16004), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16008, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16008), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -5589,23 +5597,23 @@ static void multi_dimension_rc_track_left_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15997, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15997), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16001, { 0, 0, height }, { 34, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16001), { 0, 0, height },
+                            { 34, 16, 3 }, { 0, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16005, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16005), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16009, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16009), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -5616,23 +5624,23 @@ static void multi_dimension_rc_track_left_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15998, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15998), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16002, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16002), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 16, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16006, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16006), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16010, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16010), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -5652,29 +5660,29 @@ static void multi_dimension_rc_track_left_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15999, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15999), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16003, { 0, 0, height }, { 16, 18, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16003), { 0, 0, height },
+                            { 16, 18, 3 }, { 0, 16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16007, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16007), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16011, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16011), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5693,22 +5701,22 @@ static void multi_dimension_rc_track_left_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26405, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26405), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26409, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26409), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26413, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26413), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26417, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26417), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                 }
@@ -5729,22 +5737,22 @@ static void multi_dimension_rc_track_left_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26406, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26406), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26410, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26410), { 0, 0, height + 24 },
                             { 34, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26414, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26414), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 16, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26418, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26418), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 16, height + 22 });
                         break;
                 }
@@ -5760,22 +5768,22 @@ static void multi_dimension_rc_track_left_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26407, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26407), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 16, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26411, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26411), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 16, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26415, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26415), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 0, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26419, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26419), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 0, height + 22 });
                         break;
                 }
@@ -5796,22 +5804,22 @@ static void multi_dimension_rc_track_left_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26408, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26408), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 16, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26412, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26412), { 0, 0, height + 24 },
                             { 16, 18, 3 }, { 0, 16, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26416, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26416), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26420, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26420), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 0, height + 22 });
                         break;
                 }
@@ -5861,23 +5869,23 @@ static void multi_dimension_rc_track_right_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15980, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15980), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15984, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15984), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15988, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15988), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15992, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15992), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -5894,23 +5902,23 @@ static void multi_dimension_rc_track_right_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15981, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15981), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15985, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15985), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15989, { 0, 0, height }, { 34, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15989), { 0, 0, height },
+                            { 34, 16, 3 }, { 0, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15993, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15993), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -5921,23 +5929,23 @@ static void multi_dimension_rc_track_right_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15982, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15982), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15986, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15986), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15990, { 0, 0, height }, { 28, 28, 3 },
-                            { 4, 4, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15990), { 0, 0, height },
+                            { 28, 28, 3 }, { 4, 4, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15994, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15994), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -5957,29 +5965,29 @@ static void multi_dimension_rc_track_right_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15983, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15983), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15987, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15987), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15991, { 0, 0, height }, { 16, 18, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15991), { 0, 0, height },
+                            { 16, 18, 3 }, { 0, 16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 15995, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15995), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5998,22 +6006,22 @@ static void multi_dimension_rc_track_right_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26389, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26389), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26393, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26393), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26397, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26397), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26401, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26401), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                 }
@@ -6034,22 +6042,22 @@ static void multi_dimension_rc_track_right_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26390, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26390), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 16, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26394, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26394), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 16, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26398, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26398), { 0, 0, height + 24 },
                             { 34, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26402, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26402), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 0, height + 22 });
                         break;
                 }
@@ -6065,22 +6073,22 @@ static void multi_dimension_rc_track_right_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26391, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26391), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26395, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26395), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26399, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26399), { 0, 0, height + 24 },
                             { 28, 28, 3 }, { 4, 4, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26403, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26403), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 16, height + 22 });
                         break;
                 }
@@ -6101,22 +6109,22 @@ static void multi_dimension_rc_track_right_eighth_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26392, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26392), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26396, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26396), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26400, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26400), { 0, 0, height + 24 },
                             { 16, 18, 3 }, { 0, 16, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26404, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26404), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 16, height + 22 });
                         break;
                 }
@@ -6184,23 +6192,23 @@ static void multi_dimension_rc_track_left_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16028, { 0, 0, height }, { 32, 1, 26 },
-                            { 0, 27, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16028), { 0, 0, height },
+                            { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16032, { 0, 0, height }, { 32, 1, 26 },
-                            { 0, 27, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16032), { 0, 0, height },
+                            { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16036, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16036), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16040, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16040), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -6217,23 +6225,23 @@ static void multi_dimension_rc_track_left_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16029, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16029), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16033, { 0, 0, height }, { 34, 16, 0 },
-                            { 0, 0, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16033), { 0, 0, height },
+                            { 34, 16, 0 }, { 0, 0, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16037, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16037), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16041, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16041), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6244,23 +6252,23 @@ static void multi_dimension_rc_track_left_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16030, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16030), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16034, { 0, 0, height }, { 16, 16, 0 },
-                            { 16, 16, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16034), { 0, 0, height },
+                            { 16, 16, 0 }, { 16, 16, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16038, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16038), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16042, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16042), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -6280,29 +6288,29 @@ static void multi_dimension_rc_track_left_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16031, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16031), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16035, { 0, 0, height }, { 16, 18, 0 },
-                            { 0, 16, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16035), { 0, 0, height },
+                            { 16, 18, 0 }, { 0, 16, height + 27 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16039, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16039), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16043, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16043), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6321,22 +6329,22 @@ static void multi_dimension_rc_track_left_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26437, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26437), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26441, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26441), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26445, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26445), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26449, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26449), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                 }
@@ -6358,22 +6366,22 @@ static void multi_dimension_rc_track_left_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26438, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26438), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26442, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26442), { 0, 0, height + 24 },
                             { 34, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26446, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26446), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 16, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26450, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26450), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 16, height + 22 });
                         break;
                 }
@@ -6389,22 +6397,22 @@ static void multi_dimension_rc_track_left_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26439, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26439), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 16, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26443, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26443), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 16, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26447, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26447), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 0, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26451, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26451), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 0, height + 22 });
                         break;
                 }
@@ -6425,22 +6433,22 @@ static void multi_dimension_rc_track_left_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26440, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26440), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 16, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26444, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26444), { 0, 0, height + 24 },
                             { 16, 18, 3 }, { 0, 16, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26448, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26448), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26452, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26452), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 0, height + 22 });
                         break;
                 }
@@ -6490,23 +6498,23 @@ static void multi_dimension_rc_track_right_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16012, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16012), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16016, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16016), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16020, { 0, 0, height }, { 32, 1, 26 },
-                            { 0, 27, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16020), { 0, 0, height },
+                            { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16024, { 0, 0, height }, { 32, 1, 26 },
-                            { 0, 27, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16024), { 0, 0, height },
+                            { 32, 1, 26 }, { 0, 27, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -6523,23 +6531,23 @@ static void multi_dimension_rc_track_right_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16013, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16013), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16017, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16017), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16021, { 0, 0, height }, { 34, 16, 0 },
-                            { 0, 0, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16021), { 0, 0, height },
+                            { 34, 16, 0 }, { 0, 0, height + 27 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16025, { 0, 0, height }, { 32, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16025), { 0, 0, height },
+                            { 32, 16, 3 }, { 0, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6550,23 +6558,23 @@ static void multi_dimension_rc_track_right_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16014, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16014), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16018, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16018), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16022, { 0, 0, height }, { 28, 28, 0 },
-                            { 4, 4, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16022), { 0, 0, height },
+                            { 28, 28, 0 }, { 4, 4, height + 27 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16026, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16026), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -6586,29 +6594,29 @@ static void multi_dimension_rc_track_right_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16015, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16015), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16019, { 0, 0, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16019), { 0, 0, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16023, { 0, 0, height }, { 16, 18, 0 },
-                            { 0, 16, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16023), { 0, 0, height },
+                            { 16, 18, 0 }, { 0, 16, height + 27 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16027, { 0, 0, height }, { 16, 16, 3 },
-                            { 16, 16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16027), { 0, 0, height },
+                            { 16, 16, 3 }, { 16, 16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6627,22 +6635,22 @@ static void multi_dimension_rc_track_right_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26421, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26421), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26425, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26425), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26429, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26429), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26433, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26433), { 0, 0, height + 24 },
                             { 32, 20, 3 }, { 0, 6, height + 22 });
                         break;
                 }
@@ -6664,22 +6672,22 @@ static void multi_dimension_rc_track_right_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26422, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26422), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 16, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26426, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26426), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 16, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26430, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26430), { 0, 0, height + 24 },
                             { 34, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26434, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26434), { 0, 0, height + 24 },
                             { 32, 16, 3 }, { 0, 0, height + 22 });
                         break;
                 }
@@ -6695,22 +6703,22 @@ static void multi_dimension_rc_track_right_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26423, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26423), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26427, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26427), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26431, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26431), { 0, 0, height + 24 },
                             { 28, 28, 3 }, { 4, 4, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26435, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26435), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 16, height + 22 });
                         break;
                 }
@@ -6731,22 +6739,22 @@ static void multi_dimension_rc_track_right_eighth_bank_to_diag(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26424, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26424), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 0, height + 22 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26428, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26428), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 0, 0, height + 22 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26432, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26432), { 0, 0, height + 24 },
                             { 16, 18, 3 }, { 0, 16, height + 22 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26436, { 0, 0, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26436), { 0, 0, height + 24 },
                             { 16, 16, 3 }, { 16, 16, height + 22 });
                         break;
                 }
@@ -6816,7 +6824,7 @@ static void multi_dimension_rc_track_diag_flat(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16109, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16109), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -6827,7 +6835,7 @@ static void multi_dimension_rc_track_diag_flat(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16047, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16047), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -6844,7 +6852,7 @@ static void multi_dimension_rc_track_diag_flat(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16106, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16106), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -6855,7 +6863,7 @@ static void multi_dimension_rc_track_diag_flat(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16044, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16044), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -6872,7 +6880,7 @@ static void multi_dimension_rc_track_diag_flat(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16108, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16108), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -6883,7 +6891,7 @@ static void multi_dimension_rc_track_diag_flat(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16046, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16046), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -6904,7 +6912,7 @@ static void multi_dimension_rc_track_diag_flat(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16107, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16107), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_a_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -6929,7 +6937,7 @@ static void multi_dimension_rc_track_diag_flat(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16045, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16045), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_a_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -6962,8 +6970,8 @@ static void multi_dimension_rc_track_diag_flat(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26484, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 22 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26484),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 22 });
                             break;
                     }
                 }
@@ -6973,8 +6981,8 @@ static void multi_dimension_rc_track_diag_flat(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26456, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 22 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26456),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 22 });
                             break;
                     }
                 }
@@ -6990,8 +6998,8 @@ static void multi_dimension_rc_track_diag_flat(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26481, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 22 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26481),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 22 });
                             break;
                     }
                 }
@@ -7001,8 +7009,8 @@ static void multi_dimension_rc_track_diag_flat(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26453, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 22 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26453),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 22 });
                             break;
                     }
                 }
@@ -7018,8 +7026,8 @@ static void multi_dimension_rc_track_diag_flat(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26483, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 22 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26483),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 22 });
                             break;
                     }
                 }
@@ -7029,8 +7037,8 @@ static void multi_dimension_rc_track_diag_flat(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26455, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 22 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26455),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 22 });
                             break;
                     }
                 }
@@ -7046,8 +7054,8 @@ static void multi_dimension_rc_track_diag_flat(
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26482, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 22 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26482),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 22 });
                             break;
                     }
                 }
@@ -7057,8 +7065,8 @@ static void multi_dimension_rc_track_diag_flat(
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26454, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 22 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26454),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 22 });
                             break;
                     }
                 }
@@ -7108,7 +7116,7 @@ static void multi_dimension_rc_track_diag_25_deg_up(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16121, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16121), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -7119,7 +7127,7 @@ static void multi_dimension_rc_track_diag_25_deg_up(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16059, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16059), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -7136,7 +7144,7 @@ static void multi_dimension_rc_track_diag_25_deg_up(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16118, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16118), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -7147,7 +7155,7 @@ static void multi_dimension_rc_track_diag_25_deg_up(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16056, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16056), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -7164,7 +7172,7 @@ static void multi_dimension_rc_track_diag_25_deg_up(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16120, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16120), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -7175,7 +7183,7 @@ static void multi_dimension_rc_track_diag_25_deg_up(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16058, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16058), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -7196,7 +7204,7 @@ static void multi_dimension_rc_track_diag_25_deg_up(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16119, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16119), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -7221,7 +7229,7 @@ static void multi_dimension_rc_track_diag_25_deg_up(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16057, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16057), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -7254,8 +7262,8 @@ static void multi_dimension_rc_track_diag_25_deg_up(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26496, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 40 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26496),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 40 });
                             break;
                     }
                 }
@@ -7265,8 +7273,8 @@ static void multi_dimension_rc_track_diag_25_deg_up(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26468, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 40 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26468),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 40 });
                             break;
                     }
                 }
@@ -7282,8 +7290,8 @@ static void multi_dimension_rc_track_diag_25_deg_up(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26493, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 40 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26493),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 40 });
                             break;
                     }
                 }
@@ -7293,8 +7301,8 @@ static void multi_dimension_rc_track_diag_25_deg_up(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26465, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 40 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26465),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 40 });
                             break;
                     }
                 }
@@ -7310,8 +7318,8 @@ static void multi_dimension_rc_track_diag_25_deg_up(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26495, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 40 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26495),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 40 });
                             break;
                     }
                 }
@@ -7321,8 +7329,8 @@ static void multi_dimension_rc_track_diag_25_deg_up(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26467, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 40 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26467),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 40 });
                             break;
                     }
                 }
@@ -7338,8 +7346,8 @@ static void multi_dimension_rc_track_diag_25_deg_up(
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26494, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 40 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26494),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 40 });
                             break;
                     }
                 }
@@ -7349,8 +7357,8 @@ static void multi_dimension_rc_track_diag_25_deg_up(
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26466, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 40 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26466),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 40 });
                             break;
                     }
                 }
@@ -7398,8 +7406,8 @@ static void multi_dimension_rc_track_diag_60_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16071, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16071), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -7412,8 +7420,8 @@ static void multi_dimension_rc_track_diag_60_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16068, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16068), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -7426,8 +7434,8 @@ static void multi_dimension_rc_track_diag_60_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16070, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16070), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -7444,8 +7452,8 @@ static void multi_dimension_rc_track_diag_60_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16069, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16069), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 36, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7474,7 +7482,7 @@ static void multi_dimension_rc_track_diag_60_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26480, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26480), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 88 });
                         break;
                 }
@@ -7488,7 +7496,7 @@ static void multi_dimension_rc_track_diag_60_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26477, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26477), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 88 });
                         break;
                 }
@@ -7502,7 +7510,7 @@ static void multi_dimension_rc_track_diag_60_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26479, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26479), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 88 });
                         break;
                 }
@@ -7516,7 +7524,7 @@ static void multi_dimension_rc_track_diag_60_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26478, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26478), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 24 });
                         break;
                 }
@@ -7566,7 +7574,7 @@ static void multi_dimension_rc_track_diag_flat_to_25_deg_up(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16113, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16113), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -7577,7 +7585,7 @@ static void multi_dimension_rc_track_diag_flat_to_25_deg_up(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16051, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16051), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -7594,7 +7602,7 @@ static void multi_dimension_rc_track_diag_flat_to_25_deg_up(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16110, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16110), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -7605,7 +7613,7 @@ static void multi_dimension_rc_track_diag_flat_to_25_deg_up(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16048, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16048), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -7622,7 +7630,7 @@ static void multi_dimension_rc_track_diag_flat_to_25_deg_up(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16112, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16112), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -7633,7 +7641,7 @@ static void multi_dimension_rc_track_diag_flat_to_25_deg_up(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16050, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16050), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -7654,7 +7662,7 @@ static void multi_dimension_rc_track_diag_flat_to_25_deg_up(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16111, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16111), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -7679,7 +7687,7 @@ static void multi_dimension_rc_track_diag_flat_to_25_deg_up(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16049, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16049), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -7712,8 +7720,8 @@ static void multi_dimension_rc_track_diag_flat_to_25_deg_up(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26488, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26488),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -7723,8 +7731,8 @@ static void multi_dimension_rc_track_diag_flat_to_25_deg_up(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26460, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26460),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -7740,8 +7748,8 @@ static void multi_dimension_rc_track_diag_flat_to_25_deg_up(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26485, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26485),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -7751,8 +7759,8 @@ static void multi_dimension_rc_track_diag_flat_to_25_deg_up(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26457, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26457),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -7768,8 +7776,8 @@ static void multi_dimension_rc_track_diag_flat_to_25_deg_up(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26487, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26487),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -7779,8 +7787,8 @@ static void multi_dimension_rc_track_diag_flat_to_25_deg_up(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26459, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26459),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -7796,8 +7804,8 @@ static void multi_dimension_rc_track_diag_flat_to_25_deg_up(
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26486, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26486),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -7807,8 +7815,8 @@ static void multi_dimension_rc_track_diag_flat_to_25_deg_up(
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26458, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26458),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -7856,8 +7864,8 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_60_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16063, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16063), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -7870,8 +7878,8 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_60_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16060, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16060), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -7884,8 +7892,8 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_60_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16062, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16062), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -7902,8 +7910,8 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_60_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16061, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16061), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7932,7 +7940,7 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_60_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26472, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26472), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 56 });
                         break;
                 }
@@ -7946,7 +7954,7 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_60_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26469, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26469), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 56 });
                         break;
                 }
@@ -7960,7 +7968,7 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_60_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26471, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26471), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 56 });
                         break;
                 }
@@ -7974,7 +7982,7 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_60_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26470, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26470), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 56 });
                         break;
                 }
@@ -8022,8 +8030,8 @@ static void multi_dimension_rc_track_diag_60_deg_up_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16067, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16067), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -8036,8 +8044,8 @@ static void multi_dimension_rc_track_diag_60_deg_up_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16064, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16064), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -8050,8 +8058,8 @@ static void multi_dimension_rc_track_diag_60_deg_up_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16066, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16066), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -8068,8 +8076,8 @@ static void multi_dimension_rc_track_diag_60_deg_up_to_25_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16065, { -16, -16, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16065), { -16, -16, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 21, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -8098,7 +8106,7 @@ static void multi_dimension_rc_track_diag_60_deg_up_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26476, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26476), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 56 });
                         break;
                 }
@@ -8112,7 +8120,7 @@ static void multi_dimension_rc_track_diag_60_deg_up_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26473, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26473), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 56 });
                         break;
                 }
@@ -8126,7 +8134,7 @@ static void multi_dimension_rc_track_diag_60_deg_up_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26475, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26475), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 56 });
                         break;
                 }
@@ -8140,7 +8148,7 @@ static void multi_dimension_rc_track_diag_60_deg_up_to_25_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26474, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26474), { -16, -16, height + 24 },
                             { 16, 16, 3 }, { 0, 0, height + 56 });
                         break;
                 }
@@ -8190,7 +8198,7 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_flat(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16117, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16117), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -8201,7 +8209,7 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_flat(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16055, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16055), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -8218,7 +8226,7 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_flat(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16114, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16114), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -8229,7 +8237,7 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_flat(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16052, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16052), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -8246,7 +8254,7 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_flat(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16116, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16116), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -8257,7 +8265,7 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_flat(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16054, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16054), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -8278,7 +8286,7 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_flat(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16115, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16115), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -8303,7 +8311,7 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_flat(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16053, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16053), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -8336,8 +8344,8 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_flat(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26492, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26492),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -8347,8 +8355,8 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_flat(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26464, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26464),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -8364,8 +8372,8 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_flat(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26489, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26489),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -8375,8 +8383,8 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_flat(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26461, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26461),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -8392,8 +8400,8 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_flat(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26491, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26491),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -8403,8 +8411,8 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_flat(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26463, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26463),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -8420,8 +8428,8 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_flat(
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26490, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26490),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -8431,8 +8439,8 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_flat(
                     {
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 26462, { -16, -16, height + 24 },
-                                { 32, 32, 3 }, { -16, -16, height + 32 });
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26462),
+                                { -16, -16, height + 24 }, { 32, 32, 3 }, { -16, -16, height + 32 });
                             break;
                     }
                 }
@@ -8482,7 +8490,7 @@ static void multi_dimension_rc_track_diag_25_deg_down(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16119, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16119), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -8493,7 +8501,7 @@ static void multi_dimension_rc_track_diag_25_deg_down(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16057, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16057), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -8510,7 +8518,7 @@ static void multi_dimension_rc_track_diag_25_deg_down(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16120, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16120), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -8521,7 +8529,7 @@ static void multi_dimension_rc_track_diag_25_deg_down(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16058, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16058), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -8538,7 +8546,7 @@ static void multi_dimension_rc_track_diag_25_deg_down(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16118, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16118), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -8549,7 +8557,7 @@ static void multi_dimension_rc_track_diag_25_deg_down(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16056, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16056), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -8570,7 +8578,7 @@ static void multi_dimension_rc_track_diag_25_deg_down(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16121, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16121), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -8595,7 +8603,7 @@ static void multi_dimension_rc_track_diag_25_deg_down(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16059, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16059), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -8626,7 +8634,7 @@ static void multi_dimension_rc_track_diag_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26466, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26466), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 40 });
                         break;
                 }
@@ -8640,7 +8648,7 @@ static void multi_dimension_rc_track_diag_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26467, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26467), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 40 });
                         break;
                 }
@@ -8654,7 +8662,7 @@ static void multi_dimension_rc_track_diag_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26465, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26465), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 40 });
                         break;
                 }
@@ -8668,7 +8676,7 @@ static void multi_dimension_rc_track_diag_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26468, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26468), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 40 });
                         break;
                 }
@@ -8716,8 +8724,8 @@ static void multi_dimension_rc_track_diag_60_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16069, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16069), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -8730,8 +8738,8 @@ static void multi_dimension_rc_track_diag_60_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16070, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16070), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -8744,8 +8752,8 @@ static void multi_dimension_rc_track_diag_60_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16068, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16068), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -8762,8 +8770,8 @@ static void multi_dimension_rc_track_diag_60_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16071, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16071), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 28, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -8792,7 +8800,7 @@ static void multi_dimension_rc_track_diag_60_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26478, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26478), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 24 });
                         break;
                 }
@@ -8806,7 +8814,7 @@ static void multi_dimension_rc_track_diag_60_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26479, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26479), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 88 });
                         break;
                 }
@@ -8820,7 +8828,7 @@ static void multi_dimension_rc_track_diag_60_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26477, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26477), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 88 });
                         break;
                 }
@@ -8834,7 +8842,7 @@ static void multi_dimension_rc_track_diag_60_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26480, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26480), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 88 });
                         break;
                 }
@@ -8884,7 +8892,7 @@ static void multi_dimension_rc_track_diag_flat_to_25_deg_down(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16115, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16115), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -8895,7 +8903,7 @@ static void multi_dimension_rc_track_diag_flat_to_25_deg_down(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16053, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16053), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -8911,7 +8919,7 @@ static void multi_dimension_rc_track_diag_flat_to_25_deg_down(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16116, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16116), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -8922,7 +8930,7 @@ static void multi_dimension_rc_track_diag_flat_to_25_deg_down(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16054, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16054), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -8938,7 +8946,7 @@ static void multi_dimension_rc_track_diag_flat_to_25_deg_down(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16114, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16114), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -8949,7 +8957,7 @@ static void multi_dimension_rc_track_diag_flat_to_25_deg_down(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16052, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16052), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -8969,7 +8977,7 @@ static void multi_dimension_rc_track_diag_flat_to_25_deg_down(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16117, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16117), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -8994,7 +9002,7 @@ static void multi_dimension_rc_track_diag_flat_to_25_deg_down(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16055, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16055), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -9024,7 +9032,7 @@ static void multi_dimension_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26462, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26462), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -9038,7 +9046,7 @@ static void multi_dimension_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26463, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26463), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -9052,7 +9060,7 @@ static void multi_dimension_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26461, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26461), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -9066,7 +9074,7 @@ static void multi_dimension_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26464, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26464), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -9114,8 +9122,8 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_60_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16065, { -16, -16, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16065), { -16, -16, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -9128,8 +9136,8 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_60_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16066, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16066), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -9142,8 +9150,8 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_60_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16064, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16064), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -9160,8 +9168,8 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_60_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16067, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16067), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 17, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9190,7 +9198,7 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_60_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26474, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26474), { -16, -16, height + 24 },
                             { 16, 16, 3 }, { 0, 0, height + 56 });
                         break;
                 }
@@ -9204,7 +9212,7 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_60_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26475, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26475), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 56 });
                         break;
                 }
@@ -9218,7 +9226,7 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_60_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26473, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26473), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 56 });
                         break;
                 }
@@ -9232,7 +9240,7 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_60_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26476, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26476), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 56 });
                         break;
                 }
@@ -9280,8 +9288,8 @@ static void multi_dimension_rc_track_diag_60_deg_down_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16061, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16061), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -9294,8 +9302,8 @@ static void multi_dimension_rc_track_diag_60_deg_down_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16062, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16062), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -9308,8 +9316,8 @@ static void multi_dimension_rc_track_diag_60_deg_down_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16060, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16060), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -9326,8 +9334,8 @@ static void multi_dimension_rc_track_diag_60_deg_down_to_25_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16063, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16063), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9356,7 +9364,7 @@ static void multi_dimension_rc_track_diag_60_deg_down_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26470, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26470), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 56 });
                         break;
                 }
@@ -9370,7 +9378,7 @@ static void multi_dimension_rc_track_diag_60_deg_down_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26471, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26471), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 56 });
                         break;
                 }
@@ -9384,7 +9392,7 @@ static void multi_dimension_rc_track_diag_60_deg_down_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26469, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26469), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 56 });
                         break;
                 }
@@ -9398,7 +9406,7 @@ static void multi_dimension_rc_track_diag_60_deg_down_to_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26472, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26472), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 56 });
                         break;
                 }
@@ -9448,7 +9456,7 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_flat(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16111, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16111), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9459,7 +9467,7 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_flat(
                     {
                         case 3:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16049, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16049), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9476,7 +9484,7 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_flat(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16112, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16112), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9487,7 +9495,7 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_flat(
                     {
                         case 0:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16050, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16050), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9504,7 +9512,7 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_flat(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16110, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16110), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9515,7 +9523,7 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_flat(
                     {
                         case 2:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16048, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16048), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -9536,7 +9544,7 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_flat(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16113, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16113), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -9561,7 +9569,7 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_flat(
                             break;
                         case 1:
                             PaintAddImageAsParentRotated(
-                                session, direction, session.TrackColours[SCHEME_TRACK] | 16051, { -16, -16, height },
+                                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16051), { -16, -16, height },
                                 { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -9592,7 +9600,7 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26458, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26458), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -9606,7 +9614,7 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26459, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26459), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -9620,7 +9628,7 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26457, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26457), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -9634,7 +9642,7 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26460, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26460), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -9682,8 +9690,8 @@ static void multi_dimension_rc_track_diag_flat_to_left_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16079, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16079), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -9696,11 +9704,11 @@ static void multi_dimension_rc_track_diag_flat_to_left_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16076, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16076), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16080, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16080), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 27 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -9713,8 +9721,8 @@ static void multi_dimension_rc_track_diag_flat_to_left_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16078, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16078), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -9731,8 +9739,8 @@ static void multi_dimension_rc_track_diag_flat_to_left_bank(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16077, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16077), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9761,7 +9769,7 @@ static void multi_dimension_rc_track_diag_flat_to_left_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26504, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26504), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -9775,7 +9783,7 @@ static void multi_dimension_rc_track_diag_flat_to_left_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26501, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26501), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -9789,7 +9797,7 @@ static void multi_dimension_rc_track_diag_flat_to_left_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26503, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26503), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -9803,7 +9811,7 @@ static void multi_dimension_rc_track_diag_flat_to_left_bank(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26502, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26502), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -9852,8 +9860,8 @@ static void multi_dimension_rc_track_diag_flat_to_right_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16084, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16084), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -9866,8 +9874,8 @@ static void multi_dimension_rc_track_diag_flat_to_right_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16081, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16081), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -9880,11 +9888,11 @@ static void multi_dimension_rc_track_diag_flat_to_right_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16083, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16083), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16085, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16085), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 27 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -9901,8 +9909,8 @@ static void multi_dimension_rc_track_diag_flat_to_right_bank(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16082, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16082), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9931,7 +9939,7 @@ static void multi_dimension_rc_track_diag_flat_to_right_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26508, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26508), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -9945,7 +9953,7 @@ static void multi_dimension_rc_track_diag_flat_to_right_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26505, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26505), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -9959,7 +9967,7 @@ static void multi_dimension_rc_track_diag_flat_to_right_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26507, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26507), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -9973,7 +9981,7 @@ static void multi_dimension_rc_track_diag_flat_to_right_bank(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26506, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26506), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -10022,8 +10030,8 @@ static void multi_dimension_rc_track_diag_left_bank_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16082, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16082), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -10036,11 +10044,11 @@ static void multi_dimension_rc_track_diag_left_bank_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16083, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16083), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16085, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16085), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 27 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -10053,8 +10061,8 @@ static void multi_dimension_rc_track_diag_left_bank_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16081, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16081), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -10071,8 +10079,8 @@ static void multi_dimension_rc_track_diag_left_bank_to_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16084, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16084), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -10101,7 +10109,7 @@ static void multi_dimension_rc_track_diag_left_bank_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26506, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26506), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -10115,7 +10123,7 @@ static void multi_dimension_rc_track_diag_left_bank_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26507, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26507), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -10129,7 +10137,7 @@ static void multi_dimension_rc_track_diag_left_bank_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26505, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26505), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -10143,7 +10151,7 @@ static void multi_dimension_rc_track_diag_left_bank_to_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26508, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26508), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -10192,8 +10200,8 @@ static void multi_dimension_rc_track_diag_right_bank_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16077, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16077), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -10206,8 +10214,8 @@ static void multi_dimension_rc_track_diag_right_bank_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16078, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16078), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -10220,11 +10228,11 @@ static void multi_dimension_rc_track_diag_right_bank_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16076, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16076), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16080, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16080), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 27 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -10241,8 +10249,8 @@ static void multi_dimension_rc_track_diag_right_bank_to_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16079, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16079), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -10271,7 +10279,7 @@ static void multi_dimension_rc_track_diag_right_bank_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26502, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26502), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -10285,7 +10293,7 @@ static void multi_dimension_rc_track_diag_right_bank_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26503, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26503), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -10299,7 +10307,7 @@ static void multi_dimension_rc_track_diag_right_bank_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26501, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26501), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -10313,7 +10321,7 @@ static void multi_dimension_rc_track_diag_right_bank_to_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26504, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26504), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -10362,8 +10370,8 @@ static void multi_dimension_rc_track_diag_left_bank_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16099, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16099), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -10376,11 +10384,11 @@ static void multi_dimension_rc_track_diag_left_bank_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16096, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16096), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16100, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 35 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16100), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 35 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -10393,8 +10401,8 @@ static void multi_dimension_rc_track_diag_left_bank_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16098, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16098), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -10411,8 +10419,8 @@ static void multi_dimension_rc_track_diag_left_bank_to_25_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16097, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16097), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -10441,7 +10449,7 @@ static void multi_dimension_rc_track_diag_left_bank_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26520, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26520), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -10455,7 +10463,7 @@ static void multi_dimension_rc_track_diag_left_bank_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26517, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26517), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -10469,7 +10477,7 @@ static void multi_dimension_rc_track_diag_left_bank_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26519, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26519), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -10483,7 +10491,7 @@ static void multi_dimension_rc_track_diag_left_bank_to_25_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26518, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26518), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -10531,8 +10539,8 @@ static void multi_dimension_rc_track_diag_right_bank_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16104, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16104), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -10545,8 +10553,8 @@ static void multi_dimension_rc_track_diag_right_bank_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16101, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16101), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -10559,11 +10567,11 @@ static void multi_dimension_rc_track_diag_right_bank_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16103, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16103), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16105, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 35 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16105), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 35 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -10580,8 +10588,8 @@ static void multi_dimension_rc_track_diag_right_bank_to_25_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16102, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16102), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -10610,7 +10618,7 @@ static void multi_dimension_rc_track_diag_right_bank_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26524, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26524), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -10624,7 +10632,7 @@ static void multi_dimension_rc_track_diag_right_bank_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26521, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26521), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -10638,7 +10646,7 @@ static void multi_dimension_rc_track_diag_right_bank_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26523, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26523), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -10652,7 +10660,7 @@ static void multi_dimension_rc_track_diag_right_bank_to_25_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26522, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26522), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -10700,8 +10708,8 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_left_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16089, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16089), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -10714,11 +10722,11 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_left_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16086, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16086), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16090, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 35 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16090), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 35 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -10731,8 +10739,8 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_left_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16088, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16088), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -10749,8 +10757,8 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_left_bank(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16087, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16087), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -10779,7 +10787,7 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_left_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26512, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26512), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -10793,7 +10801,7 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_left_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26509, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26509), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -10807,7 +10815,7 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_left_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26511, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26511), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -10821,7 +10829,7 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_left_bank(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26510, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26510), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -10869,8 +10877,8 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_right_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16094, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16094), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -10883,8 +10891,8 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_right_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16091, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16091), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -10897,11 +10905,11 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_right_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16093, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16093), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16095, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 35 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16095), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 35 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -10918,8 +10926,8 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_right_bank(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16092, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16092), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -10948,7 +10956,7 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_right_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26516, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26516), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -10962,7 +10970,7 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_right_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26513, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26513), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -10976,7 +10984,7 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_right_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26515, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26515), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -10990,7 +10998,7 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_right_bank(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26514, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26514), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -11038,8 +11046,8 @@ static void multi_dimension_rc_track_diag_left_bank_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16092, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16092), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -11051,11 +11059,11 @@ static void multi_dimension_rc_track_diag_left_bank_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16093, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16093), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16095, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 35 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16095), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 35 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -11067,8 +11075,8 @@ static void multi_dimension_rc_track_diag_left_bank_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16091, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16091), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -11084,8 +11092,8 @@ static void multi_dimension_rc_track_diag_left_bank_to_25_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16094, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16094), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -11113,7 +11121,7 @@ static void multi_dimension_rc_track_diag_left_bank_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26514, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26514), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -11126,7 +11134,7 @@ static void multi_dimension_rc_track_diag_left_bank_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26515, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26515), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -11139,7 +11147,7 @@ static void multi_dimension_rc_track_diag_left_bank_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26513, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26513), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -11152,7 +11160,7 @@ static void multi_dimension_rc_track_diag_left_bank_to_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26516, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26516), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -11200,8 +11208,8 @@ static void multi_dimension_rc_track_diag_right_bank_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16087, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16087), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -11213,8 +11221,8 @@ static void multi_dimension_rc_track_diag_right_bank_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16088, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16088), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -11226,11 +11234,11 @@ static void multi_dimension_rc_track_diag_right_bank_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16086, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16086), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16090, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 35 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16090), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 35 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -11246,8 +11254,8 @@ static void multi_dimension_rc_track_diag_right_bank_to_25_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16089, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16089), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -11275,7 +11283,7 @@ static void multi_dimension_rc_track_diag_right_bank_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26510, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26510), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -11288,7 +11296,7 @@ static void multi_dimension_rc_track_diag_right_bank_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26511, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26511), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -11301,7 +11309,7 @@ static void multi_dimension_rc_track_diag_right_bank_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26509, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26509), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -11314,7 +11322,7 @@ static void multi_dimension_rc_track_diag_right_bank_to_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26512, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26512), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -11362,8 +11370,8 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_left_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16102, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16102), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -11376,11 +11384,11 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_left_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16103, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16103), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16105, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 35 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16105), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 35 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -11393,8 +11401,8 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_left_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16101, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16101), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -11411,8 +11419,8 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_left_bank(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16104, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16104), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -11441,7 +11449,7 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_left_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26522, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26522), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -11455,7 +11463,7 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_left_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26523, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26523), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -11469,7 +11477,7 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_left_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26521, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26521), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -11483,7 +11491,7 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_left_bank(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26524, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26524), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -11531,8 +11539,8 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_right_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16097, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16097), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -11545,8 +11553,8 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_right_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16098, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16098), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -11559,11 +11567,11 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_right_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16096, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16096), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16100, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 35 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16100), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 35 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -11580,8 +11588,8 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_right_bank(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16099, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16099), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -11610,7 +11618,7 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_right_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26518, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26518), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -11624,7 +11632,7 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_right_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26519, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26519), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -11638,7 +11646,7 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_right_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26517, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26517), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -11652,7 +11660,7 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_right_bank(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26520, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26520), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 32 });
                         break;
                 }
@@ -11700,8 +11708,8 @@ static void multi_dimension_rc_track_diag_left_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16075, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16075), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -11714,8 +11722,8 @@ static void multi_dimension_rc_track_diag_left_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16072, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16072), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 27 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -11728,8 +11736,8 @@ static void multi_dimension_rc_track_diag_left_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16074, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16074), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -11746,8 +11754,8 @@ static void multi_dimension_rc_track_diag_left_bank(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16073, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16073), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -11776,7 +11784,7 @@ static void multi_dimension_rc_track_diag_left_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26500, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26500), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -11790,7 +11798,7 @@ static void multi_dimension_rc_track_diag_left_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26497, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26497), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -11804,7 +11812,7 @@ static void multi_dimension_rc_track_diag_left_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26499, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26499), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -11818,7 +11826,7 @@ static void multi_dimension_rc_track_diag_left_bank(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26498, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26498), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -11867,8 +11875,8 @@ static void multi_dimension_rc_track_diag_right_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16073, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16073), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -11881,8 +11889,8 @@ static void multi_dimension_rc_track_diag_right_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16074, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16074), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -11895,8 +11903,8 @@ static void multi_dimension_rc_track_diag_right_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16072, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16072), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 27 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -11913,8 +11921,8 @@ static void multi_dimension_rc_track_diag_right_bank(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16075, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16075), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES_INVERTED, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -11943,7 +11951,7 @@ static void multi_dimension_rc_track_diag_right_bank(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26498, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26498), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -11957,7 +11965,7 @@ static void multi_dimension_rc_track_diag_right_bank(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26499, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26499), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -11971,7 +11979,7 @@ static void multi_dimension_rc_track_diag_right_bank(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26497, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26497), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -11985,7 +11993,7 @@ static void multi_dimension_rc_track_diag_right_bank(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26500, { -16, -16, height + 24 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26500), { -16, -16, height + 24 },
                             { 32, 32, 3 }, { -16, -16, height + 22 });
                         break;
                 }
@@ -12032,19 +12040,23 @@ static void multi_dimension_rc_track_left_flyer_twist_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26368, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26368), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26374, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26374), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26367, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26367), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26373, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26373), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -12065,20 +12077,23 @@ static void multi_dimension_rc_track_left_flyer_twist_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26369, { 0, 6, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26369), { 0, 6, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 24 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26375, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26375), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26366, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26366), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26372, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26372), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -12093,20 +12108,23 @@ static void multi_dimension_rc_track_left_flyer_twist_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26370, { 0, 6, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26370), { 0, 6, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 24 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26376, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26376), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26365, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26365), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26371, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26371), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
             }
 
@@ -12144,19 +12162,23 @@ static void multi_dimension_rc_track_right_flyer_twist_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26380, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26380), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26386, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26386), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26379, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26379), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26385, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26385), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -12177,19 +12199,23 @@ static void multi_dimension_rc_track_right_flyer_twist_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26381, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26381), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26387, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26387), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26378, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26378), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26384, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26384), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -12204,19 +12230,23 @@ static void multi_dimension_rc_track_right_flyer_twist_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26382, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26382), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26388, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26388), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26377, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26377), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26383, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26383), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
             }
 
@@ -12254,20 +12284,23 @@ static void multi_dimension_rc_track_left_flyer_twist_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26365, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26365), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26371, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26371), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26370, { 0, 6, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26370), { 0, 6, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 24 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26376, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26376), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
             }
 
@@ -12290,20 +12323,23 @@ static void multi_dimension_rc_track_left_flyer_twist_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26366, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26366), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26372, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26372), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26369, { 0, 6, height + 24 }, { 32, 20, 3 },
-                        { 0, 6, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26369), { 0, 6, height + 24 },
+                        { 32, 20, 3 }, { 0, 6, height + 24 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26375, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26375), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -12318,19 +12354,23 @@ static void multi_dimension_rc_track_left_flyer_twist_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26367, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26367), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26373, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26373), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26368, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26368), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26374, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26374), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -12366,19 +12406,23 @@ static void multi_dimension_rc_track_right_flyer_twist_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26377, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26377), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26383, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26383), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26382, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26382), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26388, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26388), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
             }
 
@@ -12401,19 +12445,23 @@ static void multi_dimension_rc_track_right_flyer_twist_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26378, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26378), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26384, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26384), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26381, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26381), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26387, { 0, 6, height + 24 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26387), { 0, 6, height + 24 },
+                        { 32, 20, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -12428,19 +12476,23 @@ static void multi_dimension_rc_track_right_flyer_twist_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26379, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26379), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26385, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26385), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26380, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26380), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26386, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26386), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(
@@ -12478,22 +12530,22 @@ static void multi_dimension_rc_track_multidim_inverted_flat_to_90_deg_quarter_lo
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26539, { 0, 0, height + 16 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26539), { 0, 0, height + 16 },
                             { 32, 20, 3 }, { 0, 6, height + 16 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26542, { 0, 0, height + 16 }, { 2, 20, 3 },
-                            { 0, 6, height + 18 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26542), { 0, 0, height + 16 },
+                            { 2, 20, 3 }, { 0, 6, height + 18 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26545, { 0, 0, height + 16 }, { 2, 20, 3 },
-                            { 0, 6, height + 18 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26545), { 0, 0, height + 16 },
+                            { 2, 20, 3 }, { 0, 6, height + 18 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26548, { 0, 0, height + 16 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26548), { 0, 0, height + 16 },
                             { 32, 20, 3 }, { 0, 6, height + 16 });
                         break;
                 }
@@ -12510,22 +12562,22 @@ static void multi_dimension_rc_track_multidim_inverted_flat_to_90_deg_quarter_lo
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26538, { 0, 0, height + 16 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26538), { 0, 0, height + 16 },
                             { 2, 20, 31 }, { 24, 6, height + 16 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26541, { 0, 0, height + 16 }, { 2, 20, 3 },
-                            { 0, 6, height + 18 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26541), { 0, 0, height + 16 },
+                            { 2, 20, 3 }, { 0, 6, height + 18 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26544, { 0, 0, height + 16 }, { 2, 20, 3 },
-                            { 0, 6, height + 18 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26544), { 0, 0, height + 16 },
+                            { 2, 20, 3 }, { 0, 6, height + 18 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26547, { 0, 0, height + 16 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26547), { 0, 0, height + 16 },
                             { 2, 20, 31 }, { 24, 6, height + 16 });
                         break;
                 }
@@ -12538,22 +12590,22 @@ static void multi_dimension_rc_track_multidim_inverted_flat_to_90_deg_quarter_lo
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26537, { 0, 0, height + 16 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26537), { 0, 0, height + 16 },
                             { 2, 20, 31 }, { 28, 6, height + 24 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26540, { 0, 0, height + 16 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26540), { 0, 0, height + 16 },
                             { 2, 20, 31 }, { 0, 6, height + 24 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26543, { 0, 0, height + 16 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26543), { 0, 0, height + 16 },
                             { 2, 20, 31 }, { 0, 6, height + 24 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26546, { 0, 0, height + 16 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26546), { 0, 0, height + 16 },
                             { 2, 20, 31 }, { 29, 6, height + 24 });
                         break;
                 }
@@ -12574,23 +12626,23 @@ static void multi_dimension_rc_track_multidim_inverted_flat_to_90_deg_quarter_lo
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16208, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height + 24 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16208), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height + 24 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16211, { 0, 0, height }, { 2, 20, 31 },
-                            { 24, 6, height + 8 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16211), { 0, 0, height },
+                            { 2, 20, 31 }, { 24, 6, height + 8 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16214, { 0, 0, height }, { 2, 20, 31 },
-                            { 24, 6, height + 8 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16214), { 0, 0, height },
+                            { 2, 20, 31 }, { 24, 6, height + 8 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16217, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height + 24 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16217), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height + 24 });
                         break;
                 }
                 if (direction == 0 || direction == 3)
@@ -12606,23 +12658,23 @@ static void multi_dimension_rc_track_multidim_inverted_flat_to_90_deg_quarter_lo
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16207, { 0, 0, height }, { 2, 20, 31 },
-                            { -8, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16207), { 0, 0, height },
+                            { 2, 20, 31 }, { -8, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16210, { 0, 0, height }, { 2, 20, 63 },
-                            { 24, 6, height + 8 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16210), { 0, 0, height },
+                            { 2, 20, 63 }, { 24, 6, height + 8 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16213, { 0, 0, height }, { 2, 20, 63 },
-                            { 24, 6, height + 8 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16213), { 0, 0, height },
+                            { 2, 20, 63 }, { 24, 6, height + 8 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16216, { 0, 0, height }, { 2, 20, 31 },
-                            { -8, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16216), { 0, 0, height },
+                            { 2, 20, 31 }, { -8, 6, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -12634,23 +12686,23 @@ static void multi_dimension_rc_track_multidim_inverted_flat_to_90_deg_quarter_lo
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16206, { 0, 0, height }, { 2, 20, 31 },
-                            { 4, 6, height + 8 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16206), { 0, 0, height },
+                            { 2, 20, 31 }, { 4, 6, height + 8 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16209, { 0, 0, height }, { 2, 20, 31 },
-                            { 24, 6, height + 8 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16209), { 0, 0, height },
+                            { 2, 20, 31 }, { 24, 6, height + 8 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16212, { 0, 0, height }, { 2, 20, 31 },
-                            { 24, 6, height + 8 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16212), { 0, 0, height },
+                            { 2, 20, 31 }, { 24, 6, height + 8 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16215, { 0, 0, height }, { 2, 20, 31 },
-                            { 4, 6, height + 8 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16215), { 0, 0, height },
+                            { 2, 20, 31 }, { 4, 6, height + 8 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -12680,7 +12732,7 @@ static void multi_dimension_rc_track_block_brakes(
         };
 
         PaintAddImageAsParentRotated(
-            session, direction, session.TrackColours[SCHEME_TRACK] | imageIds[direction][isClosed], { 0, 0, height },
+            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][isClosed]), { 0, 0, height },
             { 32, 20, 3 }, { 0, 6, height });
         metal_a_supports_paint_setup(
             session, METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -12698,8 +12750,8 @@ static void multi_dimension_rc_track_block_brakes(
         };
 
         PaintAddImageAsParentRotated(
-            session, direction, session.TrackColours[SCHEME_TRACK] | imageIds[direction][isClosed], { 0, 0, height + 24 },
-            { 32, 20, 3 }, { 0, 6, height + 24 });
+            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][isClosed]),
+            { 0, 0, height + 24 }, { 32, 20, 3 }, { 0, 6, height + 24 });
 
         paint_util_set_segment_support_height(
             session, paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
@@ -12728,23 +12780,23 @@ static void multi_dimension_rc_track_multidim_90_deg_up_to_inverted_flat_quarter
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16206, { 0, 0, height }, { 2, 20, 31 },
-                            { 4, 6, height + 8 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16206), { 0, 0, height },
+                            { 2, 20, 31 }, { 4, 6, height + 8 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16209, { 0, 0, height }, { 2, 20, 31 },
-                            { 24, 6, height + 8 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16209), { 0, 0, height },
+                            { 2, 20, 31 }, { 24, 6, height + 8 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16212, { 0, 0, height }, { 2, 20, 31 },
-                            { 24, 6, height + 8 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16212), { 0, 0, height },
+                            { 2, 20, 31 }, { 24, 6, height + 8 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16215, { 0, 0, height }, { 2, 20, 31 },
-                            { 4, 6, height + 8 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16215), { 0, 0, height },
+                            { 2, 20, 31 }, { 4, 6, height + 8 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -12756,23 +12808,23 @@ static void multi_dimension_rc_track_multidim_90_deg_up_to_inverted_flat_quarter
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16207, { 0, 0, height }, { 2, 20, 31 },
-                            { -8, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16207), { 0, 0, height },
+                            { 2, 20, 31 }, { -8, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16210, { 0, 0, height }, { 2, 20, 63 },
-                            { 24, 6, height + 8 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16210), { 0, 0, height },
+                            { 2, 20, 63 }, { 24, 6, height + 8 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16213, { 0, 0, height }, { 2, 20, 63 },
-                            { 24, 6, height + 8 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16213), { 0, 0, height },
+                            { 2, 20, 63 }, { 24, 6, height + 8 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16216, { 0, 0, height }, { 2, 20, 31 },
-                            { -8, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16216), { 0, 0, height },
+                            { 2, 20, 31 }, { -8, 6, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -12784,23 +12836,23 @@ static void multi_dimension_rc_track_multidim_90_deg_up_to_inverted_flat_quarter
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16208, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height + 24 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16208), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height + 24 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16211, { 0, 0, height }, { 2, 20, 31 },
-                            { 24, 6, height + 8 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16211), { 0, 0, height },
+                            { 2, 20, 31 }, { 24, 6, height + 8 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16214, { 0, 0, height }, { 2, 20, 31 },
-                            { 24, 6, height + 8 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16214), { 0, 0, height },
+                            { 2, 20, 31 }, { 24, 6, height + 8 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16217, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height + 24 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16217), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height + 24 });
                         break;
                 }
                 if (direction == 0 || direction == 3)
@@ -12822,22 +12874,22 @@ static void multi_dimension_rc_track_multidim_90_deg_up_to_inverted_flat_quarter
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26537, { 0, 0, height - 16 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26537), { 0, 0, height - 16 },
                             { 2, 20, 31 }, { 28, 6, height - 8 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26540, { 0, 0, height - 16 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26540), { 0, 0, height - 16 },
                             { 2, 20, 31 }, { 0, 6, height - 8 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26543, { 0, 0, height - 16 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26543), { 0, 0, height - 16 },
                             { 2, 20, 31 }, { 0, 6, height - 8 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26546, { 0, 0, height - 16 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26546), { 0, 0, height - 16 },
                             { 2, 20, 31 }, { 28, 6, height - 8 });
                         break;
                 }
@@ -12850,22 +12902,22 @@ static void multi_dimension_rc_track_multidim_90_deg_up_to_inverted_flat_quarter
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26538, { 0, 0, height - 16 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26538), { 0, 0, height - 16 },
                             { 2, 20, 31 }, { 24, 6, height - 16 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26541, { 0, 0, height - 16 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26541), { 0, 0, height - 16 },
                             { 2, 20, 63 }, { 0, 6, height - 8 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26544, { 0, 0, height - 16 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26544), { 0, 0, height - 16 },
                             { 2, 20, 63 }, { 0, 6, height - 8 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26547, { 0, 0, height - 16 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26547), { 0, 0, height - 16 },
                             { 2, 20, 31 }, { 24, 6, height - 16 });
                         break;
                 }
@@ -12878,22 +12930,22 @@ static void multi_dimension_rc_track_multidim_90_deg_up_to_inverted_flat_quarter
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26539, { 0, 0, height - 16 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26539), { 0, 0, height - 16 },
                             { 32, 20, 3 }, { 0, 6, height - 16 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26542, { 0, 0, height - 16 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26542), { 0, 0, height - 16 },
                             { 2, 20, 31 }, { 0, 6, height - 8 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26545, { 0, 0, height - 16 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26545), { 0, 0, height - 16 },
                             { 2, 20, 31 }, { 0, 6, height - 8 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26548, { 0, 0, height - 16 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26548), { 0, 0, height - 16 },
                             { 32, 20, 3 }, { 0, 6, height - 16 });
                         break;
                 }
@@ -12923,22 +12975,22 @@ static void multi_dimension_rc_track_multidim_flat_to_90_deg_down_quarter_loop(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26539, { 0, 0, height + 16 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26539), { 0, 0, height + 16 },
                             { 32, 20, 3 }, { 0, 6, height + 16 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26542, { 0, 0, height + 16 }, { 2, 20, 3 },
-                            { 0, 6, height + 18 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26542), { 0, 0, height + 16 },
+                            { 2, 20, 3 }, { 0, 6, height + 18 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26545, { 0, 0, height + 16 }, { 2, 20, 3 },
-                            { 0, 6, height + 18 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26545), { 0, 0, height + 16 },
+                            { 2, 20, 3 }, { 0, 6, height + 18 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26548, { 0, 0, height + 16 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26548), { 0, 0, height + 16 },
                             { 32, 20, 3 }, { 0, 6, height + 16 });
                         break;
                 }
@@ -12955,22 +13007,22 @@ static void multi_dimension_rc_track_multidim_flat_to_90_deg_down_quarter_loop(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26538, { 0, 0, height + 16 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26538), { 0, 0, height + 16 },
                             { 2, 20, 31 }, { 24, 6, height + 16 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26541, { 0, 0, height + 16 }, { 2, 20, 3 },
-                            { 0, 6, height + 18 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26541), { 0, 0, height + 16 },
+                            { 2, 20, 3 }, { 0, 6, height + 18 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26544, { 0, 0, height + 16 }, { 2, 20, 3 },
-                            { 0, 6, height + 18 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26544), { 0, 0, height + 16 },
+                            { 2, 20, 3 }, { 0, 6, height + 18 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26547, { 0, 0, height + 16 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26547), { 0, 0, height + 16 },
                             { 2, 20, 31 }, { 24, 6, height + 16 });
                         break;
                 }
@@ -12983,22 +13035,22 @@ static void multi_dimension_rc_track_multidim_flat_to_90_deg_down_quarter_loop(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26537, { 0, 0, height + 16 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26537), { 0, 0, height + 16 },
                             { 2, 20, 31 }, { 28, 6, height + 24 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26540, { 0, 0, height + 16 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26540), { 0, 0, height + 16 },
                             { 2, 20, 31 }, { 0, 6, height + 24 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26543, { 0, 0, height + 16 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26543), { 0, 0, height + 16 },
                             { 2, 20, 31 }, { 0, 6, height + 24 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26546, { 0, 0, height + 16 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26546), { 0, 0, height + 16 },
                             { 2, 20, 31 }, { 29, 6, height + 24 });
                         break;
                 }
@@ -13019,23 +13071,23 @@ static void multi_dimension_rc_track_multidim_flat_to_90_deg_down_quarter_loop(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16208, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height + 24 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16208), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height + 24 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16211, { 0, 0, height }, { 2, 20, 31 },
-                            { 24, 6, height + 8 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16211), { 0, 0, height },
+                            { 2, 20, 31 }, { 24, 6, height + 8 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16214, { 0, 0, height }, { 2, 20, 31 },
-                            { 24, 6, height + 8 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16214), { 0, 0, height },
+                            { 2, 20, 31 }, { 24, 6, height + 8 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16217, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height + 24 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16217), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height + 24 });
                         break;
                 }
                 if (direction == 0 || direction == 3)
@@ -13051,23 +13103,23 @@ static void multi_dimension_rc_track_multidim_flat_to_90_deg_down_quarter_loop(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16207, { 0, 0, height }, { 2, 20, 31 },
-                            { -8, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16207), { 0, 0, height },
+                            { 2, 20, 31 }, { -8, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16210, { 0, 0, height }, { 2, 20, 63 },
-                            { 24, 6, height + 8 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16210), { 0, 0, height },
+                            { 2, 20, 63 }, { 24, 6, height + 8 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16213, { 0, 0, height }, { 2, 20, 63 },
-                            { 24, 6, height + 8 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16213), { 0, 0, height },
+                            { 2, 20, 63 }, { 24, 6, height + 8 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16216, { 0, 0, height }, { 2, 20, 31 },
-                            { -8, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16216), { 0, 0, height },
+                            { 2, 20, 31 }, { -8, 6, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -13079,23 +13131,23 @@ static void multi_dimension_rc_track_multidim_flat_to_90_deg_down_quarter_loop(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16206, { 0, 0, height }, { 2, 20, 31 },
-                            { 4, 6, height + 8 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16206), { 0, 0, height },
+                            { 2, 20, 31 }, { 4, 6, height + 8 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16209, { 0, 0, height }, { 2, 20, 31 },
-                            { 24, 6, height + 8 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16209), { 0, 0, height },
+                            { 2, 20, 31 }, { 24, 6, height + 8 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16212, { 0, 0, height }, { 2, 20, 31 },
-                            { 24, 6, height + 8 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16212), { 0, 0, height },
+                            { 2, 20, 31 }, { 24, 6, height + 8 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16215, { 0, 0, height }, { 2, 20, 31 },
-                            { 4, 6, height + 8 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16215), { 0, 0, height },
+                            { 2, 20, 31 }, { 4, 6, height + 8 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -13122,23 +13174,23 @@ static void multi_dimension_rc_track_multidim_inverted_90_deg_up_to_flat_quarter
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16206, { 0, 0, height }, { 2, 20, 31 },
-                            { 4, 6, height + 8 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16206), { 0, 0, height },
+                            { 2, 20, 31 }, { 4, 6, height + 8 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16209, { 0, 0, height }, { 2, 20, 31 },
-                            { 24, 6, height + 8 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16209), { 0, 0, height },
+                            { 2, 20, 31 }, { 24, 6, height + 8 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16212, { 0, 0, height }, { 2, 20, 31 },
-                            { 24, 6, height + 8 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16212), { 0, 0, height },
+                            { 2, 20, 31 }, { 24, 6, height + 8 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16215, { 0, 0, height }, { 2, 20, 31 },
-                            { 4, 6, height + 8 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16215), { 0, 0, height },
+                            { 2, 20, 31 }, { 4, 6, height + 8 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -13150,23 +13202,23 @@ static void multi_dimension_rc_track_multidim_inverted_90_deg_up_to_flat_quarter
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16207, { 0, 0, height }, { 2, 20, 31 },
-                            { -8, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16207), { 0, 0, height },
+                            { 2, 20, 31 }, { -8, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16210, { 0, 0, height }, { 2, 20, 63 },
-                            { 24, 6, height + 8 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16210), { 0, 0, height },
+                            { 2, 20, 63 }, { 24, 6, height + 8 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16213, { 0, 0, height }, { 2, 20, 63 },
-                            { 24, 6, height + 8 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16213), { 0, 0, height },
+                            { 2, 20, 63 }, { 24, 6, height + 8 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16216, { 0, 0, height }, { 2, 20, 31 },
-                            { -8, 6, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16216), { 0, 0, height },
+                            { 2, 20, 31 }, { -8, 6, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -13178,23 +13230,23 @@ static void multi_dimension_rc_track_multidim_inverted_90_deg_up_to_flat_quarter
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16208, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height + 24 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16208), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height + 24 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16211, { 0, 0, height }, { 2, 20, 31 },
-                            { 24, 6, height + 8 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16211), { 0, 0, height },
+                            { 2, 20, 31 }, { 24, 6, height + 8 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16214, { 0, 0, height }, { 2, 20, 31 },
-                            { 24, 6, height + 8 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16214), { 0, 0, height },
+                            { 2, 20, 31 }, { 24, 6, height + 8 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 16217, { 0, 0, height }, { 32, 20, 3 },
-                            { 0, 6, height + 24 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16217), { 0, 0, height },
+                            { 32, 20, 3 }, { 0, 6, height + 24 });
                         break;
                 }
                 if (direction == 0 || direction == 3)
@@ -13216,22 +13268,22 @@ static void multi_dimension_rc_track_multidim_inverted_90_deg_up_to_flat_quarter
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26537, { 0, 0, height - 16 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26537), { 0, 0, height - 16 },
                             { 2, 20, 31 }, { 28, 6, height - 8 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26540, { 0, 0, height - 16 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26540), { 0, 0, height - 16 },
                             { 2, 20, 31 }, { 0, 6, height - 8 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26543, { 0, 0, height - 16 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26543), { 0, 0, height - 16 },
                             { 2, 20, 31 }, { 0, 6, height - 8 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26546, { 0, 0, height - 16 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26546), { 0, 0, height - 16 },
                             { 2, 20, 31 }, { 28, 6, height - 8 });
                         break;
                 }
@@ -13244,22 +13296,22 @@ static void multi_dimension_rc_track_multidim_inverted_90_deg_up_to_flat_quarter
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26538, { 0, 0, height - 16 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26538), { 0, 0, height - 16 },
                             { 2, 20, 31 }, { 24, 6, height - 16 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26541, { 0, 0, height - 16 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26541), { 0, 0, height - 16 },
                             { 2, 20, 63 }, { 0, 6, height - 8 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26544, { 0, 0, height - 16 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26544), { 0, 0, height - 16 },
                             { 2, 20, 63 }, { 0, 6, height - 8 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26547, { 0, 0, height - 16 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26547), { 0, 0, height - 16 },
                             { 2, 20, 31 }, { 24, 6, height - 16 });
                         break;
                 }
@@ -13272,22 +13324,22 @@ static void multi_dimension_rc_track_multidim_inverted_90_deg_up_to_flat_quarter
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26539, { 0, 0, height - 16 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26539), { 0, 0, height - 16 },
                             { 32, 20, 3 }, { 0, 6, height - 16 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26542, { 0, 0, height - 16 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26542), { 0, 0, height - 16 },
                             { 2, 20, 31 }, { 0, 6, height - 8 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26545, { 0, 0, height - 16 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26545), { 0, 0, height - 16 },
                             { 2, 20, 31 }, { 0, 6, height - 8 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26548, { 0, 0, height - 16 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26548), { 0, 0, height - 16 },
                             { 32, 20, 3 }, { 0, 6, height - 16 });
                         break;
                 }

--- a/src/openrct2/ride/coaster/ReverseFreefallCoaster.cpp
+++ b/src/openrct2/ride/coaster/ReverseFreefallCoaster.cpp
@@ -201,13 +201,13 @@ static void paint_reverse_freefall_rc_flat(
 {
     if (direction & 1)
     {
-        uint32_t imageId = SPR_REVERSE_FREEFALL_RC_FLAT_NW_SE | session.TrackColours[SCHEME_TRACK];
+        auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_REVERSE_FREEFALL_RC_FLAT_NW_SE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 20, 32, 1 }, { 6, 0, height });
         paint_util_push_tunnel_right(session, height, TUNNEL_SQUARE_FLAT);
     }
     else
     {
-        uint32_t imageId = SPR_REVERSE_FREEFALL_RC_FLAT_SW_NE | session.TrackColours[SCHEME_TRACK];
+        auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_REVERSE_FREEFALL_RC_FLAT_SW_NE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 20, 1 }, { 0, 6, height });
         paint_util_push_tunnel_left(session, height, TUNNEL_SQUARE_FLAT);
     }
@@ -221,16 +221,16 @@ static void paint_reverse_freefall_rc_station(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId;
+    ImageId imageId;
 
     if (direction == 0 || direction == 2)
     {
         // height -= 2 (height - 2)
-        imageId = SPR_STATION_BASE_B_SW_NE | session.TrackColours[SCHEME_MISC];
+        imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_STATION_BASE_B_SW_NE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height - 2 }, { 32, 28, 1 }, { 0, 2, height });
         // height += 2 (height)
 
-        imageId = reverse_freefall_rc_track_pieces_station[direction] | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(reverse_freefall_rc_track_pieces_station[direction]);
         PaintAddImageAsChild(session, imageId, { 0, 0, height }, { 32, 20, 1 }, { 0, 6, height });
 
         wooden_a_supports_paint_setup(session, (direction & 1) ? 1 : 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -239,11 +239,11 @@ static void paint_reverse_freefall_rc_station(
     else if (direction == 1 || direction == 3)
     {
         // height -= 2 (height - 2)
-        imageId = SPR_STATION_BASE_B_NW_SE | session.TrackColours[SCHEME_MISC];
+        imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_STATION_BASE_B_NW_SE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height - 2 }, { 28, 32, 1 }, { 2, 0, height });
         // height += 2 (height)
 
-        imageId = reverse_freefall_rc_track_pieces_station[direction] | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(reverse_freefall_rc_track_pieces_station[direction]);
         PaintAddImageAsChild(session, imageId, { 0, 0, height }, { 20, 32, 1 }, { 6, 0, height });
 
         wooden_a_supports_paint_setup(session, (direction & 1) ? 1 : 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -265,10 +265,10 @@ static void paint_reverse_freefall_rc_slope(
     static constexpr const int32_t supportHeights[] = { 48, 64, 128, 176, 208, 240, 240 };
     static constexpr const int32_t tunnelOffsets03[] = { 0, 0, 0, 16, 64 };
 
-    uint32_t supportsImageId = reverse_freefall_rc_track_pieces_slope_supports[trackSequence][direction]
-        | session.TrackColours[SCHEME_SUPPORTS];
-    uint32_t trackImageId = reverse_freefall_rc_track_pieces_slope[trackSequence][direction]
-        | session.TrackColours[SCHEME_TRACK];
+    auto supportsImageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(
+        reverse_freefall_rc_track_pieces_slope_supports[trackSequence][direction]);
+    auto trackImageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+        reverse_freefall_rc_track_pieces_slope[trackSequence][direction]);
     int8_t bbHeight;
     bool isDirection03 = (direction == 0 || direction == 3);
     switch (trackSequence)
@@ -312,14 +312,14 @@ static void paint_reverse_freefall_rc_slope(
         case 5:
             if (wooden_a_supports_paint_setup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]))
             {
-                uint32_t floorImageId;
+                ImageId floorImageId;
                 if (direction & 1)
                 {
-                    floorImageId = SPR_FLOOR_PLANKS_90_DEG | session.TrackColours[SCHEME_SUPPORTS];
+                    floorImageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_FLOOR_PLANKS_90_DEG);
                 }
                 else
                 {
-                    floorImageId = SPR_FLOOR_PLANKS | session.TrackColours[SCHEME_SUPPORTS];
+                    floorImageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_FLOOR_PLANKS);
                 }
                 PaintAddImageAsParent(session, floorImageId, { 0, 0, height }, { 26, 26, 126 }, { 3, 3, height });
                 PaintAddImageAsChildRotated(
@@ -361,18 +361,18 @@ static void paint_reverse_freefall_rc_vertical(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t supportsImageId, trackImageId;
+    ImageId supportsImageId, trackImageId;
     switch (trackSequence)
     {
         case 0:
-            supportsImageId = reverse_freefall_rc_track_pieces_vertical_supports[direction]
-                | session.TrackColours[SCHEME_SUPPORTS];
+            supportsImageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(
+                reverse_freefall_rc_track_pieces_vertical_supports[direction]);
             PaintAddImageAsParent(session, supportsImageId, { 0, 0, height }, { 26, 26, 79 }, { 3, 3, height });
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
             paint_util_set_general_support_height(session, height + 80, 0x20);
             break;
         case 1:
-            trackImageId = reverse_freefall_rc_track_pieces_vertical[direction] | session.TrackColours[SCHEME_TRACK];
+            trackImageId = session.TrackColours[SCHEME_TRACK].WithIndex(reverse_freefall_rc_track_pieces_vertical[direction]);
             if (direction == 0 || direction == 3)
             {
                 PaintAddImageAsParentRotated(
@@ -403,17 +403,14 @@ static void paint_reverse_freefall_rc_onride_photo(
 
     // The straight track without booster is borrowed from the APVC.
     // It has one track colour, instead of the two that the Reverse Freefall Colour has.
-    uint32_t colour = session.TrackColours[SCHEME_TRACK];
+    auto colour = session.TrackColours[SCHEME_TRACK];
     if (!trackElement.IsGhost() && !trackElement.IsHighlighted())
     {
-        // Replace remap colour 1 (bits 19-23) with a copy of remap colour 2 (bits 24-28).
-        colour_t colour2 = (colour >> 24) & 31;
-        colour &= ~0xF80000;
-        colour |= (colour2 << 19);
+        colour = colour.WithPrimary(colour.GetSecondary());
     }
 
-    uint32_t imageId = imageIds[direction] | colour;
-    PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 1 }, { 0, 6, height });
+    PaintAddImageAsParentRotated(
+        session, direction, colour.WithIndex(imageIds[direction]), { 0, 0, height }, { 32, 20, 1 }, { 0, 6, height });
 
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
 

--- a/src/openrct2/ride/coaster/ReverserRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/ReverserRollerCoaster.cpp
@@ -57,14 +57,14 @@ static void reverser_rc_track_flat(
             case 0:
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21520, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21520), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21521, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21521), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -77,14 +77,14 @@ static void reverser_rc_track_flat(
             case 0:
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21504, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21504), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21505, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21505), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -107,11 +107,11 @@ static void reverser_rc_track_station(
     };
 
     PaintAddImageAsParentRotated(
-        session, direction, imageIds[direction][1] | session.TrackColours[SCHEME_MISC], { 0, 0, height }, { 32, 27, 2 },
-        { 0, 2, height });
+        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][1]), { 0, 0, height },
+        { 32, 27, 2 }, { 0, 2, height });
     PaintAddImageAsChildRotated(
-        session, direction, imageIds[direction][0] | session.TrackColours[SCHEME_TRACK], { 0, 0, height }, { 32, 27, 2 },
-        { 0, 2, height });
+        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]), { 0, 0, height },
+        { 32, 27, 2 }, { 0, 2, height });
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
     track_paint_util_draw_station_2(session, ride, direction, height, trackElement, 9, 11);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -130,25 +130,25 @@ static void reverser_rc_track_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21530, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21530), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 wooden_a_supports_paint_setup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21531, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21531), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 wooden_a_supports_paint_setup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21532, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21532), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 wooden_a_supports_paint_setup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21533, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21533), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 wooden_a_supports_paint_setup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -160,25 +160,25 @@ static void reverser_rc_track_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21516, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21516), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 wooden_a_supports_paint_setup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21517, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21517), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 wooden_a_supports_paint_setup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21518, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21518), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 wooden_a_supports_paint_setup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21519, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21519), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 wooden_a_supports_paint_setup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -207,25 +207,25 @@ static void reverser_rc_track_flat_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21522, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21522), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 wooden_a_supports_paint_setup(session, 0, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21523, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21523), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 wooden_a_supports_paint_setup(session, 1, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21524, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21524), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 wooden_a_supports_paint_setup(session, 0, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21525, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21525), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 wooden_a_supports_paint_setup(session, 1, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -237,25 +237,25 @@ static void reverser_rc_track_flat_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21508, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21508), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 wooden_a_supports_paint_setup(session, 0, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21509, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21509), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 wooden_a_supports_paint_setup(session, 1, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21510, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21510), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 wooden_a_supports_paint_setup(session, 0, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21511, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21511), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 wooden_a_supports_paint_setup(session, 1, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -284,25 +284,25 @@ static void reverser_rc_track_25_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21526, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21526), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 wooden_a_supports_paint_setup(session, 0, 5, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21527, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21527), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 wooden_a_supports_paint_setup(session, 1, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21528, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21528), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 wooden_a_supports_paint_setup(session, 0, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21529, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21529), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 wooden_a_supports_paint_setup(session, 1, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -314,25 +314,25 @@ static void reverser_rc_track_25_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21512, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21512), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 wooden_a_supports_paint_setup(session, 0, 5, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21513, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21513), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 wooden_a_supports_paint_setup(session, 1, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21514, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21514), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 wooden_a_supports_paint_setup(session, 0, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21515, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21515), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 wooden_a_supports_paint_setup(session, 1, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -386,22 +386,26 @@ static void reverser_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21543, { 0, 2, height }, { 32, 27, 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21543), { 0, 2, height },
+                        { 32, 27, 2 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21548, { 0, 2, height }, { 32, 27, 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21548), { 0, 2, height },
+                        { 32, 27, 2 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21553, { 0, 2, height }, { 32, 32, 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21553), { 0, 2, height },
+                        { 32, 32, 2 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21538, { 0, 2, height }, { 32, 32, 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21538), { 0, 2, height },
+                        { 32, 32, 2 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -422,22 +426,26 @@ static void reverser_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21542, { 0, 0, height }, { 32, 16, 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21542), { 0, 0, height },
+                        { 32, 16, 2 });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21547, { 0, 0, height }, { 32, 16, 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21547), { 0, 0, height },
+                        { 32, 16, 2 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21552, { 0, 16, height }, { 32, 16, 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21552), { 0, 16, height },
+                        { 32, 16, 2 });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21537, { 0, 16, height }, { 32, 16, 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21537), { 0, 16, height },
+                        { 32, 16, 2 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -453,22 +461,26 @@ static void reverser_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21541, { 0, 16, height }, { 16, 16, 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21541), { 0, 16, height },
+                        { 16, 16, 2 });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21546, { 16, 16, height }, { 16, 16, 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21546), { 16, 16, height },
+                        { 16, 16, 2 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21551, { 16, 0, height }, { 16, 16, 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21551), { 16, 0, height },
+                        { 16, 16, 2 });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21536, { 0, 0, height }, { 16, 16, 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21536), { 0, 0, height },
+                        { 16, 16, 2 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -490,22 +502,26 @@ static void reverser_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21540, { 16, 0, height }, { 16, 34, 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21540), { 16, 0, height },
+                        { 16, 34, 2 });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21545, { 0, 0, height }, { 16, 32, 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21545), { 0, 0, height },
+                        { 16, 32, 2 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21550, { 0, 0, height }, { 16, 32, 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21550), { 0, 0, height },
+                        { 16, 32, 2 });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21535, { 16, 0, height }, { 16, 32, 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21535), { 16, 0, height },
+                        { 16, 32, 2 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -521,22 +537,26 @@ static void reverser_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21539, { 2, 0, height }, { 32, 32, 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21539), { 2, 0, height },
+                        { 32, 32, 2 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21544, { 2, 0, height }, { 27, 32, 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21544), { 2, 0, height },
+                        { 27, 32, 2 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21549, { 2, 0, height }, { 27, 32, 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21549), { 2, 0, height },
+                        { 27, 32, 2 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21534, { 2, 0, height }, { 32, 32, 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21534), { 2, 0, height },
+                        { 32, 32, 2 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -576,26 +596,26 @@ static void reverser_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21566, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21566), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21570, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21570), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21569, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21569), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21573, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21573), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -611,26 +631,26 @@ static void reverser_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21567, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21567), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21571, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21571), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21568, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21568), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21572, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21572), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -646,26 +666,26 @@ static void reverser_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21568, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21568), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21572, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21572), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21567, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21567), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21571, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21571), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -681,26 +701,26 @@ static void reverser_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21569, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21569), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21573, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21573), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21566, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21566), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21570, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21570), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -731,26 +751,26 @@ static void reverser_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21574, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21574), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21578, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21578), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21577, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21577), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21581, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21581), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -766,26 +786,26 @@ static void reverser_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21575, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21575), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21579, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21579), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21576, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21576), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21580, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21580), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -801,26 +821,26 @@ static void reverser_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21576, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21576), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21580, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21580), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21575, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21575), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21579, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21579), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -836,26 +856,26 @@ static void reverser_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21577, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21577), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21581, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21581), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21574, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21574), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21578, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21578), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -886,26 +906,26 @@ static void reverser_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21559, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21559), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21562, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21562), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21565, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21565), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21556, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21556), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -924,23 +944,23 @@ static void reverser_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21558, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21558), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21561, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21561), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21564, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21564), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21555, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21555), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -952,26 +972,26 @@ static void reverser_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21557, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21557), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21560, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21560), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21563, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21563), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21554, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21554), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1009,14 +1029,14 @@ static void reverser_rc_track_brakes(
         case 0:
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 21506, { 0, 0, height }, { 32, 27, 2 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21506), { 0, 0, height }, { 32, 27, 2 },
                 { 0, 2, height });
             wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 21507, { 0, 0, height }, { 32, 27, 2 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21507), { 0, 0, height }, { 32, 27, 2 },
                 { 0, 2, height });
             wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -1038,26 +1058,26 @@ static void reverser_rc_track_left_reverser(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21582, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21582), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21588, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21588), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21594, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21594), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21600, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21600), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1073,26 +1093,26 @@ static void reverser_rc_track_left_reverser(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21585, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21585), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21591, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21591), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21597, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21597), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21603, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21603), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1104,26 +1124,26 @@ static void reverser_rc_track_left_reverser(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21586, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21586), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21592, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21592), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21598, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21598), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21604, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21604), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1135,26 +1155,26 @@ static void reverser_rc_track_left_reverser(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21587, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21587), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21593, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21593), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21599, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21599), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21605, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21605), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1166,26 +1186,26 @@ static void reverser_rc_track_left_reverser(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21583, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21583), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21589, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21589), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21595, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21595), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21601, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21601), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1197,26 +1217,26 @@ static void reverser_rc_track_left_reverser(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21584, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21584), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21590, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21590), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21596, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21596), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21602, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21602), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1247,26 +1267,26 @@ static void reverser_rc_track_right_reverser(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21596, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21596), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21602, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21602), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21584, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21584), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21590, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21590), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1282,26 +1302,26 @@ static void reverser_rc_track_right_reverser(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21599, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21599), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21605, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21605), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21587, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21587), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21593, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21593), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1313,26 +1333,26 @@ static void reverser_rc_track_right_reverser(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21598, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21598), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21604, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21604), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21586, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21586), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21592, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21592), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1344,26 +1364,26 @@ static void reverser_rc_track_right_reverser(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21597, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21597), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21603, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21603), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21585, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21585), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21591, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21591), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1375,26 +1395,26 @@ static void reverser_rc_track_right_reverser(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21595, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21595), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21601, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21601), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21583, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21583), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21589, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21589), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1406,26 +1426,26 @@ static void reverser_rc_track_right_reverser(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21594, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21594), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21600, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21600), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21582, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21582), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21588, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21588), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }

--- a/src/openrct2/ride/coaster/SideFrictionRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/SideFrictionRollerCoaster.cpp
@@ -76,37 +76,37 @@ static void side_friction_rc_track_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21662, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21662), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21664, { 0, 0, height }, { 32, 27, 0 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21664), { 0, 0, height }, { 32, 27, 0 },
                     { 0, 2, height + 27 });
                 wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21663, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21663), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21665, { 0, 0, height }, { 32, 27, 0 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21665), { 0, 0, height }, { 32, 27, 0 },
                     { 0, 2, height + 27 });
                 wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21666, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21666), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21668, { 0, 0, height }, { 32, 27, 0 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21668), { 0, 0, height }, { 32, 27, 0 },
                     { 0, 2, height + 27 });
                 wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21667, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21667), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21669, { 0, 0, height }, { 32, 27, 0 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21669), { 0, 0, height }, { 32, 27, 0 },
                     { 0, 2, height + 27 });
                 wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -119,20 +119,20 @@ static void side_friction_rc_track_flat(
             case 0:
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21606, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21606), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21608, { 0, 0, height }, { 32, 27, 0 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21608), { 0, 0, height }, { 32, 27, 0 },
                     { 0, 2, height + 27 });
                 wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21607, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21607), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21609, { 0, 0, height }, { 32, 27, 0 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21609), { 0, 0, height }, { 32, 27, 0 },
                     { 0, 2, height + 27 });
                 wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -156,7 +156,7 @@ static void side_friction_rc_track_station(
     };
 
     PaintAddImageAsParentRotated(
-        session, direction, imageIds[direction] | session.TrackColours[SCHEME_TRACK], { 0, 0, height }, { 32, 27, 2 },
+        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction]), { 0, 0, height }, { 32, 27, 2 },
         { 0, 2, height });
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
     track_paint_util_draw_station_2(session, ride, direction, height, trackElement, 9, 11);
@@ -176,37 +176,37 @@ static void side_friction_rc_track_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21678, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21678), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21690, { 0, 0, height }, { 32, 1, 9 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21690), { 0, 0, height }, { 32, 1, 9 },
                     { 0, 26, height + 5 });
                 wooden_a_supports_paint_setup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21679, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21679), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21691, { 0, 0, height }, { 32, 1, 9 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21691), { 0, 0, height }, { 32, 1, 9 },
                     { 0, 26, height + 5 });
                 wooden_a_supports_paint_setup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21680, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21680), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21692, { 0, 0, height }, { 32, 1, 9 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21692), { 0, 0, height }, { 32, 1, 9 },
                     { 0, 26, height + 5 });
                 wooden_a_supports_paint_setup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21681, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21681), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21693, { 0, 0, height }, { 32, 1, 9 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21693), { 0, 0, height }, { 32, 1, 9 },
                     { 0, 26, height + 5 });
                 wooden_a_supports_paint_setup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -218,37 +218,37 @@ static void side_friction_rc_track_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21622, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21622), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21634, { 0, 0, height }, { 32, 1, 9 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21634), { 0, 0, height }, { 32, 1, 9 },
                     { 0, 26, height + 5 });
                 wooden_a_supports_paint_setup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21623, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21623), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21635, { 0, 0, height }, { 32, 1, 9 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21635), { 0, 0, height }, { 32, 1, 9 },
                     { 0, 26, height + 5 });
                 wooden_a_supports_paint_setup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21624, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21624), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21636, { 0, 0, height }, { 32, 1, 9 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21636), { 0, 0, height }, { 32, 1, 9 },
                     { 0, 26, height + 5 });
                 wooden_a_supports_paint_setup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21625, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21625), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21637, { 0, 0, height }, { 32, 1, 9 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21637), { 0, 0, height }, { 32, 1, 9 },
                     { 0, 26, height + 5 });
                 wooden_a_supports_paint_setup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -277,37 +277,37 @@ static void side_friction_rc_track_flat_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21670, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21670), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21682, { 0, 0, height }, { 32, 1, 9 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21682), { 0, 0, height }, { 32, 1, 9 },
                     { 0, 26, height + 5 });
                 wooden_a_supports_paint_setup(session, 0, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21671, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21671), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21683, { 0, 0, height }, { 32, 1, 9 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21683), { 0, 0, height }, { 32, 1, 9 },
                     { 0, 26, height + 5 });
                 wooden_a_supports_paint_setup(session, 1, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21672, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21672), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21684, { 0, 0, height }, { 32, 1, 9 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21684), { 0, 0, height }, { 32, 1, 9 },
                     { 0, 26, height + 5 });
                 wooden_a_supports_paint_setup(session, 0, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21673, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21673), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21685, { 0, 0, height }, { 32, 1, 9 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21685), { 0, 0, height }, { 32, 1, 9 },
                     { 0, 26, height + 5 });
                 wooden_a_supports_paint_setup(session, 1, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -319,37 +319,37 @@ static void side_friction_rc_track_flat_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21614, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21614), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21626, { 0, 0, height }, { 32, 1, 9 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21626), { 0, 0, height }, { 32, 1, 9 },
                     { 0, 26, height + 5 });
                 wooden_a_supports_paint_setup(session, 0, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21615, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21615), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21627, { 0, 0, height }, { 32, 1, 9 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21627), { 0, 0, height }, { 32, 1, 9 },
                     { 0, 26, height + 5 });
                 wooden_a_supports_paint_setup(session, 1, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21616, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21616), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21628, { 0, 0, height }, { 32, 1, 9 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21628), { 0, 0, height }, { 32, 1, 9 },
                     { 0, 26, height + 5 });
                 wooden_a_supports_paint_setup(session, 0, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21617, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21617), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21629, { 0, 0, height }, { 32, 1, 9 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21629), { 0, 0, height }, { 32, 1, 9 },
                     { 0, 26, height + 5 });
                 wooden_a_supports_paint_setup(session, 1, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -378,37 +378,37 @@ static void side_friction_rc_track_25_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21674, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21674), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21686, { 0, 0, height }, { 32, 1, 9 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21686), { 0, 0, height }, { 32, 1, 9 },
                     { 0, 26, height + 5 });
                 wooden_a_supports_paint_setup(session, 0, 5, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21675, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21675), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21687, { 0, 0, height }, { 32, 1, 9 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21687), { 0, 0, height }, { 32, 1, 9 },
                     { 0, 26, height + 5 });
                 wooden_a_supports_paint_setup(session, 1, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21676, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21676), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21688, { 0, 0, height }, { 32, 1, 9 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21688), { 0, 0, height }, { 32, 1, 9 },
                     { 0, 26, height + 5 });
                 wooden_a_supports_paint_setup(session, 0, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21677, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21677), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21689, { 0, 0, height }, { 32, 1, 9 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21689), { 0, 0, height }, { 32, 1, 9 },
                     { 0, 26, height + 5 });
                 wooden_a_supports_paint_setup(session, 1, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -420,37 +420,37 @@ static void side_friction_rc_track_25_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21618, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21618), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21630, { 0, 0, height }, { 32, 1, 9 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21630), { 0, 0, height }, { 32, 1, 9 },
                     { 0, 26, height + 5 });
                 wooden_a_supports_paint_setup(session, 0, 5, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21619, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21619), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21631, { 0, 0, height }, { 32, 1, 9 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21631), { 0, 0, height }, { 32, 1, 9 },
                     { 0, 26, height + 5 });
                 wooden_a_supports_paint_setup(session, 1, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21620, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21620), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21632, { 0, 0, height }, { 32, 1, 9 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21632), { 0, 0, height }, { 32, 1, 9 },
                     { 0, 26, height + 5 });
                 wooden_a_supports_paint_setup(session, 0, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21621, { 0, 0, height }, { 32, 27, 2 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21621), { 0, 0, height }, { 32, 27, 2 },
                     { 0, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 21633, { 0, 0, height }, { 32, 1, 9 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21633), { 0, 0, height }, { 32, 1, 9 },
                     { 0, 26, height + 5 });
                 wooden_a_supports_paint_setup(session, 1, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -504,34 +504,38 @@ static void side_friction_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21727, { 0, 2, height }, { 32, 27, 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21727), { 0, 2, height },
+                        { 32, 27, 2 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21747, { 0, 2, height }, { 32, 27, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21747), { 0, 2, height },
+                        { 32, 27, 0 }, { 0, 2, height + 27 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21732, { 0, 2, height }, { 32, 27, 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21732), { 0, 2, height },
+                        { 32, 27, 2 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21752, { 0, 2, height }, { 32, 27, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21752), { 0, 2, height },
+                        { 32, 27, 0 }, { 0, 2, height + 27 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21737, { 0, 2, height }, { 32, 32, 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21737), { 0, 2, height },
+                        { 32, 32, 2 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21757, { 0, 2, height }, { 32, 32, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21757), { 0, 2, height },
+                        { 32, 32, 0 }, { 0, 2, height + 27 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21722, { 0, 2, height }, { 32, 32, 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21722), { 0, 2, height },
+                        { 32, 32, 2 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21742, { 0, 2, height }, { 32, 32, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21742), { 0, 2, height },
+                        { 32, 32, 0 }, { 0, 2, height + 27 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -552,34 +556,38 @@ static void side_friction_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21726, { 0, 0, height }, { 32, 16, 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21726), { 0, 0, height },
+                        { 32, 16, 2 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21746, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21746), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21731, { 0, 0, height }, { 32, 16, 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21731), { 0, 0, height },
+                        { 32, 16, 2 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21751, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21751), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21736, { 0, 16, height }, { 32, 16, 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21736), { 0, 16, height },
+                        { 32, 16, 2 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21756, { 0, 16, height }, { 32, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21756), { 0, 16, height },
+                        { 32, 16, 0 }, { 0, 16, height + 27 });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21721, { 0, 16, height }, { 32, 16, 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21721), { 0, 16, height },
+                        { 32, 16, 2 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21741, { 0, 16, height }, { 32, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21741), { 0, 16, height },
+                        { 32, 16, 0 }, { 0, 16, height + 27 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -595,34 +603,38 @@ static void side_friction_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21725, { 0, 16, height }, { 16, 16, 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21725), { 0, 16, height },
+                        { 16, 16, 2 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21745, { 0, 16, height }, { 16, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21745), { 0, 16, height },
+                        { 16, 16, 0 }, { 0, 16, height + 27 });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21730, { 16, 16, height }, { 16, 16, 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21730), { 16, 16, height },
+                        { 16, 16, 2 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21750, { 16, 16, height }, { 16, 16, 0 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21750), { 16, 16, height },
+                        { 16, 16, 0 }, { 16, 16, height + 27 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21735, { 16, 0, height }, { 16, 16, 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21735), { 16, 0, height },
+                        { 16, 16, 2 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21755, { 16, 0, height }, { 16, 16, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21755), { 16, 0, height },
+                        { 16, 16, 0 }, { 16, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21720, { 0, 0, height }, { 16, 16, 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21720), { 0, 0, height },
+                        { 16, 16, 2 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21740, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21740), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -644,34 +656,38 @@ static void side_friction_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21724, { 16, 0, height }, { 16, 34, 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21724), { 16, 0, height },
+                        { 16, 34, 2 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21744, { 16, 0, height }, { 16, 34, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21744), { 16, 0, height },
+                        { 16, 34, 0 }, { 16, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21729, { 0, 0, height }, { 16, 32, 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21729), { 0, 0, height },
+                        { 16, 32, 2 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21749, { 0, 0, height }, { 16, 32, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21749), { 0, 0, height },
+                        { 16, 32, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21734, { 0, 0, height }, { 16, 32, 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21734), { 0, 0, height },
+                        { 16, 32, 2 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21754, { 0, 0, height }, { 16, 32, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21754), { 0, 0, height },
+                        { 16, 32, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21719, { 16, 0, height }, { 16, 32, 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21719), { 16, 0, height },
+                        { 16, 32, 2 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21739, { 16, 0, height }, { 16, 32, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21739), { 16, 0, height },
+                        { 16, 32, 0 }, { 16, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -687,34 +703,38 @@ static void side_friction_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21723, { 2, 0, height }, { 32, 32, 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21723), { 2, 0, height },
+                        { 32, 32, 2 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21743, { 2, 0, height }, { 32, 32, 0 },
-                        { 2, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21743), { 2, 0, height },
+                        { 32, 32, 0 }, { 2, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21728, { 2, 0, height }, { 27, 32, 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21728), { 2, 0, height },
+                        { 27, 32, 2 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21748, { 2, 0, height }, { 27, 32, 0 },
-                        { 2, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21748), { 2, 0, height },
+                        { 27, 32, 0 }, { 2, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21733, { 2, 0, height }, { 27, 32, 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21733), { 2, 0, height },
+                        { 27, 32, 2 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21753, { 2, 0, height }, { 27, 32, 0 },
-                        { 2, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21753), { 2, 0, height },
+                        { 27, 32, 0 }, { 2, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21718, { 2, 0, height }, { 32, 32, 2 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21718), { 2, 0, height },
+                        { 32, 32, 2 });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21738, { 2, 0, height }, { 32, 32, 0 },
-                        { 2, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21738), { 2, 0, height },
+                        { 32, 32, 0 }, { 2, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -754,38 +774,38 @@ static void side_friction_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21888, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21888), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21904, { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21904), { 0, 0, height },
+                        { 32, 27, 0 }, { 0, 2, height + 27 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21892, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21892), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21908, { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21908), { 0, 0, height },
+                        { 32, 27, 0 }, { 0, 2, height + 27 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21891, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21891), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21907, { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21907), { 0, 0, height },
+                        { 32, 27, 0 }, { 0, 2, height + 27 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21895, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21895), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21911, { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21911), { 0, 0, height },
+                        { 32, 27, 0 }, { 0, 2, height + 27 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -801,38 +821,38 @@ static void side_friction_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21889, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21889), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21905, { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21905), { 0, 0, height },
+                        { 32, 26, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21893, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21893), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21909, { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21909), { 0, 0, height },
+                        { 32, 26, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21890, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21890), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21906, { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21906), { 0, 0, height },
+                        { 32, 26, 0 }, { 0, 6, height + 27 });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21894, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21894), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21910, { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21910), { 0, 0, height },
+                        { 32, 26, 0 }, { 0, 6, height + 27 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -848,38 +868,38 @@ static void side_friction_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21890, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21890), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21906, { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21906), { 0, 0, height },
+                        { 32, 26, 0 }, { 0, 6, height + 27 });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21894, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21894), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21910, { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21910), { 0, 0, height },
+                        { 32, 26, 0 }, { 0, 6, height + 27 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21889, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21889), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21905, { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21905), { 0, 0, height },
+                        { 32, 26, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21893, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21893), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21909, { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21909), { 0, 0, height },
+                        { 32, 26, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -895,38 +915,38 @@ static void side_friction_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21891, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21891), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21907, { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21907), { 0, 0, height },
+                        { 32, 27, 0 }, { 0, 2, height + 27 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21895, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21895), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21911, { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21911), { 0, 0, height },
+                        { 32, 27, 0 }, { 0, 2, height + 27 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21888, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21888), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21904, { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21904), { 0, 0, height },
+                        { 32, 27, 0 }, { 0, 2, height + 27 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21892, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21892), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21908, { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21908), { 0, 0, height },
+                        { 32, 27, 0 }, { 0, 2, height + 27 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -957,38 +977,38 @@ static void side_friction_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21896, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21896), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21912, { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21912), { 0, 0, height },
+                        { 32, 27, 0 }, { 0, 2, height + 27 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21900, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21900), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21916, { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21916), { 0, 0, height },
+                        { 32, 27, 0 }, { 0, 2, height + 27 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21899, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21899), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21915, { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21915), { 0, 0, height },
+                        { 32, 27, 0 }, { 0, 2, height + 27 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21903, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21903), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21919, { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21919), { 0, 0, height },
+                        { 32, 27, 0 }, { 0, 2, height + 27 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1004,38 +1024,38 @@ static void side_friction_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21897, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21897), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21913, { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21913), { 0, 0, height },
+                        { 32, 26, 0 }, { 0, 6, height + 27 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21901, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21901), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21917, { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21917), { 0, 0, height },
+                        { 32, 26, 0 }, { 0, 6, height + 27 });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21898, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21898), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21914, { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21914), { 0, 0, height },
+                        { 32, 26, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21902, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21902), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21918, { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21918), { 0, 0, height },
+                        { 32, 26, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1051,38 +1071,38 @@ static void side_friction_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21898, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21898), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21914, { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21914), { 0, 0, height },
+                        { 32, 26, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21902, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21902), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21918, { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21918), { 0, 0, height },
+                        { 32, 26, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21897, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21897), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21913, { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21913), { 0, 0, height },
+                        { 32, 26, 0 }, { 0, 6, height + 27 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21901, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21901), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21917, { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21917), { 0, 0, height },
+                        { 32, 26, 0 }, { 0, 6, height + 27 });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1098,38 +1118,38 @@ static void side_friction_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21899, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21899), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21915, { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21915), { 0, 0, height },
+                        { 32, 27, 0 }, { 0, 2, height + 27 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21903, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21903), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21919, { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21919), { 0, 0, height },
+                        { 32, 27, 0 }, { 0, 2, height + 27 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21896, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21896), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21912, { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21912), { 0, 0, height },
+                        { 32, 27, 0 }, { 0, 2, height + 27 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21900, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21900), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21916, { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21916), { 0, 0, height },
+                        { 32, 27, 0 }, { 0, 2, height + 27 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1160,38 +1180,38 @@ static void side_friction_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21699, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21699), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21711, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21711), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21702, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21702), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21714, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21714), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21705, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21705), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21717, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21717), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21696, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21696), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21708, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21708), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1210,35 +1230,35 @@ static void side_friction_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21698, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21698), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21710, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21710), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 0, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21701, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21701), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21713, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21713), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21704, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21704), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21716, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21716), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 16, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21695, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21695), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21707, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21707), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1250,38 +1270,38 @@ static void side_friction_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21697, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21697), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21709, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21709), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21700, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21700), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21712, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21712), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21703, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21703), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21715, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21715), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21694, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21694), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21706, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21706), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1319,20 +1339,20 @@ static void side_friction_rc_track_brakes(
         case 0:
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 21610, { 0, 0, height }, { 32, 27, 2 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21610), { 0, 0, height }, { 32, 27, 2 },
                 { 0, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 21612, { 0, 0, height }, { 32, 27, 0 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21612), { 0, 0, height }, { 32, 27, 0 },
                 { 0, 2, height + 27 });
             wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 21611, { 0, 0, height }, { 32, 27, 2 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21611), { 0, 0, height }, { 32, 27, 2 },
                 { 0, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 21613, { 0, 0, height }, { 32, 27, 0 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21613), { 0, 0, height }, { 32, 27, 0 },
                 { 0, 2, height + 27 });
             wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -1354,38 +1374,38 @@ static void side_friction_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21790, { 0, 0, height }, { 32, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21790), { 0, 0, height },
+                        { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21806, { 0, 0, height }, { 32, 32, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21806), { 0, 0, height },
+                        { 32, 32, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21794, { 0, 0, height }, { 32, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21794), { 0, 0, height },
+                        { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21810, { 0, 0, height }, { 32, 32, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21810), { 0, 0, height },
+                        { 32, 32, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21798, { 0, 0, height }, { 32, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21798), { 0, 0, height },
+                        { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21814, { 0, 0, height }, { 32, 32, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21814), { 0, 0, height },
+                        { 32, 32, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21802, { 0, 0, height }, { 32, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21802), { 0, 0, height },
+                        { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21818, { 0, 0, height }, { 32, 32, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21818), { 0, 0, height },
+                        { 32, 32, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1401,38 +1421,38 @@ static void side_friction_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21791, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21791), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21807, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21807), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21795, { 0, 0, height }, { 34, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21795), { 0, 0, height },
+                        { 34, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21811, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21811), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21799, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21799), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21815, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21815), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height + 27 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21803, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21803), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21819, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21819), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height + 27 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1444,38 +1464,38 @@ static void side_friction_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21792, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21792), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21808, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21808), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 16, height + 27 });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21796, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21796), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21812, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21812), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 16, height + 27 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21800, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21800), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21816, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21816), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21804, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21804), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21820, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21820), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1506,35 +1526,35 @@ static void side_friction_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21793, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21793), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21809, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21809), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 16, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21797, { 0, 0, height }, { 16, 18, 2 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21797), { 0, 0, height },
+                        { 16, 18, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21813, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21813), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21801, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21801), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21817, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21817), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21805, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21805), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21821, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21821), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 0, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -1555,38 +1575,38 @@ static void side_friction_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21758, { 0, 0, height }, { 32, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21758), { 0, 0, height },
+                        { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21774, { 0, 0, height }, { 32, 32, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21774), { 0, 0, height },
+                        { 32, 32, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21762, { 0, 0, height }, { 32, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21762), { 0, 0, height },
+                        { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21778, { 0, 0, height }, { 32, 32, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21778), { 0, 0, height },
+                        { 32, 32, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21766, { 0, 0, height }, { 32, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21766), { 0, 0, height },
+                        { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21782, { 0, 0, height }, { 32, 32, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21782), { 0, 0, height },
+                        { 32, 32, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21770, { 0, 0, height }, { 32, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21770), { 0, 0, height },
+                        { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21786, { 0, 0, height }, { 32, 32, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21786), { 0, 0, height },
+                        { 32, 32, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1602,38 +1622,38 @@ static void side_friction_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21759, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21759), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21775, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21775), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height + 27 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21763, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21763), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21779, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21779), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height + 27 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21767, { 0, 0, height }, { 34, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21767), { 0, 0, height },
+                        { 34, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21783, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21783), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21771, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21771), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21787, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21787), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1645,38 +1665,38 @@ static void side_friction_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21760, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21760), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21776, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21776), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21764, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21764), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21780, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21780), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21768, { 0, 0, height }, { 28, 28, 2 },
-                        { 4, 4, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21768), { 0, 0, height },
+                        { 28, 28, 2 }, { 4, 4, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21784, { 0, 0, height }, { 28, 28, 0 },
-                        { 4, 4, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21784), { 0, 0, height },
+                        { 28, 28, 0 }, { 4, 4, height + 27 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21772, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21772), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21788, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21788), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 16, height + 27 });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1707,35 +1727,35 @@ static void side_friction_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21761, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21761), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21777, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21777), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 0, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21765, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21765), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21781, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21781), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21769, { 0, 0, height }, { 16, 18, 2 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21769), { 0, 0, height },
+                        { 16, 18, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21785, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21785), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 16, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21773, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21773), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 21789, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21789), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -1776,8 +1796,8 @@ static void side_friction_rc_track_diag_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21849, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21849), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
             }
@@ -1787,8 +1807,8 @@ static void side_friction_rc_track_diag_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21825, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21825), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
             }
@@ -1802,11 +1822,11 @@ static void side_friction_rc_track_diag_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21846, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21846), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21850, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21850), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 27 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
@@ -1826,11 +1846,11 @@ static void side_friction_rc_track_diag_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21822, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21822), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21826, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21826), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 27 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
@@ -1860,11 +1880,11 @@ static void side_friction_rc_track_diag_flat(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21848, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21848), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21851, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21851), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 27 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
@@ -1884,11 +1904,11 @@ static void side_friction_rc_track_diag_flat(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21824, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21824), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21827, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 27 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21827), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 27 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
@@ -1906,8 +1926,8 @@ static void side_friction_rc_track_diag_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21847, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21847), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
             }
@@ -1917,8 +1937,8 @@ static void side_friction_rc_track_diag_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21823, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21823), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
             }
@@ -1942,8 +1962,8 @@ static void side_friction_rc_track_diag_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21867, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21867), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
             }
@@ -1953,8 +1973,8 @@ static void side_friction_rc_track_diag_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21843, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21843), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
             }
@@ -1968,11 +1988,11 @@ static void side_friction_rc_track_diag_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21864, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21864), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21868, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 43 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21868), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 43 });
                         wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
@@ -1992,11 +2012,11 @@ static void side_friction_rc_track_diag_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21840, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21840), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21844, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 43 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21844), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 43 });
                         wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
@@ -2026,11 +2046,11 @@ static void side_friction_rc_track_diag_25_deg_up(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21866, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21866), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21869, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 43 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21869), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 43 });
                         wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
@@ -2050,11 +2070,11 @@ static void side_friction_rc_track_diag_25_deg_up(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21842, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21842), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21845, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 43 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21845), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 43 });
                         wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
@@ -2072,8 +2092,8 @@ static void side_friction_rc_track_diag_25_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21865, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21865), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
             }
@@ -2083,8 +2103,8 @@ static void side_friction_rc_track_diag_25_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21841, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21841), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
             }
@@ -2108,8 +2128,8 @@ static void side_friction_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21855, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21855), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
             }
@@ -2119,8 +2139,8 @@ static void side_friction_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21831, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21831), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
             }
@@ -2134,11 +2154,11 @@ static void side_friction_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21852, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21852), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21856, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 35 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21856), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 35 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
@@ -2158,11 +2178,11 @@ static void side_friction_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21828, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21828), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21832, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 35 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21832), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 35 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
@@ -2192,11 +2212,11 @@ static void side_friction_rc_track_diag_flat_to_25_deg_up(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21854, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21854), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21857, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 35 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21857), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 35 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
@@ -2216,11 +2236,11 @@ static void side_friction_rc_track_diag_flat_to_25_deg_up(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21830, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21830), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21833, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 35 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21833), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 35 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
@@ -2238,8 +2258,8 @@ static void side_friction_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21853, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21853), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
             }
@@ -2249,8 +2269,8 @@ static void side_friction_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21829, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21829), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
             }
@@ -2274,8 +2294,8 @@ static void side_friction_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21861, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21861), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
             }
@@ -2285,8 +2305,8 @@ static void side_friction_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21837, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21837), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
             }
@@ -2300,11 +2320,11 @@ static void side_friction_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21858, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21858), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21862, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 35 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21862), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 35 });
                         wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
@@ -2324,11 +2344,11 @@ static void side_friction_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21834, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21834), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21838, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 35 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21838), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 35 });
                         wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
@@ -2358,11 +2378,11 @@ static void side_friction_rc_track_diag_25_deg_up_to_flat(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21860, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21860), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21863, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 35 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21863), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 35 });
                         wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
@@ -2382,11 +2402,11 @@ static void side_friction_rc_track_diag_25_deg_up_to_flat(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21836, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21836), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21839, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 35 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21839), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 35 });
                         wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
@@ -2404,8 +2424,8 @@ static void side_friction_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21859, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21859), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
             }
@@ -2415,8 +2435,8 @@ static void side_friction_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21835, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21835), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
             }
@@ -2440,8 +2460,8 @@ static void side_friction_rc_track_diag_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21865, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21865), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
             }
@@ -2451,8 +2471,8 @@ static void side_friction_rc_track_diag_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21841, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21841), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
             }
@@ -2466,11 +2486,11 @@ static void side_friction_rc_track_diag_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21866, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21866), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21869, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 43 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21869), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 43 });
                         wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
@@ -2490,11 +2510,11 @@ static void side_friction_rc_track_diag_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21842, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21842), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21845, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 43 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21845), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 43 });
                         wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
@@ -2524,11 +2544,11 @@ static void side_friction_rc_track_diag_25_deg_down(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21864, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21864), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21868, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 43 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21868), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 43 });
                         wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
@@ -2548,11 +2568,11 @@ static void side_friction_rc_track_diag_25_deg_down(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21840, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21840), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21844, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 43 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21844), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 43 });
                         wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
@@ -2570,8 +2590,8 @@ static void side_friction_rc_track_diag_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21867, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21867), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
             }
@@ -2581,8 +2601,8 @@ static void side_friction_rc_track_diag_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21843, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21843), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
             }
@@ -2606,8 +2626,8 @@ static void side_friction_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21859, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21859), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
             }
@@ -2617,8 +2637,8 @@ static void side_friction_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21835, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21835), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
             }
@@ -2630,11 +2650,11 @@ static void side_friction_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21860, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21860), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21863, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 35 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21863), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 35 });
                         wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
@@ -2654,11 +2674,11 @@ static void side_friction_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21836, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21836), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21839, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 35 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21839), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 35 });
                         wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
@@ -2686,11 +2706,11 @@ static void side_friction_rc_track_diag_flat_to_25_deg_down(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21858, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21858), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21862, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 35 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21862), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 35 });
                         wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
@@ -2710,11 +2730,11 @@ static void side_friction_rc_track_diag_flat_to_25_deg_down(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21834, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21834), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21838, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 35 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21838), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 35 });
                         wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
@@ -2730,8 +2750,8 @@ static void side_friction_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21861, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21861), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
             }
@@ -2741,8 +2761,8 @@ static void side_friction_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21837, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21837), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
             }
@@ -2767,8 +2787,8 @@ static void side_friction_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21853, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21853), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
             }
@@ -2778,8 +2798,8 @@ static void side_friction_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21829, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21829), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
             }
@@ -2793,11 +2813,11 @@ static void side_friction_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21854, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21854), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21857, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 35 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21857), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 35 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
@@ -2817,11 +2837,11 @@ static void side_friction_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21830, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21830), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21833, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 35 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21833), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 35 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
@@ -2851,11 +2871,11 @@ static void side_friction_rc_track_diag_25_deg_down_to_flat(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21852, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21852), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21856, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 35 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21856), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 35 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
@@ -2875,11 +2895,11 @@ static void side_friction_rc_track_diag_25_deg_down_to_flat(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21828, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21828), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21832, { -16, -16, height }, { 32, 32, 0 },
-                            { -16, -16, height + 35 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21832), { -16, -16, height },
+                            { 32, 32, 0 }, { -16, -16, height + 35 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
@@ -2897,8 +2917,8 @@ static void side_friction_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21855, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21855), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
             }
@@ -2908,8 +2928,8 @@ static void side_friction_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 21831, { -16, -16, height }, { 32, 32, 2 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21831), { -16, -16, height },
+                            { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
             }
@@ -2927,41 +2947,41 @@ static void side_friction_rc_track_60_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_60_DEG_UP_DIR_0_A, { 0, 0, height },
-                { 32, 27, 2 }, { 0, 2, height });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_60_DEG_UP_DIR_0_A),
+                { 0, 0, height }, { 32, 27, 2 }, { 0, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_60_DEG_UP_DIR_0_B, { 0, 0, height },
-                { 32, 1, 9 }, { 0, 26, height + 5 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_60_DEG_UP_DIR_0_B),
+                { 0, 0, height }, { 32, 1, 9 }, { 0, 26, height + 5 });
             wooden_a_supports_paint_setup(session, 0, 21, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_60_DEG_UP_DIR_1_A, { 0, 0, height },
-                { 32, 27, 2 }, { 0, 2, height });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_60_DEG_UP_DIR_1_A),
+                { 0, 0, height }, { 32, 27, 2 }, { 0, 2, height });
 
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_60_DEG_UP_DIR_1_B, { 0, 0, height },
-                { 32, 1, 9 }, { 0, 26, height + 5 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_60_DEG_UP_DIR_1_B),
+                { 0, 0, height }, { 32, 1, 9 }, { 0, 26, height + 5 });
 
             wooden_a_supports_paint_setup(session, 1, 22, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_60_DEG_UP_DIR_2_A, { 0, 0, height },
-                { 32, 27, 2 }, { 0, 2, height });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_60_DEG_UP_DIR_2_A),
+                { 0, 0, height }, { 32, 27, 2 }, { 0, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_60_DEG_UP_DIR_2_B, { 0, 0, height },
-                { 32, 1, 9 }, { 0, 26, height + 5 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_60_DEG_UP_DIR_2_B),
+                { 0, 0, height }, { 32, 1, 9 }, { 0, 26, height + 5 });
 
             wooden_a_supports_paint_setup(session, 0, 23, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_60_DEG_UP_DIR_3_A, { 0, 0, height },
-                { 32, 27, 2 }, { 0, 2, height });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_60_DEG_UP_DIR_3_A),
+                { 0, 0, height }, { 32, 27, 2 }, { 0, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_60_DEG_UP_DIR_3_B, { 0, 0, height },
-                { 32, 1, 9 }, { 0, 26, height + 5 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_60_DEG_UP_DIR_3_B),
+                { 0, 0, height }, { 32, 1, 9 }, { 0, 26, height + 5 });
             wooden_a_supports_paint_setup(session, 1, 24, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
     }
@@ -2993,37 +3013,45 @@ static void side_friction_rc_track_25_deg_up_to_60_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_25_DEG_UP_TO_60_DEG_UP_DIR_0_A,
+                session, direction,
+                session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_25_DEG_UP_TO_60_DEG_UP_DIR_0_A),
                 { 0, 0, height }, { 32, 27, 2 }, { 0, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_25_DEG_UP_TO_60_DEG_UP_DIR_0_B,
+                session, direction,
+                session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_25_DEG_UP_TO_60_DEG_UP_DIR_0_B),
                 { 0, 0, height }, { 32, 1, 9 }, { 0, 26, height + 5 });
             wooden_a_supports_paint_setup(session, 0, 13, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_25_DEG_UP_TO_60_DEG_UP_DIR_1_A,
+                session, direction,
+                session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_25_DEG_UP_TO_60_DEG_UP_DIR_1_A),
                 { 0, 0, height }, { 32, 27, 2 }, { 0, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_25_DEG_UP_TO_60_DEG_UP_DIR_1_B,
+                session, direction,
+                session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_25_DEG_UP_TO_60_DEG_UP_DIR_1_B),
                 { 0, 0, height }, { 32, 1, 9 }, { 0, 26, height + 5 });
             wooden_a_supports_paint_setup(session, 1, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_25_DEG_UP_TO_60_DEG_UP_DIR_2_A,
+                session, direction,
+                session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_25_DEG_UP_TO_60_DEG_UP_DIR_2_A),
                 { 0, 0, height }, { 32, 27, 2 }, { 0, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_25_DEG_UP_TO_60_DEG_UP_DIR_2_B,
+                session, direction,
+                session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_25_DEG_UP_TO_60_DEG_UP_DIR_2_B),
                 { 0, 0, height }, { 32, 1, 9 }, { 0, 26, height + 5 });
             wooden_a_supports_paint_setup(session, 0, 15, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_25_DEG_UP_TO_60_DEG_UP_DIR_3_A,
+                session, direction,
+                session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_25_DEG_UP_TO_60_DEG_UP_DIR_3_A),
                 { 0, 0, height }, { 32, 27, 2 }, { 0, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_25_DEG_UP_TO_60_DEG_UP_DIR_3_B,
+                session, direction,
+                session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_25_DEG_UP_TO_60_DEG_UP_DIR_3_B),
                 { 0, 0, height }, { 32, 1, 9 }, { 0, 26, height + 5 });
             wooden_a_supports_paint_setup(session, 1, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -3056,37 +3084,45 @@ static void side_friction_rc_track_60_deg_up_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_60_DEG_UP_TO_25_DEG_UP_DIR_0_A,
+                session, direction,
+                session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_60_DEG_UP_TO_25_DEG_UP_DIR_0_A),
                 { 0, 0, height }, { 32, 27, 2 }, { 0, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_60_DEG_UP_TO_25_DEG_UP_DIR_0_B,
+                session, direction,
+                session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_60_DEG_UP_TO_25_DEG_UP_DIR_0_B),
                 { 0, 0, height }, { 32, 1, 9 }, { 0, 26, height + 5 });
             wooden_a_supports_paint_setup(session, 0, 17, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_60_DEG_UP_TO_25_DEG_UP_DIR_1_A,
+                session, direction,
+                session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_60_DEG_UP_TO_25_DEG_UP_DIR_1_A),
                 { 0, 0, height }, { 32, 27, 2 }, { 0, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_60_DEG_UP_TO_25_DEG_UP_DIR_1_B,
+                session, direction,
+                session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_60_DEG_UP_TO_25_DEG_UP_DIR_1_B),
                 { 0, 0, height }, { 32, 1, 9 }, { 0, 26, height + 5 });
             wooden_a_supports_paint_setup(session, 1, 18, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_60_DEG_UP_TO_25_DEG_UP_DIR_2_A,
+                session, direction,
+                session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_60_DEG_UP_TO_25_DEG_UP_DIR_2_A),
                 { 0, 0, height }, { 32, 27, 2 }, { 0, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_60_DEG_UP_TO_25_DEG_UP_DIR_2_B,
+                session, direction,
+                session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_60_DEG_UP_TO_25_DEG_UP_DIR_2_B),
                 { 0, 0, height }, { 32, 1, 9 }, { 0, 26, height + 5 });
             wooden_a_supports_paint_setup(session, 0, 19, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_60_DEG_UP_TO_25_DEG_UP_DIR_3_A,
+                session, direction,
+                session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_60_DEG_UP_TO_25_DEG_UP_DIR_3_A),
                 { 0, 0, height }, { 32, 27, 2 }, { 0, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_60_DEG_UP_TO_25_DEG_UP_DIR_3_B,
+                session, direction,
+                session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_60_DEG_UP_TO_25_DEG_UP_DIR_3_B),
                 { 0, 0, height }, { 32, 1, 9 }, { 0, 26, height + 5 });
             wooden_a_supports_paint_setup(session, 1, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -3122,7 +3158,8 @@ static void side_friction_rc_track_diag_60_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_DIAG_60_DEG_UP_DIR_3_A,
+                        session, direction,
+                        session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_DIAG_60_DEG_UP_DIR_3_A),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
@@ -3134,10 +3171,12 @@ static void side_friction_rc_track_diag_60_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_DIAG_60_DEG_UP_DIR_0_A,
+                        session, direction,
+                        session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_DIAG_60_DEG_UP_DIR_0_A),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_DIAG_60_DEG_UP_DIR_0_B,
+                        session, direction,
+                        session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_DIAG_60_DEG_UP_DIR_0_B),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 43 });
                     wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3166,10 +3205,12 @@ static void side_friction_rc_track_diag_60_deg_up(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_DIAG_60_DEG_UP_DIR_2_A,
+                        session, direction,
+                        session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_DIAG_60_DEG_UP_DIR_2_A),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_DIAG_60_DEG_UP_DIR_2_B,
+                        session, direction,
+                        session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_DIAG_60_DEG_UP_DIR_2_B),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 43 });
                     wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3185,7 +3226,8 @@ static void side_friction_rc_track_diag_60_deg_up(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_DIAG_60_DEG_UP_DIR_1_A,
+                        session, direction,
+                        session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_DIAG_60_DEG_UP_DIR_1_A),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
@@ -3215,7 +3257,7 @@ static void side_friction_rc_track_diag_60_deg_up_to_25_deg_up(
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        session.TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_DIAG_60_DEG_UP_TO_25_DEG_UP_DIR_3_A,
+                        session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_DIAG_60_DEG_UP_TO_25_DEG_UP_DIR_3_A),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
@@ -3228,11 +3270,11 @@ static void side_friction_rc_track_diag_60_deg_up_to_25_deg_up(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        session.TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_DIAG_60_DEG_UP_TO_25_DEG_UP_DIR_0_A,
+                        session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_DIAG_60_DEG_UP_TO_25_DEG_UP_DIR_0_A),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        session.TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_DIAG_60_DEG_UP_TO_25_DEG_UP_DIR_0_B,
+                        session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_DIAG_60_DEG_UP_TO_25_DEG_UP_DIR_0_B),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 59 });
                     wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3261,11 +3303,11 @@ static void side_friction_rc_track_diag_60_deg_up_to_25_deg_up(
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        session.TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_DIAG_60_DEG_UP_TO_25_DEG_UP_DIR_2_A,
+                        session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_DIAG_60_DEG_UP_TO_25_DEG_UP_DIR_2_A),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        session.TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_DIAG_60_DEG_UP_TO_25_DEG_UP_DIR_2_B,
+                        session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_DIAG_60_DEG_UP_TO_25_DEG_UP_DIR_2_B),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 59 });
                     wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3282,7 +3324,7 @@ static void side_friction_rc_track_diag_60_deg_up_to_25_deg_up(
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        session.TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_DIAG_60_DEG_UP_TO_25_DEG_UP_DIR_1_A,
+                        session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_DIAG_60_DEG_UP_TO_25_DEG_UP_DIR_1_A),
                         { -16, -16, height }, { 16, 16, 2 }, { 0, 0, height });
                     break;
             }
@@ -3312,7 +3354,7 @@ static void side_friction_rc_track_diag_25_deg_up_to_60_deg_up(
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        session.TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_DIAG_25_DEG_UP_TO_60_DEG_UP_DIR_3_A,
+                        session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_DIAG_25_DEG_UP_TO_60_DEG_UP_DIR_3_A),
                         { -16 + 4, -16 + 2, height }, { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
@@ -3325,11 +3367,11 @@ static void side_friction_rc_track_diag_25_deg_up_to_60_deg_up(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        session.TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_DIAG_25_DEG_UP_TO_60_DEG_UP_DIR_0_A,
+                        session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_DIAG_25_DEG_UP_TO_60_DEG_UP_DIR_0_A),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 24033, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 59 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(24033), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 59 });
                     wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -3357,11 +3399,11 @@ static void side_friction_rc_track_diag_25_deg_up_to_60_deg_up(
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        session.TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_DIAG_25_DEG_UP_TO_60_DEG_UP_DIR_2_A,
+                        session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_DIAG_25_DEG_UP_TO_60_DEG_UP_DIR_2_A),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 24034, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 59 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(24034), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 59 });
                     wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -3377,7 +3419,7 @@ static void side_friction_rc_track_diag_25_deg_up_to_60_deg_up(
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        session.TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_DIAG_25_DEG_UP_TO_60_DEG_UP_DIR_1_A,
+                        session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_DIAG_25_DEG_UP_TO_60_DEG_UP_DIR_1_A),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     break;
             }

--- a/src/openrct2/ride/coaster/SingleRailRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/SingleRailRollerCoaster.cpp
@@ -36,22 +36,26 @@ namespace SingleRailRC
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_FLAT + 0),
+                        session, direction,
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_FLAT + 0)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_FLAT + 1),
+                        session, direction,
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_FLAT + 1)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_FLAT + 2),
+                        session, direction,
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_FLAT + 2)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_FLAT + 3),
+                        session, direction,
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_FLAT + 3)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
@@ -68,13 +72,13 @@ namespace SingleRailRC
                 case 0:
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_FLAT + 0),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_FLAT + 0)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_FLAT + 1),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_FLAT + 1)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
@@ -104,18 +108,18 @@ namespace SingleRailRC
         if (trackElement.GetTrackType() == TrackElemType::EndStation)
         {
             PaintAddImageAsParentRotated(
-                session, direction, imageIds[direction][1] | session.TrackColours[SCHEME_TRACK], { 0, 0, height },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][1]), { 0, 0, height },
                 { 32, 20, 1 }, { 0, 6, height + 3 });
         }
         else
         {
             PaintAddImageAsParentRotated(
-                session, direction, imageIds[direction][0] | session.TrackColours[SCHEME_TRACK], { 0, 0, height },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]), { 0, 0, height },
                 { 32, 20, 1 }, { 0, 6, height + 3 });
         }
         PaintAddImageAsParentRotated(
-            session, direction, imageIds[direction][2] | session.TrackColours[SCHEME_MISC], { 0, 0, height - 2 }, { 32, 28, 2 },
-            { 0, 2, height });
+            session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][2]), { 0, 0, height - 2 },
+            { 32, 28, 2 }, { 0, 2, height });
         track_paint_util_draw_station_metal_supports_2(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], 0);
         track_paint_util_draw_station_2(session, ride, direction, height, trackElement, 4, 7);
         paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -133,22 +137,26 @@ namespace SingleRailRC
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE + 8),
+                        session, direction,
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE + 8)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE + 9),
+                        session, direction,
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE + 9)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE + 10),
+                        session, direction,
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE + 10)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE + 11),
+                        session, direction,
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE + 11)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
@@ -164,23 +172,25 @@ namespace SingleRailRC
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE + 8),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE + 8)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE + 9),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE + 9)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE + 10),
-                        { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
+                        session, direction,
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE + 10)), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE + 11),
-                        { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
+                        session, direction,
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE + 11)), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -212,22 +222,26 @@ namespace SingleRailRC
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP + 12),
+                        session, direction,
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP + 12)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP + 13),
+                        session, direction,
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP + 13)),
                         { 0, 0, height }, { 32, 1, 98 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP + 14),
+                        session, direction,
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP + 14)),
                         { 0, 0, height }, { 32, 1, 98 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP + 15),
+                        session, direction,
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP + 15)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
@@ -243,22 +257,22 @@ namespace SingleRailRC
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP + 12),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP + 12)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP + 13),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP + 13)),
                         { 0, 0, height }, { 32, 1, 98 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP + 14),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP + 14)),
                         { 0, 0, height }, { 32, 1, 98 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP + 15),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP + 15)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
@@ -291,22 +305,26 @@ namespace SingleRailRC
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE + 0),
+                        session, direction,
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE + 0)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE + 1),
+                        session, direction,
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE + 1)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE + 2),
+                        session, direction,
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE + 2)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE + 3),
+                        session, direction,
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE + 3)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
@@ -322,22 +340,22 @@ namespace SingleRailRC
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE + 0),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE + 0)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE + 1),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE + 1)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE + 2),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE + 2)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE + 3),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE + 3)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
@@ -370,28 +388,34 @@ namespace SingleRailRC
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP + 0),
+                        session, direction,
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP + 0)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP + 1),
+                        session, direction,
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP + 1)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP + 2),
+                        session, direction,
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP + 2)),
                         { 0, 0, height }, { 32, 1, 66 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP + 3),
+                        session, direction,
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP + 3)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP + 4),
+                        session, direction,
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP + 4)),
                         { 0, 0, height }, { 32, 1, 66 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP + 5),
+                        session, direction,
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP + 5)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
@@ -407,28 +431,28 @@ namespace SingleRailRC
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP + 0),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP + 0)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP + 1),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP + 1)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP + 2),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP + 2)),
                         { 0, 0, height }, { 32, 1, 66 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP + 3),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP + 3)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP + 4),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP + 4)),
                         { 0, 0, height }, { 32, 1, 66 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP + 5),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP + 5)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
@@ -461,28 +485,34 @@ namespace SingleRailRC
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP + 6),
+                        session, direction,
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP + 6)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP + 7),
+                        session, direction,
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP + 7)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP + 8),
+                        session, direction,
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP + 8)),
                         { 0, 0, height }, { 32, 1, 66 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP + 9),
+                        session, direction,
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP + 9)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP + 10),
+                        session, direction,
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP + 10)),
                         { 0, 0, height }, { 32, 1, 66 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP + 11),
+                        session, direction,
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP + 11)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
@@ -498,28 +528,28 @@ namespace SingleRailRC
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP + 6),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP + 6)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP + 7),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP + 7)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP + 8),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP + 8)),
                         { 0, 0, height }, { 32, 1, 66 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP + 9),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP + 9)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP + 10),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP + 10)),
                         { 0, 0, height }, { 32, 1, 66 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP + 11),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP + 11)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
@@ -552,22 +582,26 @@ namespace SingleRailRC
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE + 4),
+                        session, direction,
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE + 4)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE + 5),
+                        session, direction,
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE + 5)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE + 6),
+                        session, direction,
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE + 6)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE + 7),
+                        session, direction,
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE + 7)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
@@ -583,22 +617,22 @@ namespace SingleRailRC
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE + 4),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE + 4)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE + 5),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE + 5)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE + 6),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE + 6)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE + 7),
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE + 7)),
                         { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
@@ -674,22 +708,26 @@ namespace SingleRailRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_VERTICAL + 8),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_VERTICAL + 8)),
                             { 0, 0, height }, { 2, 20, 31 }, { 4, 6, height + 8 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_VERTICAL + 9),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_VERTICAL + 9)),
                             { 0, 0, height }, { 2, 20, 31 }, { 24, 6, height + 8 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_VERTICAL + 10),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_VERTICAL + 10)),
                             { 0, 0, height }, { 2, 20, 31 }, { 24, 6, height + 8 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_VERTICAL + 11),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_VERTICAL + 11)),
                             { 0, 0, height }, { 2, 20, 31 }, { 4, 6, height + 8 });
                         break;
                 }
@@ -721,22 +759,26 @@ namespace SingleRailRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_VERTICAL + 0),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_VERTICAL + 0)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_VERTICAL + 1),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_VERTICAL + 1)),
                             { 0, 0, height }, { 2, 20, 55 }, { 24, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_VERTICAL + 2),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_VERTICAL + 2)),
                             { 0, 0, height }, { 2, 20, 55 }, { 24, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_VERTICAL + 3),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_VERTICAL + 3)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -774,22 +816,22 @@ namespace SingleRailRC
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_VERTICAL + 4),
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_VERTICAL + 4)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height + 8 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_VERTICAL + 5),
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_VERTICAL + 5)),
                     { 0, 0, height }, { 2, 20, 31 }, { 24, 6, height + 8 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_VERTICAL + 6),
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_VERTICAL + 6)),
                     { 0, 0, height }, { 2, 20, 31 }, { 24, 6, height + 8 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_VERTICAL + 7),
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_VERTICAL + 7)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height + 8 });
                 break;
         }
@@ -818,22 +860,26 @@ namespace SingleRailRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_VERTICAL + 6),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_VERTICAL + 6)),
                             { 0, 0, height }, { 2, 20, 31 }, { 24, 6, height + 8 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_VERTICAL + 7),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_VERTICAL + 7)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height + 8 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_VERTICAL + 4),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_VERTICAL + 4)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height + 8 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_VERTICAL + 5),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_VERTICAL + 5)),
                             { 0, 0, height }, { 2, 20, 31 }, { 24, 6, height + 8 });
                         break;
                 }
@@ -861,22 +907,26 @@ namespace SingleRailRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE + 0),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE + 0)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE + 3),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE + 3)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE + 6),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE + 6)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE + 9),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE + 9)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -899,24 +949,27 @@ namespace SingleRailRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE + 1),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE + 1)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE + 4),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE + 4)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE + 7),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE + 7)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE + 10), { 0, 0, height },
-                            { 16, 16, 3 }, { 16, 16, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE + 10)),
+                            { 0, 0, height }, { 16, 16, 3 }, { 16, 16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -929,24 +982,27 @@ namespace SingleRailRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE + 2),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE + 2)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE + 5),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE + 5)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE + 8),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE + 8)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE + 11), { 0, 0, height },
-                            { 20, 32, 3 }, { 6, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE + 11)),
+                            { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -988,26 +1044,26 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE + 0), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE + 0)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE + 5), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE + 5)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE + 10), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE + 10)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE + 15), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE + 15)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -1030,26 +1086,26 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE + 1), { 0, 0, height },
-                            { 32, 16, 3 }, { 0, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE + 1)),
+                            { 0, 0, height }, { 32, 16, 3 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE + 6), { 0, 0, height },
-                            { 32, 16, 3 }, { 0, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE + 6)),
+                            { 0, 0, height }, { 32, 16, 3 }, { 0, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE + 11), { 0, 0, height },
-                            { 32, 16, 3 }, { 0, 16, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE + 11)),
+                            { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE + 16), { 0, 0, height },
-                            { 32, 16, 3 }, { 0, 16, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE + 16)),
+                            { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -1065,26 +1121,26 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE + 2), { 0, 0, height },
-                            { 16, 16, 3 }, { 0, 16, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE + 2)),
+                            { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE + 7), { 0, 0, height },
-                            { 16, 16, 3 }, { 16, 16, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE + 7)),
+                            { 0, 0, height }, { 16, 16, 3 }, { 16, 16, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE + 12), { 0, 0, height },
-                            { 16, 16, 3 }, { 16, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE + 12)),
+                            { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE + 17), { 0, 0, height },
-                            { 16, 16, 3 }, { 0, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE + 17)),
+                            { 0, 0, height }, { 16, 16, 3 }, { 0, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -1101,26 +1157,26 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE + 3), { 0, 0, height },
-                            { 16, 32, 3 }, { 16, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE + 3)),
+                            { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE + 8), { 0, 0, height },
-                            { 16, 32, 3 }, { 0, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE + 8)),
+                            { 0, 0, height }, { 16, 32, 3 }, { 0, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE + 13), { 0, 0, height },
-                            { 16, 32, 3 }, { 0, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE + 13)),
+                            { 0, 0, height }, { 16, 32, 3 }, { 0, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE + 18), { 0, 0, height },
-                            { 16, 32, 3 }, { 16, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE + 18)),
+                            { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -1136,26 +1192,26 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE + 4), { 0, 0, height },
-                            { 20, 32, 3 }, { 6, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE + 4)),
+                            { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE + 9), { 0, 0, height },
-                            { 20, 32, 3 }, { 6, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE + 9)),
+                            { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE + 14), { 0, 0, height },
-                            { 20, 32, 3 }, { 6, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE + 14)),
+                            { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE + 19), { 0, 0, height },
-                            { 20, 32, 3 }, { 6, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE + 19)),
+                            { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -1196,24 +1252,27 @@ namespace SingleRailRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 0),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 0)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 4),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 4)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 8),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 8)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 12), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 12)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -1231,24 +1290,27 @@ namespace SingleRailRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 1),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 1)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 5),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 5)),
                             { 0, 0, height }, { 34, 16, 3 }, { 0, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 9),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 9)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 13), { 0, 0, height },
-                            { 32, 16, 3 }, { 0, 16, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 13)),
+                            { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -1263,25 +1325,27 @@ namespace SingleRailRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 2),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 2)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 6),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 6)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 16, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 10), { 0, 0, height },
-                            { 16, 16, 3 }, { 16, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 10)),
+                            { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 14), { 0, 0, height },
-                            { 16, 16, 3 }, { 0, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 14)),
+                            { 0, 0, height }, { 16, 16, 3 }, { 0, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -1301,14 +1365,16 @@ namespace SingleRailRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 3),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 3)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 7),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 7)),
                             { 0, 0, height }, { 16, 18, 3 }, { 0, 16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1316,16 +1382,16 @@ namespace SingleRailRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 11), { 0, 0, height },
-                            { 16, 16, 3 }, { 0, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 11)),
+                            { 0, 0, height }, { 16, 16, 3 }, { 0, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 15), { 0, 0, height },
-                            { 16, 16, 3 }, { 16, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 15)),
+                            { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -1352,26 +1418,26 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 16), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 16)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 20), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 20)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 24), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 24)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 28), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 28)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -1390,26 +1456,26 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 17), { 0, 0, height },
-                            { 32, 16, 3 }, { 0, 16, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 17)),
+                            { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 21), { 0, 0, height },
-                            { 32, 16, 3 }, { 0, 16, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 21)),
+                            { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 25), { 0, 0, height },
-                            { 34, 16, 3 }, { 0, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 25)),
+                            { 0, 0, height }, { 34, 16, 3 }, { 0, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 29), { 0, 0, height },
-                            { 32, 16, 3 }, { 0, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 29)),
+                            { 0, 0, height }, { 32, 16, 3 }, { 0, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -1425,26 +1491,26 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 18), { 0, 0, height },
-                            { 16, 16, 3 }, { 0, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 18)),
+                            { 0, 0, height }, { 16, 16, 3 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 22), { 0, 0, height },
-                            { 16, 16, 3 }, { 16, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 22)),
+                            { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 26), { 0, 0, height },
-                            { 28, 28, 3 }, { 4, 4, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 26)),
+                            { 0, 0, height }, { 28, 28, 3 }, { 4, 4, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 30), { 0, 0, height },
-                            { 16, 16, 3 }, { 0, 16, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 30)),
+                            { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -1465,32 +1531,32 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 19), { 0, 0, height },
-                            { 16, 16, 3 }, { 16, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 19)),
+                            { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 23), { 0, 0, height },
-                            { 16, 16, 3 }, { 0, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 23)),
+                            { 0, 0, height }, { 16, 16, 3 }, { 0, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 27), { 0, 0, height },
-                            { 16, 18, 3 }, { 0, 16, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 27)),
+                            { 0, 0, height }, { 16, 18, 3 }, { 0, 16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 31), { 0, 0, height },
-                            { 16, 16, 3 }, { 16, 16, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 31)),
+                            { 0, 0, height }, { 16, 16, 3 }, { 16, 16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -1535,7 +1601,7 @@ namespace SingleRailRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_FLAT_DIAGONAL + 3),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_FLAT_DIAGONAL + 3)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1547,7 +1613,7 @@ namespace SingleRailRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_FLAT_DIAGONAL + 3),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_FLAT_DIAGONAL + 3)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1565,7 +1631,7 @@ namespace SingleRailRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_FLAT_DIAGONAL + 0),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_FLAT_DIAGONAL + 0)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1577,7 +1643,7 @@ namespace SingleRailRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_FLAT_DIAGONAL + 0),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_FLAT_DIAGONAL + 0)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1595,7 +1661,7 @@ namespace SingleRailRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_FLAT_DIAGONAL + 2),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_FLAT_DIAGONAL + 2)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1607,7 +1673,7 @@ namespace SingleRailRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_FLAT_DIAGONAL + 2),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_FLAT_DIAGONAL + 2)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1629,7 +1695,7 @@ namespace SingleRailRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_FLAT_DIAGONAL + 1),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_FLAT_DIAGONAL + 1)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             metal_a_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1655,7 +1721,7 @@ namespace SingleRailRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_FLAT_DIAGONAL + 1),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_FLAT_DIAGONAL + 1)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             metal_a_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1692,7 +1758,8 @@ namespace SingleRailRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 11),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 11)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1704,7 +1771,7 @@ namespace SingleRailRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 11),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 11)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1722,7 +1789,8 @@ namespace SingleRailRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 8),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 8)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1734,7 +1802,7 @@ namespace SingleRailRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 8),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 8)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1752,7 +1820,8 @@ namespace SingleRailRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 10),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 10)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1764,7 +1833,7 @@ namespace SingleRailRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 10),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 10)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1786,7 +1855,8 @@ namespace SingleRailRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 1),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 1)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1812,7 +1882,7 @@ namespace SingleRailRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 1),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 1)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1849,7 +1919,8 @@ namespace SingleRailRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 7),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 7)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1861,7 +1932,7 @@ namespace SingleRailRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 7),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 7)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1879,7 +1950,8 @@ namespace SingleRailRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 4),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 4)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1891,7 +1963,7 @@ namespace SingleRailRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 4),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 4)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1909,7 +1981,8 @@ namespace SingleRailRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 6),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 6)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1921,7 +1994,7 @@ namespace SingleRailRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 6),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 6)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -1943,7 +2016,8 @@ namespace SingleRailRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 5),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 5)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1969,7 +2043,7 @@ namespace SingleRailRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 5),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 5)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2006,7 +2080,8 @@ namespace SingleRailRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 3),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 3)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2018,7 +2093,7 @@ namespace SingleRailRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 3),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 3)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2036,7 +2111,8 @@ namespace SingleRailRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 0),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 0)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2048,7 +2124,7 @@ namespace SingleRailRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 0),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 0)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2066,7 +2142,8 @@ namespace SingleRailRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 2),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 2)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2078,7 +2155,7 @@ namespace SingleRailRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 2),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 2)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2100,7 +2177,8 @@ namespace SingleRailRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 1),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 1)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2126,7 +2204,7 @@ namespace SingleRailRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 1),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 1)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES, 0, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2163,7 +2241,8 @@ namespace SingleRailRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 9),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 9)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2175,7 +2254,7 @@ namespace SingleRailRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 9),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 9)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2193,7 +2272,8 @@ namespace SingleRailRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 10),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 10)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2205,7 +2285,7 @@ namespace SingleRailRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 10),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 10)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2223,7 +2303,8 @@ namespace SingleRailRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 8),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 8)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2235,7 +2316,7 @@ namespace SingleRailRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 8),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 8)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2257,7 +2338,8 @@ namespace SingleRailRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 11),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 11)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2283,7 +2365,7 @@ namespace SingleRailRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 11),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 11)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2320,7 +2402,8 @@ namespace SingleRailRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 5),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 5)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2332,7 +2415,7 @@ namespace SingleRailRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 5),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 5)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2349,7 +2432,8 @@ namespace SingleRailRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 6),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 6)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2361,7 +2445,7 @@ namespace SingleRailRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 6),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 6)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2378,7 +2462,8 @@ namespace SingleRailRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 4),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 4)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2390,7 +2475,7 @@ namespace SingleRailRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 4),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 4)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2411,7 +2496,8 @@ namespace SingleRailRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 7),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 7)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2437,7 +2523,7 @@ namespace SingleRailRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 7),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 7)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2475,7 +2561,8 @@ namespace SingleRailRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 1),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 1)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2487,7 +2574,7 @@ namespace SingleRailRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 1),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 1)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2505,7 +2592,8 @@ namespace SingleRailRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 2),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 2)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2517,7 +2605,7 @@ namespace SingleRailRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 2),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 2)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2535,7 +2623,8 @@ namespace SingleRailRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 0),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 0)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2547,7 +2636,7 @@ namespace SingleRailRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 0),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 0)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2569,7 +2658,8 @@ namespace SingleRailRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 3),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 3)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2595,7 +2685,7 @@ namespace SingleRailRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 3),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 3)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2632,7 +2722,8 @@ namespace SingleRailRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 11),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 11)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2644,7 +2735,7 @@ namespace SingleRailRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 11),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 11)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2662,7 +2753,8 @@ namespace SingleRailRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 8),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 8)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2674,7 +2766,7 @@ namespace SingleRailRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 8),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 8)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2692,7 +2784,8 @@ namespace SingleRailRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 10),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 10)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2704,7 +2797,7 @@ namespace SingleRailRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 10),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 10)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2726,7 +2819,8 @@ namespace SingleRailRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 9),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 9)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES, 0, 36, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2752,7 +2846,7 @@ namespace SingleRailRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 9),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 9)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES, 0, 36, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2789,7 +2883,8 @@ namespace SingleRailRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 3),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 3)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2801,7 +2896,7 @@ namespace SingleRailRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 3),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 3)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2819,7 +2914,8 @@ namespace SingleRailRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 0),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 0)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2831,7 +2927,7 @@ namespace SingleRailRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 0),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 0)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2849,7 +2945,8 @@ namespace SingleRailRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 2),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 2)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2861,7 +2958,7 @@ namespace SingleRailRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 2),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 2)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2883,7 +2980,8 @@ namespace SingleRailRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 1),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 1)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES, 0, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2909,7 +3007,7 @@ namespace SingleRailRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 1),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 1)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES, 0, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2946,7 +3044,8 @@ namespace SingleRailRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 7),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 7)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2958,7 +3057,7 @@ namespace SingleRailRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 7),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 7)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2976,7 +3075,8 @@ namespace SingleRailRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 4),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 4)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -2988,7 +3088,7 @@ namespace SingleRailRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 4),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 4)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -3006,7 +3106,8 @@ namespace SingleRailRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 6),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 6)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -3018,7 +3119,7 @@ namespace SingleRailRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 6),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 6)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -3040,7 +3141,8 @@ namespace SingleRailRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 5),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 5)),
                                 { -16, -16, height }, { 16, 16, 3 }, { 0, 0, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES, 0, 21, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3066,7 +3168,7 @@ namespace SingleRailRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 5),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 5)),
                                 { -16, -16, height }, { 16, 16, 3 }, { 0, 0, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES, 0, 21, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3103,7 +3205,8 @@ namespace SingleRailRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 9),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 9)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -3115,7 +3218,7 @@ namespace SingleRailRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 9),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 9)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -3133,7 +3236,8 @@ namespace SingleRailRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 10),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 10)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -3145,7 +3249,7 @@ namespace SingleRailRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 10),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 10)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -3163,7 +3267,8 @@ namespace SingleRailRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 8),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 8)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -3175,7 +3280,7 @@ namespace SingleRailRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 8),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 8)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -3197,7 +3302,8 @@ namespace SingleRailRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 11),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 11)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES, 0, 28, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3223,7 +3329,7 @@ namespace SingleRailRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 11),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 11)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES, 0, 28, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3260,7 +3366,8 @@ namespace SingleRailRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 5),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 5)),
                                 { -16, -16, height }, { 16, 16, 3 }, { 0, 0, height });
                             break;
                     }
@@ -3272,7 +3379,7 @@ namespace SingleRailRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 5),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 5)),
                                 { -16, -16, height }, { 16, 16, 3 }, { 0, 0, height });
                             break;
                     }
@@ -3290,7 +3397,8 @@ namespace SingleRailRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 6),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 6)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -3302,7 +3410,7 @@ namespace SingleRailRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 6),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 6)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -3320,7 +3428,8 @@ namespace SingleRailRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 4),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 4)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -3332,7 +3441,7 @@ namespace SingleRailRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 4),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 4)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -3354,7 +3463,8 @@ namespace SingleRailRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 7),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 7)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES, 0, 17, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3380,7 +3490,7 @@ namespace SingleRailRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 7),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 7)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES, 0, 17, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3417,7 +3527,8 @@ namespace SingleRailRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 1),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 1)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -3429,7 +3540,7 @@ namespace SingleRailRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 1),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 1)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -3447,7 +3558,8 @@ namespace SingleRailRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 2),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 2)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -3459,7 +3571,7 @@ namespace SingleRailRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 2),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 2)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -3477,7 +3589,8 @@ namespace SingleRailRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 0),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 0)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -3489,7 +3602,7 @@ namespace SingleRailRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 0),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 0)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             break;
                     }
@@ -3511,7 +3624,8 @@ namespace SingleRailRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 3),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_STEEP_DIAGONAL + 3)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3537,7 +3651,7 @@ namespace SingleRailRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 3),
+                                session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP_DIAGONAL + 3)),
                                 { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3568,28 +3682,34 @@ namespace SingleRailRC
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 0),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 0)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 1),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 1)),
                     { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 2),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 2)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 3),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 3)),
                     { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 4),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 4)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 5),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 5)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
         }
@@ -3611,28 +3731,34 @@ namespace SingleRailRC
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 6),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 6)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 7),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 7)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 8),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 8)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 9),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 9)),
                     { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 10),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 10)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 11),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 11)),
                     { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                 break;
         }
@@ -3668,28 +3794,34 @@ namespace SingleRailRC
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 12),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 12)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 13),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 13)),
                     { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 14),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 14)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 15),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 15)),
                     { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 16),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 16)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 17),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 17)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
         }
@@ -3718,28 +3850,34 @@ namespace SingleRailRC
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 18),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 18)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 19),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 19)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 20),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 20)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 21),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 21)),
                     { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 22),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 22)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 23),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 23)),
                     { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
         }
@@ -3768,28 +3906,34 @@ namespace SingleRailRC
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 24),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 24)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 25),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 25)),
                     { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 26),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 26)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 27),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 27)),
                     { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 28),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 28)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 29),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 29)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
         }
@@ -3818,28 +3962,34 @@ namespace SingleRailRC
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 30),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 30)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 31),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 31)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 32),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 32)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 33),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 33)),
                     { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 34),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 34)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 35),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 35)),
                     { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
         }
@@ -3896,22 +4046,26 @@ namespace SingleRailRC
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 36),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 36)),
                     { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 37),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 37)),
                     { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 38),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 38)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 39),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION + 39)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
         }
@@ -3944,7 +4098,8 @@ namespace SingleRailRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 4),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 4)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -3959,11 +4114,13 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 0),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 0)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 1),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 1)),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                         break;
                 }
@@ -3978,7 +4135,8 @@ namespace SingleRailRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 3),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 3)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -3997,7 +4155,8 @@ namespace SingleRailRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 2),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 2)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4031,7 +4190,8 @@ namespace SingleRailRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 9),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 9)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4046,7 +4206,8 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 5),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 5)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4061,11 +4222,13 @@ namespace SingleRailRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 7),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 7)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 8),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 8)),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                         break;
                 }
@@ -4084,7 +4247,8 @@ namespace SingleRailRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 6),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 6)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4118,7 +4282,8 @@ namespace SingleRailRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 6),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 6)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4133,11 +4298,13 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 7),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 7)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 8),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 8)),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                         break;
                 }
@@ -4152,7 +4319,8 @@ namespace SingleRailRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 5),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 5)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4171,7 +4339,8 @@ namespace SingleRailRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 9),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 9)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4205,7 +4374,8 @@ namespace SingleRailRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 2),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 2)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4220,7 +4390,8 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 3),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 3)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4235,11 +4406,13 @@ namespace SingleRailRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 0),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 0)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 1),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 1)),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                         break;
                 }
@@ -4258,7 +4431,8 @@ namespace SingleRailRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 4),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 4)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4292,7 +4466,8 @@ namespace SingleRailRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 14),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 14)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4307,11 +4482,13 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 10),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 10)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 11),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 11)),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         break;
                 }
@@ -4326,7 +4503,8 @@ namespace SingleRailRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 13),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 13)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4345,7 +4523,8 @@ namespace SingleRailRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 12),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 12)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4379,7 +4558,8 @@ namespace SingleRailRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 19),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 19)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4394,7 +4574,8 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 15),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 15)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4409,11 +4590,13 @@ namespace SingleRailRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 17),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 17)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 18),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 18)),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         break;
                 }
@@ -4432,7 +4615,8 @@ namespace SingleRailRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 16),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 16)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4466,7 +4650,8 @@ namespace SingleRailRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 24),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 24)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4481,11 +4666,13 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 20),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 20)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 21),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 21)),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         break;
                 }
@@ -4500,7 +4687,8 @@ namespace SingleRailRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 23),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 23)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4519,7 +4707,8 @@ namespace SingleRailRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 22),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 22)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4553,7 +4742,8 @@ namespace SingleRailRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 29),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 29)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4568,7 +4758,8 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 25),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 25)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4583,11 +4774,13 @@ namespace SingleRailRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 27),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 27)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 28),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 28)),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         break;
                 }
@@ -4606,7 +4799,8 @@ namespace SingleRailRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 26),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 26)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4640,7 +4834,8 @@ namespace SingleRailRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 26),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 26)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4654,11 +4849,13 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 27),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 27)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 28),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 28)),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         break;
                 }
@@ -4672,7 +4869,8 @@ namespace SingleRailRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 25),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 25)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4690,7 +4888,8 @@ namespace SingleRailRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 29),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 29)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4725,7 +4924,8 @@ namespace SingleRailRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 22),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 22)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4739,7 +4939,8 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 23),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 23)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4753,11 +4954,13 @@ namespace SingleRailRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 20),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 20)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 21),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 21)),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         break;
                 }
@@ -4775,7 +4978,8 @@ namespace SingleRailRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 24),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 24)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4810,7 +5014,8 @@ namespace SingleRailRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 16),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 16)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4825,11 +5030,13 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 17),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 17)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 18),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 18)),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         break;
                 }
@@ -4844,7 +5051,8 @@ namespace SingleRailRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 15),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 15)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4863,7 +5071,8 @@ namespace SingleRailRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 19),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 19)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4897,7 +5106,8 @@ namespace SingleRailRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 12),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 12)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4912,7 +5122,8 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 13),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 13)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4927,11 +5138,13 @@ namespace SingleRailRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 10),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 10)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 11),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 11)),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         break;
                 }
@@ -4950,7 +5163,8 @@ namespace SingleRailRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 14),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 14)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4984,7 +5198,8 @@ namespace SingleRailRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 33),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 33)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -4999,7 +5214,8 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 30),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 30)),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                         break;
                 }
@@ -5014,7 +5230,8 @@ namespace SingleRailRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 32),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 32)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -5033,7 +5250,8 @@ namespace SingleRailRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 31),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 31)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -5067,7 +5285,8 @@ namespace SingleRailRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 31),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 31)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -5082,7 +5301,8 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 32),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 32)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
@@ -5097,7 +5317,8 @@ namespace SingleRailRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 30),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 30)),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                         break;
                 }
@@ -5116,7 +5337,8 @@ namespace SingleRailRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 33),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_BANK_TRANSITION_DIAGONAL + 33)),
                             { -16, -16, height }, { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -5150,29 +5372,29 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE_BANKED + 0),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE_BANKED + 0)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE_BANKED + 1),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE_BANKED + 1)),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE_BANKED + 4),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE_BANKED + 4)),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE_BANKED + 7),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE_BANKED + 7)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE_BANKED + 11),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE_BANKED + 11)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -5196,25 +5418,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE_BANKED + 2),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE_BANKED + 2)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE_BANKED + 5),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE_BANKED + 5)),
                             { 0, 0, height }, { 16, 16, 1 }, { 0, 0, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE_BANKED + 8),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE_BANKED + 8)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE_BANKED + 12),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE_BANKED + 12)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 16, height });
                         break;
                 }
@@ -5229,29 +5451,29 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE_BANKED + 3),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE_BANKED + 3)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE_BANKED + 6),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE_BANKED + 6)),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE_BANKED + 9),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE_BANKED + 9)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE_BANKED + 10),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE_BANKED + 10)),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE_BANKED + 13),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_CURVE_BANKED + 13)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                 }
@@ -5294,29 +5516,29 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 0),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 0)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 1),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 1)),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 6),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 6)),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 11),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 11)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 17),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 17)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -5340,25 +5562,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 2),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 2)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 7),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 7)),
                             { 0, 0, height }, { 32, 16, 1 }, { 0, 0, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 12),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 12)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 18),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 18)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                 }
@@ -5375,25 +5597,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 3),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 3)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 8),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 8)),
                             { 0, 0, height }, { 16, 16, 1 }, { 16, 16, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 13),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 13)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 19),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 19)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 0, height });
                         break;
                 }
@@ -5411,25 +5633,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 4),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 4)),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 9),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 9)),
                             { 0, 0, height }, { 16, 32, 1 }, { 0, 0, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 14),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 14)),
                             { 0, 0, height }, { 16, 32, 3 }, { 0, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 20),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 20)),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         break;
                 }
@@ -5446,29 +5668,29 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 5),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 5)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 10),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 10)),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 15),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 15)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 16),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 16)),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 21),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_CURVE_BANKED + 21)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                 }
@@ -5511,25 +5733,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 0),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 0)),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 4),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 4)),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 8),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 8)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 12),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 12)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -5549,25 +5771,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 1),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 1)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 5),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 5)),
                             { 0, 0, height }, { 34, 16, 0 }, { 0, 0, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 9),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 9)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 13),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 13)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                 }
@@ -5584,25 +5806,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 2),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 2)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 6),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 6)),
                             { 0, 0, height }, { 16, 16, 0 }, { 16, 16, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 10),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 10)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 14),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 14)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 0, height });
                         break;
                 }
@@ -5624,7 +5846,7 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 3),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 3)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -5632,7 +5854,7 @@ namespace SingleRailRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 7),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 7)),
                             { 0, 0, height }, { 16, 18, 0 }, { 0, 16, height + 27 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -5640,7 +5862,7 @@ namespace SingleRailRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 11),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 11)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -5648,7 +5870,7 @@ namespace SingleRailRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 15),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 15)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -5676,25 +5898,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 16),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 16)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 20),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 20)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 24),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 24)),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 28),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 28)),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                 }
@@ -5714,25 +5936,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 17),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 17)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 21),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 21)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 25),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 25)),
                             { 0, 0, height }, { 34, 16, 0 }, { 0, 0, height + 27 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 29),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 29)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 0, height });
                         break;
                 }
@@ -5749,25 +5971,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 18),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 18)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 22),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 22)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 26),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 26)),
                             { 0, 0, height }, { 28, 28, 0 }, { 4, 4, height + 27 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 30),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 30)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         break;
                 }
@@ -5789,7 +6011,7 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 19),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 19)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -5797,7 +6019,7 @@ namespace SingleRailRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 23),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 23)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -5805,7 +6027,7 @@ namespace SingleRailRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 27),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 27)),
                             { 0, 0, height }, { 16, 18, 0 }, { 0, 16, height + 27 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -5813,7 +6035,7 @@ namespace SingleRailRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 31),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE_BANKED + 31)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -5857,25 +6079,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE + 0),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE + 0)),
                             { 0, 6, height }, { 32, 20, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE + 2),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE + 2)),
                             { 0, 6, height }, { 32, 20, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE + 4),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE + 4)),
                             { 0, 6, height }, { 32, 20, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE + 6),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE + 6)),
                             { 0, 6, height }, { 32, 20, 3 });
                         break;
                 }
@@ -5902,25 +6124,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE + 1),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE + 1)),
                             { 6, 0, height }, { 20, 32, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE + 3),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE + 3)),
                             { 6, 0, height }, { 20, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE + 5),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE + 5)),
                             { 6, 0, height }, { 20, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE + 7),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE + 7)),
                             { 6, 0, height }, { 20, 32, 3 });
                         break;
                 }
@@ -5955,25 +6177,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE + 8),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE + 8)),
                             { 0, 6, height }, { 32, 20, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE + 10),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE + 10)),
                             { 0, 6, height }, { 32, 20, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE + 12),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE + 12)),
                             { 0, 6, height }, { 32, 20, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE + 14),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE + 14)),
                             { 0, 6, height }, { 32, 20, 3 });
                         break;
                 }
@@ -6000,7 +6222,7 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE + 9),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE + 9)),
                             { 6, 0, height }, { 20, 32, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -6008,7 +6230,7 @@ namespace SingleRailRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE + 11),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE + 11)),
                             { 6, 0, height }, { 20, 32, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -6016,7 +6238,7 @@ namespace SingleRailRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE + 13),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE + 13)),
                             { 6, 0, height }, { 20, 32, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -6024,7 +6246,7 @@ namespace SingleRailRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE + 15),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE + 15)),
                             { 6, 0, height }, { 20, 32, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -6075,25 +6297,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 0),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 0)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 5),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 5)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 10),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 10)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 15),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 15)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -6117,25 +6339,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 1),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 1)),
                             { 0, 0, height }, { 32, 16, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 6),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 6)),
                             { 0, 0, height }, { 32, 16, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 11),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 11)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 16),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 16)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                 }
@@ -6152,25 +6374,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 2),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 2)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 7),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 7)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 16, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 12),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 12)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 17),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 17)),
                             { 0, 0, height }, { 16, 16, 3 });
                         break;
                 }
@@ -6188,25 +6410,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 3),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 3)),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 8),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 8)),
                             { 0, 0, height }, { 16, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 13),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 13)),
                             { 0, 0, height }, { 16, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 18),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 18)),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         break;
                 }
@@ -6223,25 +6445,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 4),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 4)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 9),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 9)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 14),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 14)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 19),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 19)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                 }
@@ -6276,25 +6498,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 20),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 20)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 25),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 25)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 30),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 30)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 35),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 35)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -6318,25 +6540,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 21),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 21)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 26),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 26)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 31),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 31)),
                             { 0, 0, height }, { 32, 16, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 36),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 36)),
                             { 0, 0, height }, { 32, 16, 3 });
                         break;
                 }
@@ -6353,25 +6575,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 22),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 22)),
                             { 0, 0, height }, { 16, 16, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 27),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 27)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 32),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 32)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 37),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 37)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         break;
                 }
@@ -6389,25 +6611,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 23),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 23)),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 28),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 28)),
                             { 0, 0, height }, { 16, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 33),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 33)),
                             { 0, 0, height }, { 16, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 38),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 38)),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         break;
                 }
@@ -6424,25 +6646,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 24),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 24)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 29),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 29)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 34),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 34)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 39),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE + 39)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                 }
@@ -6489,34 +6711,42 @@ namespace SingleRailRC
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP_SMALL_CURVE + 0),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP_SMALL_CURVE + 0)),
                     { 0, 0, height }, { 28, 28, 3 }, { 2, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP_SMALL_CURVE + 1),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP_SMALL_CURVE + 1)),
                     { 0, 0, height }, { 28, 28, 1 }, { 2, 2, height + 99 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP_SMALL_CURVE + 2),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP_SMALL_CURVE + 2)),
                     { 0, 0, height }, { 28, 28, 3 }, { 2, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP_SMALL_CURVE + 3),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP_SMALL_CURVE + 3)),
                     { 0, 0, height }, { 28, 28, 1 }, { 2, 2, height + 99 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP_SMALL_CURVE + 4),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP_SMALL_CURVE + 4)),
                     { 0, 0, height }, { 28, 28, 3 }, { 2, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP_SMALL_CURVE + 5),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP_SMALL_CURVE + 5)),
                     { 0, 0, height }, { 28, 28, 1 }, { 2, 2, height + 99 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP_SMALL_CURVE + 6),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP_SMALL_CURVE + 6)),
                     { 0, 0, height }, { 28, 28, 3 }, { 2, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP_SMALL_CURVE + 7),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP_SMALL_CURVE + 7)),
                     { 0, 0, height }, { 28, 28, 1 }, { 2, 2, height + 99 });
                 break;
         }
@@ -6533,34 +6763,42 @@ namespace SingleRailRC
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP_SMALL_CURVE + 8),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP_SMALL_CURVE + 8)),
                     { 0, 0, height }, { 28, 28, 3 }, { 2, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP_SMALL_CURVE + 9),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP_SMALL_CURVE + 9)),
                     { 0, 0, height }, { 28, 28, 1 }, { 2, 2, height + 99 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP_SMALL_CURVE + 10),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP_SMALL_CURVE + 10)),
                     { 0, 0, height }, { 28, 28, 3 }, { 2, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP_SMALL_CURVE + 11),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP_SMALL_CURVE + 11)),
                     { 0, 0, height }, { 28, 28, 1 }, { 2, 2, height + 99 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP_SMALL_CURVE + 12),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP_SMALL_CURVE + 12)),
                     { 0, 0, height }, { 28, 28, 3 }, { 2, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP_SMALL_CURVE + 13),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP_SMALL_CURVE + 13)),
                     { 0, 0, height }, { 28, 28, 1 }, { 2, 2, height + 99 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP_SMALL_CURVE + 14),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP_SMALL_CURVE + 14)),
                     { 0, 0, height }, { 28, 28, 3 }, { 2, 2, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_STEEP_SMALL_CURVE + 15),
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_STEEP_SMALL_CURVE + 15)),
                     { 0, 0, height }, { 28, 28, 1 }, { 2, 2, height + 99 });
                 break;
         }
@@ -6595,33 +6833,33 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_VERTICAL_TWIST + 0),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_VERTICAL_TWIST + 0)),
                             { 0, 0, height }, { 2, 20, 63 }, { 4, 6, height + 8 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_VERTICAL_TWIST + 1),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_VERTICAL_TWIST + 1)),
                             { 0, 0, height }, { 2, 20, 63 }, { 4, 6, height + 8 });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_VERTICAL_TWIST + 2),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_VERTICAL_TWIST + 2)),
                             { 0, 0, height }, { 2, 20, 63 }, { 24, 6, height + 8 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_VERTICAL_TWIST + 3),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_VERTICAL_TWIST + 3)),
                             { 0, 0, height }, { 2, 20, 63 }, { 24, 6, height + 8 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_VERTICAL_TWIST + 4),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_VERTICAL_TWIST + 4)),
                             { 0, 0, height }, { 2, 20, 63 }, { 4, 6, height + 8 });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_VERTICAL_TWIST + 5),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_VERTICAL_TWIST + 5)),
                             { 0, 0, height }, { 2, 20, 63 }, { 24, 6, height + 8 });
                         break;
                 }
@@ -6647,33 +6885,33 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_VERTICAL_TWIST + 6),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_VERTICAL_TWIST + 6)),
                             { 0, 0, height }, { 2, 20, 63 }, { 4, 6, height + 8 });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_VERTICAL_TWIST + 7),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_VERTICAL_TWIST + 7)),
                             { 0, 0, height }, { 2, 20, 63 }, { 24, 6, height + 8 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_VERTICAL_TWIST + 8),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_VERTICAL_TWIST + 8)),
                             { 0, 0, height }, { 2, 20, 63 }, { 24, 6, height + 8 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_VERTICAL_TWIST + 9),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_VERTICAL_TWIST + 9)),
                             { 0, 0, height }, { 2, 20, 63 }, { 4, 6, height + 8 });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_VERTICAL_TWIST + 10),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_VERTICAL_TWIST + 10)),
                             { 0, 0, height }, { 2, 20, 63 }, { 24, 6, height + 8 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_VERTICAL_TWIST + 11),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_VERTICAL_TWIST + 11)),
                             { 0, 0, height }, { 2, 20, 63 }, { 4, 6, height + 8 });
                         break;
                 }
@@ -6710,30 +6948,30 @@ namespace SingleRailRC
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 0), { 0, 0, height },
-                    { 32, 20, 3 }, { 0, 6, height });
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 0)),
+                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 1), { 0, 0, height },
-                    { 32, 20, 3 }, { 0, 6, height });
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 1)),
+                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 2), { 0, 0, height },
-                    { 32, 1, 34 }, { 0, 27, height });
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 2)),
+                    { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 3), { 0, 0, height },
-                    { 32, 20, 3 }, { 0, 6, height });
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 3)),
+                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 4), { 0, 0, height },
-                    { 32, 20, 3 }, { 0, 6, height });
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 4)),
+                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
         }
         if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -6762,30 +7000,30 @@ namespace SingleRailRC
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 5), { 0, 0, height },
-                    { 32, 20, 3 }, { 0, 6, height });
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 5)),
+                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 6), { 0, 0, height },
-                    { 32, 20, 3 }, { 0, 6, height });
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 6)),
+                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 7), { 0, 0, height },
-                    { 32, 20, 3 }, { 0, 6, height });
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 7)),
+                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 8), { 0, 0, height },
-                    { 32, 1, 34 }, { 0, 27, height });
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 8)),
+                    { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 9), { 0, 0, height },
-                    { 32, 20, 3 }, { 0, 6, height });
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 9)),
+                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
         }
         if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -6814,29 +7052,29 @@ namespace SingleRailRC
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 10),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 10)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 11),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 11)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 12),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 12)),
                     { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 13),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 13)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 14),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 14)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
         }
@@ -6866,29 +7104,29 @@ namespace SingleRailRC
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 15),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 15)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 16),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 16)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 17),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 17)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 18),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 18)),
                     { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 19),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 19)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
         }
@@ -6946,25 +7184,25 @@ namespace SingleRailRC
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 20),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 20)),
                     { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 21),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 21)),
                     { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 22),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 22)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 23),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 23)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
         }
@@ -6994,25 +7232,25 @@ namespace SingleRailRC
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 24),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 24)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 25),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 25)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 26),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 26)),
                     { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 27),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 27)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
         }
@@ -7042,25 +7280,25 @@ namespace SingleRailRC
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 28),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 28)),
                     { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 29),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 29)),
                     { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 30),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 30)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 31),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 31)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
         }
@@ -7090,25 +7328,25 @@ namespace SingleRailRC
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 32),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 32)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 33),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 33)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 34),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 34)),
                     { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 35),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 35)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
         }
@@ -7166,25 +7404,25 @@ namespace SingleRailRC
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 36),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 36)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 37),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 37)),
                     { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 38),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 38)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 39),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 39)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
         }
@@ -7214,25 +7452,25 @@ namespace SingleRailRC
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 40),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 40)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 41),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 41)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 42),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 42)),
                     { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 43),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 43)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
         }
@@ -7276,29 +7514,29 @@ namespace SingleRailRC
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 44),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 44)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 45),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 45)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 46),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 46)),
                     { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 47),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 47)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 48),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 48)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
         }
@@ -7328,29 +7566,29 @@ namespace SingleRailRC
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 49),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 49)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 50),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 50)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 51),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 51)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 52),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 52)),
                     { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 53),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 53)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
         }
@@ -7380,29 +7618,29 @@ namespace SingleRailRC
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 54),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 54)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 55),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 55)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 56),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 56)),
                     { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 57),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 57)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 58),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 58)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
         }
@@ -7432,29 +7670,29 @@ namespace SingleRailRC
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 59),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 59)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 60),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 60)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 61),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 61)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 62),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 62)),
                     { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction,
-                    session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 63),
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SLOPE_BANK_TRANSITION + 63)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
         }
@@ -7515,25 +7753,29 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE_BANKED + 0),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE_BANKED + 0)),
                             { 0, 6, height }, { 32, 20, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE_BANKED + 2),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE_BANKED + 2)),
                             { 0, 6, height }, { 32, 1, 34 }, { 0, 27, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE_BANKED + 4),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE_BANKED + 4)),
                             { 0, 6, height }, { 32, 20, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE_BANKED + 6),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE_BANKED + 6)),
                             { 0, 6, height }, { 32, 20, 3 });
                         break;
                 }
@@ -7560,25 +7802,29 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE_BANKED + 1),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE_BANKED + 1)),
                             { 6, 0, height }, { 20, 32, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE_BANKED + 3),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE_BANKED + 3)),
                             { 6, 0, height }, { 1, 32, 34 }, { 27, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE_BANKED + 5),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE_BANKED + 5)),
                             { 6, 0, height }, { 1, 32, 34 }, { 27, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE_BANKED + 7),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE_BANKED + 7)),
                             { 6, 0, height }, { 20, 32, 3 });
                         break;
                 }
@@ -7613,25 +7859,29 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE_BANKED + 8),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE_BANKED + 8)),
                             { 0, 6, height }, { 32, 20, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE_BANKED + 10),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE_BANKED + 10)),
                             { 0, 6, height }, { 32, 20, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE_BANKED + 12),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE_BANKED + 12)),
                             { 0, 6, height }, { 32, 1, 34 }, { 0, 27, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE_BANKED + 14),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE_BANKED + 14)),
                             { 0, 6, height }, { 32, 20, 3 });
                         break;
                 }
@@ -7658,7 +7908,8 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE_BANKED + 9),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE_BANKED + 9)),
                             { 6, 0, height }, { 20, 32, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -7666,7 +7917,8 @@ namespace SingleRailRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE_BANKED + 11),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE_BANKED + 11)),
                             { 6, 0, height }, { 1, 32, 34 }, { 27, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -7674,7 +7926,8 @@ namespace SingleRailRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE_BANKED + 13),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE_BANKED + 13)),
                             { 6, 0, height }, { 1, 32, 34 }, { 27, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -7682,7 +7935,8 @@ namespace SingleRailRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE_BANKED + 15),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_SMALL_CURVE_BANKED + 15)),
                             { 6, 0, height }, { 20, 32, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -7733,25 +7987,29 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 0),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 0)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 5),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 5)),
                             { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 10),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 10)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 15),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 15)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -7775,25 +8033,29 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 1),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 1)),
                             { 0, 0, height }, { 32, 16, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 6),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 6)),
                             { 0, 0, height }, { 1, 1, 34 }, { 30, 30, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 11),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 11)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 16),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 16)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                 }
@@ -7810,25 +8072,29 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 2),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 2)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 7),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 7)),
                             { 0, 0, height }, { 1, 1, 34 }, { 30, 30, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 12),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 12)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 17),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 17)),
                             { 0, 0, height }, { 16, 16, 3 });
                         break;
                 }
@@ -7846,25 +8112,29 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 3),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 3)),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 8),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 8)),
                             { 0, 0, height }, { 1, 1, 34 }, { 30, 30, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 13),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 13)),
                             { 0, 0, height }, { 1, 32, 34 }, { 27, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 18),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 18)),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         break;
                 }
@@ -7881,25 +8151,29 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 4),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 4)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 9),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 9)),
                             { 0, 0, height }, { 1, 32, 34 }, { 27, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 14),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 14)),
                             { 0, 0, height }, { 1, 32, 34 }, { 27, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 19),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 19)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                 }
@@ -7934,25 +8208,29 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 20),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 20)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 25),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 25)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 30),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 30)),
                             { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 35),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 35)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -7976,25 +8254,29 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 21),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 21)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 26),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 26)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 31),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 31)),
                             { 0, 0, height }, { 1, 1, 34 }, { 30, 30, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 36),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 36)),
                             { 0, 0, height }, { 32, 16, 3 });
                         break;
                 }
@@ -8011,25 +8293,29 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 22),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 22)),
                             { 0, 0, height }, { 16, 16, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 27),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 27)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 32),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 32)),
                             { 0, 0, height }, { 1, 1, 34 }, { 30, 30, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 37),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 37)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         break;
                 }
@@ -8047,25 +8333,29 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 23),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 23)),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 28),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 28)),
                             { 0, 0, height }, { 1, 32, 34 }, { 27, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 33),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 33)),
                             { 0, 0, height }, { 1, 1, 34 }, { 30, 30, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 38),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 38)),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         break;
                 }
@@ -8082,25 +8372,29 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 24),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 24)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 29),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 29)),
                             { 0, 0, height }, { 1, 32, 34 }, { 27, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 34),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 34)),
                             { 0, 0, height }, { 1, 32, 34 }, { 27, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 39),
+                            session.TrackColours[SCHEME_TRACK].WithIndex(
+                                (SPR_G2_SINGLE_RAIL_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 39)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                 }
@@ -8150,22 +8444,26 @@ namespace SingleRailRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 0),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 0)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 4),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 4)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 3),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 3)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 7),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 7)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -8185,26 +8483,30 @@ namespace SingleRailRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 1),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 1)),
                             { 0, 0, height }, { 32, 26, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 5),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 5)),
                             { 0, 0, height }, { 32, 26, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 6, 1, height - 1, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 2),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 2)),
                             { 0, 0, height }, { 32, 26, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 6),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 6)),
                             { 0, 0, height }, { 32, 26, 3 }, { 0, 6, height });
                         break;
                 }
@@ -8220,24 +8522,28 @@ namespace SingleRailRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 2),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 2)),
                             { 0, 0, height }, { 32, 26, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 6),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 6)),
                             { 0, 0, height }, { 32, 26, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 1),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 1)),
                             { 0, 0, height }, { 32, 26, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 5),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 5)),
                             { 0, 0, height }, { 32, 26, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 6, 1, height - 1, session.TrackColours[SCHEME_SUPPORTS]);
@@ -8255,22 +8561,26 @@ namespace SingleRailRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 3),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 3)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 7),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 7)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 0),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 0)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 4),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 4)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -8304,22 +8614,26 @@ namespace SingleRailRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 8),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 8)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 12),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 12)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 11),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 11)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 15),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 15)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -8339,26 +8653,30 @@ namespace SingleRailRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 9),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 9)),
                             { 0, 0, height }, { 32, 26, 3 }, { 0, 6, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 13),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 13)),
                             { 0, 0, height }, { 32, 26, 3 }, { 0, 6, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 10),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 10)),
                             { 0, 0, height }, { 32, 26, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 14),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 14)),
                             { 0, 0, height }, { 32, 26, 3 });
                         break;
                 }
@@ -8374,24 +8692,28 @@ namespace SingleRailRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 10),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 10)),
                             { 0, 0, height }, { 32, 26, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 14),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 14)),
                             { 0, 0, height }, { 32, 26, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 9),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 9)),
                             { 0, 0, height }, { 32, 26, 3 }, { 0, 6, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 13),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 13)),
                             { 0, 0, height }, { 32, 26, 3 }, { 0, 6, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -8409,22 +8731,26 @@ namespace SingleRailRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 11),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 11)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 15),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 15)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 8),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 8)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 12),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_S_BEND + 12)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -8458,27 +8784,31 @@ namespace SingleRailRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 0),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 0)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 1),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 1)),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 4),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 4)),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 7),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 7)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 11), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 11)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -8501,24 +8831,27 @@ namespace SingleRailRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 2),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 2)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 5),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 5)),
                             { 0, 0, height }, { 16, 16, 1 }, { 0, 0, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 8),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 8)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 12), { 0, 0, height },
-                            { 16, 16, 3 }, { 16, 16, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 12)),
+                            { 0, 0, height }, { 16, 16, 3 }, { 16, 16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -8531,28 +8864,31 @@ namespace SingleRailRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 3),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 3)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 6),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 6)),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 9),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 9)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 10), { 0, 0, height },
-                            { 1, 32, 26 }, { 27, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 10)),
+                            { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 13), { 0, 0, height },
-                            { 20, 32, 3 }, { 6, 0, height + 8 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 13)),
+                            { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height + 8 });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -8578,25 +8914,29 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 11), { 0, 0, height },
-                            { 20, 32, 3 }, { 6, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 11)),
+                            { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 0),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 0)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 1),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 1)),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 4),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 4)),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 7),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 7)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                 }
@@ -8626,22 +8966,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 12), { 0, 0, height },
-                            { 16, 16, 3 }, { 16, 16, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 12)),
+                            { 0, 0, height }, { 16, 16, 3 }, { 16, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 2),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 2)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 5),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 5)),
                             { 0, 0, height }, { 16, 16, 1 }, { 0, 0, height + 27 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 8),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 8)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         break;
                 }
@@ -8656,27 +8999,30 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 13), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height + 8 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 13)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height + 8 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 3),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 3)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 6),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 6)),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 9),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 9)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 10), { 0, 0, height },
-                            { 32, 1, 26 }, { 0, 27, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 10)),
+                            { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -8706,30 +9052,30 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 14), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 14)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 17), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 17)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 21), { 0, 0, height },
-                            { 32, 1, 26 }, { 0, 27, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 21)),
+                            { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 24), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 24)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 25), { 0, 0, height },
-                            { 32, 1, 26 }, { 0, 27, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 25)),
+                            { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -8753,26 +9099,26 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 15), { 0, 0, height },
-                            { 16, 16, 3 }, { 16, 16, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 15)),
+                            { 0, 0, height }, { 16, 16, 3 }, { 16, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 18), { 0, 0, height },
-                            { 16, 16, 3 }, { 0, 16, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 18)),
+                            { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 22), { 0, 0, height },
-                            { 16, 16, 1 }, { 0, 0, height + 27 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 22)),
+                            { 0, 0, height }, { 16, 16, 1 }, { 0, 0, height + 27 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 26), { 0, 0, height },
-                            { 16, 16, 3 }, { 16, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 26)),
+                            { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -8786,30 +9132,30 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 16), { 0, 0, height },
-                            { 20, 32, 3 }, { 6, 0, height + 8 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 16)),
+                            { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height + 8 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 19), { 0, 0, height },
-                            { 20, 32, 3 }, { 6, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 19)),
+                            { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 20), { 0, 0, height },
-                            { 1, 32, 26 }, { 27, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 20)),
+                            { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 23), { 0, 0, height },
-                            { 1, 32, 26 }, { 27, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 23)),
+                            { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 27), { 0, 0, height },
-                            { 20, 32, 3 }, { 6, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 27)),
+                            { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -8835,30 +9181,30 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 17), { 0, 0, height },
-                            { 20, 32, 3 }, { 6, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 17)),
+                            { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 21), { 0, 0, height },
-                            { 1, 32, 26 }, { 27, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 21)),
+                            { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 24), { 0, 0, height },
-                            { 20, 32, 3 }, { 6, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 24)),
+                            { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 25), { 0, 0, height },
-                            { 1, 32, 26 }, { 27, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 25)),
+                            { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 14), { 0, 0, height },
-                            { 20, 32, 3 }, { 6, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 14)),
+                            { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -8887,26 +9233,26 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 18), { 0, 0, height },
-                            { 16, 16, 3 }, { 16, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 18)),
+                            { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 22), { 0, 0, height },
-                            { 16, 16, 1 }, { 0, 0, height + 27 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 22)),
+                            { 0, 0, height }, { 16, 16, 1 }, { 0, 0, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 26), { 0, 0, height },
-                            { 16, 16, 3 }, { 0, 16, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 26)),
+                            { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 15), { 0, 0, height },
-                            { 16, 16, 3 }, { 16, 16, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 15)),
+                            { 0, 0, height }, { 16, 16, 3 }, { 16, 16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -8920,30 +9266,30 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 19), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 19)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 20), { 0, 0, height },
-                            { 32, 1, 26 }, { 0, 27, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 20)),
+                            { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 23), { 0, 0, height },
-                            { 32, 1, 26 }, { 0, 27, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 23)),
+                            { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 27), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 27)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 16), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height + 8 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_HELIX + 16)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height + 8 });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -8998,28 +9344,31 @@ namespace SingleRailRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 0),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 0)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 1),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 1)),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 6),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 6)),
                             { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 11), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 11)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 17), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 17)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -9042,25 +9391,27 @@ namespace SingleRailRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 2),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 2)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 7),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 7)),
                             { 0, 0, height }, { 32, 16, 1 }, { 0, 0, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 12), { 0, 0, height },
-                            { 32, 16, 3 }, { 0, 16, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 12)),
+                            { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 18), { 0, 0, height },
-                            { 32, 16, 3 }, { 0, 16, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 18)),
+                            { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -9075,25 +9426,27 @@ namespace SingleRailRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 3),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 3)),
                             { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 8),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 8)),
                             { 0, 0, height }, { 16, 16, 1 }, { 16, 16, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 13), { 0, 0, height },
-                            { 16, 16, 3 }, { 16, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 13)),
+                            { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 19), { 0, 0, height },
-                            { 16, 16, 3 }, { 0, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 19)),
+                            { 0, 0, height }, { 16, 16, 3 }, { 0, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -9109,25 +9462,27 @@ namespace SingleRailRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 4),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 4)),
                             { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 9),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 9)),
                             { 0, 0, height }, { 16, 32, 1 }, { 0, 0, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 14), { 0, 0, height },
-                            { 16, 32, 3 }, { 0, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 14)),
+                            { 0, 0, height }, { 16, 32, 3 }, { 0, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 20), { 0, 0, height },
-                            { 16, 32, 3 }, { 16, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 20)),
+                            { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -9142,30 +9497,31 @@ namespace SingleRailRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 5),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 5)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 10), { 0, 0, height },
-                            { 1, 32, 26 }, { 27, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 10)),
+                            { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 15), { 0, 0, height },
-                            { 20, 32, 3 }, { 6, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 15)),
+                            { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 16), { 0, 0, height },
-                            { 1, 32, 26 }, { 27, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 16)),
+                            { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 21), { 0, 0, height },
-                            { 20, 32, 3 }, { 6, 0, height + 8 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 21)),
+                            { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height + 8 });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -9191,27 +9547,30 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 17), { 0, 0, height },
-                            { 20, 32, 3 }, { 6, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 17)),
+                            { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 0),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 0)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 1),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 1)),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 6),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 6)),
                             { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 11), { 0, 0, height },
-                            { 20, 32, 3 }, { 6, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 11)),
+                            { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -9240,24 +9599,26 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 18), { 0, 0, height },
-                            { 16, 32, 3 }, { 16, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 18)),
+                            { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 2),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 2)),
                             { 0, 0, height }, { 16, 32, 3 }, { 0, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 7),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 7)),
                             { 0, 0, height }, { 16, 32, 1 }, { 0, 0, height + 27 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 12), { 0, 0, height },
-                            { 16, 32, 3 }, { 16, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 12)),
+                            { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -9273,24 +9634,26 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 19), { 0, 0, height },
-                            { 16, 16, 3 }, { 0, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 19)),
+                            { 0, 0, height }, { 16, 16, 3 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 3),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 3)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 8),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 8)),
                             { 0, 0, height }, { 16, 16, 1 }, { 16, 16, height + 27 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 13), { 0, 0, height },
-                            { 16, 16, 3 }, { 0, 16, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 13)),
+                            { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -9307,24 +9670,26 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 20), { 0, 0, height },
-                            { 32, 16, 3 }, { 0, 16, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 20)),
+                            { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 4),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 4)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 9),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 9)),
                             { 0, 0, height }, { 32, 16, 1 }, { 0, 0, height + 27 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 14), { 0, 0, height },
-                            { 32, 16, 3 }, { 0, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 14)),
+                            { 0, 0, height }, { 32, 16, 3 }, { 0, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -9340,29 +9705,30 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 21), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height + 8 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 21)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height + 8 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 5),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 5)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 10), { 0, 0, height },
-                            { 32, 1, 26 }, { 0, 27, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 10)),
+                            { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 15), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 15)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 16), { 0, 0, height },
-                            { 32, 1, 26 }, { 0, 27, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 16)),
+                            { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -9391,30 +9757,30 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 22), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 22)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 27), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 27)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 33), { 0, 0, height },
-                            { 32, 1, 26 }, { 0, 27, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 33)),
+                            { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 38), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 38)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 39), { 0, 0, height },
-                            { 32, 1, 26 }, { 0, 27, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 39)),
+                            { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -9438,26 +9804,26 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 23), { 0, 0, height },
-                            { 32, 16, 3 }, { 0, 16, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 23)),
+                            { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 28), { 0, 0, height },
-                            { 32, 16, 3 }, { 0, 16, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 28)),
+                            { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 34), { 0, 0, height },
-                            { 32, 16, 1 }, { 0, 0, height + 27 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 34)),
+                            { 0, 0, height }, { 32, 16, 1 }, { 0, 0, height + 27 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 40), { 0, 0, height },
-                            { 32, 16, 3 }, { 0, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 40)),
+                            { 0, 0, height }, { 32, 16, 3 }, { 0, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -9473,26 +9839,26 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 24), { 0, 0, height },
-                            { 16, 16, 3 }, { 0, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 24)),
+                            { 0, 0, height }, { 16, 16, 3 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 29), { 0, 0, height },
-                            { 16, 16, 3 }, { 16, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 29)),
+                            { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 35), { 0, 0, height },
-                            { 16, 16, 1 }, { 16, 16, height + 27 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 35)),
+                            { 0, 0, height }, { 16, 16, 1 }, { 16, 16, height + 27 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 41), { 0, 0, height },
-                            { 16, 16, 3 }, { 0, 16, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 41)),
+                            { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -9509,26 +9875,26 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 25), { 0, 0, height },
-                            { 16, 32, 3 }, { 16, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 25)),
+                            { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 30), { 0, 0, height },
-                            { 16, 32, 3 }, { 0, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 30)),
+                            { 0, 0, height }, { 16, 32, 3 }, { 0, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 36), { 0, 0, height },
-                            { 16, 32, 1 }, { 0, 0, height + 27 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 36)),
+                            { 0, 0, height }, { 16, 32, 1 }, { 0, 0, height + 27 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 42), { 0, 0, height },
-                            { 16, 32, 3 }, { 16, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 42)),
+                            { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -9544,36 +9910,36 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 26), { 0, 0, height },
-                            { 20, 32, 3 }, { 6, 0, height + 8 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 26)),
+                            { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height + 8 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 31), { 0, 0, height },
-                            { 20, 32, 3 }, { 6, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 31)),
+                            { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 32), { 0, 0, height },
-                            { 1, 32, 26 }, { 27, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 32)),
+                            { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 37), { 0, 0, height },
-                            { 1, 32, 26 }, { 27, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 37)),
+                            { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 43), { 0, 0, height },
-                            { 20, 32, 3 }, { 6, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 43)),
+                            { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9599,30 +9965,30 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 27), { 0, 0, height },
-                            { 20, 32, 3 }, { 6, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 27)),
+                            { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 33), { 0, 0, height },
-                            { 1, 32, 26 }, { 27, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 33)),
+                            { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 38), { 0, 0, height },
-                            { 20, 32, 3 }, { 6, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 38)),
+                            { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 39), { 0, 0, height },
-                            { 1, 32, 26 }, { 27, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 39)),
+                            { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 22), { 0, 0, height },
-                            { 20, 32, 3 }, { 6, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 22)),
+                            { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -9651,26 +10017,26 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 28), { 0, 0, height },
-                            { 16, 32, 3 }, { 16, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 28)),
+                            { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 34), { 0, 0, height },
-                            { 16, 32, 1 }, { 0, 0, height + 27 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 34)),
+                            { 0, 0, height }, { 16, 32, 1 }, { 0, 0, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 40), { 0, 0, height },
-                            { 16, 32, 3 }, { 0, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 40)),
+                            { 0, 0, height }, { 16, 32, 3 }, { 0, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 23), { 0, 0, height },
-                            { 16, 32, 3 }, { 16, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 23)),
+                            { 0, 0, height }, { 16, 32, 3 }, { 16, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -9686,26 +10052,26 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 29), { 0, 0, height },
-                            { 16, 16, 3 }, { 0, 16, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 29)),
+                            { 0, 0, height }, { 16, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 35), { 0, 0, height },
-                            { 16, 16, 1 }, { 16, 16, height + 27 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 35)),
+                            { 0, 0, height }, { 16, 16, 1 }, { 16, 16, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 41), { 0, 0, height },
-                            { 16, 16, 3 }, { 16, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 41)),
+                            { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 24), { 0, 0, height },
-                            { 16, 16, 3 }, { 0, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 24)),
+                            { 0, 0, height }, { 16, 16, 3 }, { 0, 0, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -9722,26 +10088,26 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 30), { 0, 0, height },
-                            { 32, 16, 3 }, { 0, 0, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 30)),
+                            { 0, 0, height }, { 32, 16, 3 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 36), { 0, 0, height },
-                            { 32, 16, 1 }, { 0, 0, height + 27 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 36)),
+                            { 0, 0, height }, { 32, 16, 1 }, { 0, 0, height + 27 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 42), { 0, 0, height },
-                            { 32, 16, 3 }, { 0, 16, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 42)),
+                            { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 25), { 0, 0, height },
-                            { 32, 16, 3 }, { 0, 16, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 25)),
+                            { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -9757,36 +10123,36 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 31), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 31)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 32), { 0, 0, height },
-                            { 32, 1, 26 }, { 0, 27, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 32)),
+                            { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 37), { 0, 0, height },
-                            { 32, 1, 26 }, { 0, 27, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 37)),
+                            { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 43), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 43)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 26), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height + 8 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HELIX + 26)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height + 8 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9841,20 +10207,24 @@ namespace SingleRailRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 0),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 0)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 1),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 1)),
                             { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 28 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 2, 4, height + 1, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 6),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 6)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 7),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 7)),
                             { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 28 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 3, 4, height + 1, session.TrackColours[SCHEME_SUPPORTS]);
@@ -9862,24 +10232,24 @@ namespace SingleRailRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 12), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 12)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 13), { 0, 0, height },
-                            { 32, 20, 0 }, { 0, 6, height + 28 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 13)),
+                            { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 28 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 1, 0, height + 1, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 18), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 18)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 19), { 0, 0, height },
-                            { 32, 20, 0 }, { 0, 6, height + 28 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 19)),
+                            { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 28 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9899,39 +10269,43 @@ namespace SingleRailRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 2),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 2)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 3),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 3)),
                             { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 28 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 8),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 8)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 9),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 9)),
                             { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 28 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 14), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 14)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 15), { 0, 0, height },
-                            { 32, 20, 0 }, { 0, 6, height + 28 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 15)),
+                            { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 28 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 20), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 20)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 21), { 0, 0, height },
-                            { 32, 20, 0 }, { 0, 6, height + 28 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 21)),
+                            { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 28 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -9946,41 +10320,43 @@ namespace SingleRailRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 4),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 4)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 5),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 5)),
                             { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 44 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 10), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 10)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 11), { 0, 0, height },
-                            { 32, 20, 0 }, { 0, 6, height + 44 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 11)),
+                            { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 44 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 16), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 16)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 17), { 0, 0, height },
-                            { 32, 20, 0 }, { 0, 6, height + 44 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 17)),
+                            { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 44 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 22), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 22)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 23), { 0, 0, height },
-                            { 32, 20, 0 }, { 0, 6, height + 44 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 23)),
+                            { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 44 });
                         break;
                 }
                 switch (direction)
@@ -10013,48 +10389,48 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 24), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 24)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 25), { 0, 0, height },
-                            { 32, 20, 0 }, { 0, 6, height + 28 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 25)),
+                            { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 28 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 30), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 30)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 31), { 0, 0, height },
-                            { 32, 20, 0 }, { 0, 6, height + 28 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 31)),
+                            { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 28 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 2, 0, height + 1, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 36), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 36)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 37), { 0, 0, height },
-                            { 32, 20, 0 }, { 0, 6, height + 28 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 37)),
+                            { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 28 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 3, 4, height + 1, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 42), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 42)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 43), { 0, 0, height },
-                            { 32, 20, 0 }, { 0, 6, height + 28 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 43)),
+                            { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 28 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 1, 4, height + 1, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -10075,42 +10451,42 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 26), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 26)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 27), { 0, 0, height },
-                            { 32, 20, 0 }, { 0, 6, height + 28 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 27)),
+                            { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 28 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 32), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 32)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 33), { 0, 0, height },
-                            { 32, 20, 0 }, { 0, 6, height + 28 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 33)),
+                            { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 28 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 38), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 38)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 39), { 0, 0, height },
-                            { 32, 20, 0 }, { 0, 6, height + 28 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 39)),
+                            { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 28 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 44), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 44)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 45), { 0, 0, height },
-                            { 32, 20, 0 }, { 0, 6, height + 28 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 45)),
+                            { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 28 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -10126,42 +10502,42 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 28), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 28)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 29), { 0, 0, height },
-                            { 32, 20, 0 }, { 0, 6, height + 44 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 29)),
+                            { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 44 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 34), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 34)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 35), { 0, 0, height },
-                            { 32, 20, 0 }, { 0, 6, height + 44 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 35)),
+                            { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 44 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 40), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 40)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 41), { 0, 0, height },
-                            { 32, 20, 0 }, { 0, 6, height + 44 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 41)),
+                            { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 44 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 46), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 46)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 47), { 0, 0, height },
-                            { 32, 20, 0 }, { 0, 6, height + 44 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BARREL_ROLL + 47)),
+                            { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 44 });
                         break;
                 }
                 switch (direction)
@@ -10207,22 +10583,26 @@ namespace SingleRailRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_HALF_LOOP + 0),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_HALF_LOOP + 0)),
                             { 0, 6, height }, { 32, 20, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_HALF_LOOP + 4),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_HALF_LOOP + 4)),
                             { 0, 6, height }, { 32, 20, 11 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_HALF_LOOP + 8),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_HALF_LOOP + 8)),
                             { 0, 6, height }, { 32, 20, 9 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_HALF_LOOP + 12),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_HALF_LOOP + 12)),
                             { 0, 6, height }, { 32, 20, 7 });
                         break;
                 }
@@ -10241,28 +10621,32 @@ namespace SingleRailRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_HALF_LOOP + 1),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_HALF_LOOP + 1)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_HALF_LOOP + 5),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_HALF_LOOP + 5)),
                             { 0, 14, height }, { 3, 20, 63 }, { 28, 6, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 15, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_HALF_LOOP + 9),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_HALF_LOOP + 9)),
                             { 0, 6, height }, { 3, 20, 63 }, { 28, 6, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_HALF_LOOP + 13),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_HALF_LOOP + 13)),
                             { 0, 6, height }, { 32, 20, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -10276,22 +10660,26 @@ namespace SingleRailRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_HALF_LOOP + 2),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_HALF_LOOP + 2)),
                             { 16, 0, height }, { 2, 16, 119 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_HALF_LOOP + 6),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_HALF_LOOP + 6)),
                             { 12, 0, height }, { 3, 16, 119 }, { 12, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_HALF_LOOP + 10),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_HALF_LOOP + 10)),
                             { 10, 16, height }, { 4, 12, 119 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_HALF_LOOP + 14),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_HALF_LOOP + 14)),
                             { 16, 16, height }, { 2, 16, 119 }, { 15, 6, height });
                         break;
                 }
@@ -10307,22 +10695,26 @@ namespace SingleRailRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_HALF_LOOP + 3),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_HALF_LOOP + 3)),
                             { 0, 0, height + 32 }, { 32, 16, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_HALF_LOOP + 7),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_HALF_LOOP + 7)),
                             { 0, 0, height + 32 }, { 32, 16, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_HALF_LOOP + 11),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_HALF_LOOP + 11)),
                             { 0, 16, height + 32 }, { 32, 12, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_HALF_LOOP + 15),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_HALF_LOOP + 15)),
                             { 0, 16, height + 32 }, { 32, 12, 3 });
                         break;
                 }
@@ -10353,13 +10745,13 @@ namespace SingleRailRC
             case 0:
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BRAKE + 0),
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BRAKE + 0)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 1:
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BRAKE + 1),
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BRAKE + 1)),
                     { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                 break;
         }
@@ -10381,46 +10773,46 @@ namespace SingleRailRC
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                    session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_FLAT + 0),
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_FLAT + 0)),
                     { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 3 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                    session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_FLAT + 1),
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_FLAT + 1)),
                     { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 3 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                    session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_FLAT + 0),
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_FLAT + 0)),
                     { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 3 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                    session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_FLAT + 1),
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_FLAT + 1)),
                     { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 3 });
                 break;
         }
@@ -10442,25 +10834,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 0), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 0)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 4), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 4)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 8), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 8)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 12),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 12)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -10483,25 +10875,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 1), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 1)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 5), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 5)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 9), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 9)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 13),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 13)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -10520,25 +10912,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 2), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 2)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 6), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 6)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 10),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 10)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 14),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 14)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -10557,25 +10949,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 3), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 3)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 7), { 0, 0, height },
-                            { 32, 1, 98 }, { 0, 27, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 7)),
+                            { 0, 0, height }, { 32, 1, 98 }, { 0, 27, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 11),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 11)),
                             { 0, 0, height }, { 32, 1, 98 }, { 0, 27, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 15),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 15)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -10611,25 +11003,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 16),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 16)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 20),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 20)),
                             { 0, 0, height }, { 32, 1, 98 }, { 0, 27, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 24),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 24)),
                             { 0, 0, height }, { 32, 1, 98 }, { 0, 27, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 28),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 28)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -10652,25 +11044,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 17),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 17)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 21),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 21)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 25),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 25)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 29),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 29)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -10689,25 +11081,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 18),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 18)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 22),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 22)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 26),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 26)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 30),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 30)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -10726,25 +11118,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 19),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 19)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 23),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 23)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 27),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 27)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 31),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_FLAT_TO_STEEP + 31)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -10792,14 +11184,16 @@ namespace SingleRailRC
             case 0:
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BLOCK_BRAKE + 0),
-                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BLOCK_BRAKE + 0)), { 0, 0, height },
+                    { 32, 20, 3 }, { 0, 6, height });
                 break;
             case 1:
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_BLOCK_BRAKE + 1),
-                    { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
+                    session, direction,
+                    session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_BLOCK_BRAKE + 1)), { 0, 0, height },
+                    { 32, 20, 3 }, { 0, 6, height });
                 break;
         }
         if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -10823,22 +11217,26 @@ namespace SingleRailRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 0),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 0)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height + 4 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 3),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 3)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height + 4 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 6),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 6)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height + 4 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 9),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 9)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height + 4 });
                         break;
                 }
@@ -10861,22 +11259,26 @@ namespace SingleRailRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 1),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 1)),
                             { 0, 0, height }, { 20, 20, 3 }, { 6, 6, height + 10 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 4),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 4)),
                             { 0, 0, height }, { 20, 20, 3 }, { 6, 6, height + 10 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 7),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 7)),
                             { 0, 0, height }, { 20, 20, 3 }, { 6, 6, height + 10 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 10),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 10)),
                             { 0, 0, height }, { 20, 20, 3 }, { 6, 6, height + 10 });
                         break;
                 }
@@ -10888,22 +11290,26 @@ namespace SingleRailRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 2),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 2)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height + 24 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 5),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 5)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height + 24 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 8),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 8)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height + 24 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 11),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 11)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height + 24 });
                         break;
                 }
@@ -10940,22 +11346,26 @@ namespace SingleRailRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 12),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 12)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height + 4 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 15),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 15)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height + 4 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 18),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 18)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height + 4 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 21),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 21)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height + 4 });
                         break;
                 }
@@ -10976,22 +11386,26 @@ namespace SingleRailRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 13),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 13)),
                             { 0, 0, height }, { 20, 20, 3 }, { 6, 6, height + 10 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 16),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 16)),
                             { 0, 0, height }, { 20, 20, 3 }, { 6, 6, height + 10 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 19),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 19)),
                             { 0, 0, height }, { 20, 20, 3 }, { 6, 6, height + 10 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 22),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 22)),
                             { 0, 0, height }, { 20, 20, 3 }, { 6, 6, height + 10 });
                         break;
                 }
@@ -11003,22 +11417,26 @@ namespace SingleRailRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 14),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 14)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height + 24 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 17),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 17)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height + 24 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 20),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 20)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height + 24 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 23),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_CORKSCREW + 23)),
                             { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height + 24 });
                         break;
                 }
@@ -11070,25 +11488,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 0),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 0)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height + 4 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 5),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 5)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height + 4 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 10),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 10)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height + 4 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 15),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 15)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height + 4 });
                         break;
                 }
@@ -11112,7 +11530,7 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 1),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 1)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 6, 34, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11120,7 +11538,7 @@ namespace SingleRailRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 6),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 6)),
                             { 0, 0, height }, { 26, 1, 32 }, { 0, 29, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 8, 22, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11128,7 +11546,7 @@ namespace SingleRailRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 11),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 11)),
                             { 0, 0, height }, { 20, 20, 3 }, { 0, 6, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 7, 24, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11136,7 +11554,7 @@ namespace SingleRailRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 16),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 16)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 5, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11155,25 +11573,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 2),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 2)),
                             { 0, 0, height }, { 48, 1, 64 }, { 0, 31, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 7),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 7)),
                             { 0, 0, height }, { 28, 28, 1 }, { 2, 2, height + 40 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 12),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 12)),
                             { 0, 0, height }, { 28, 28, 1 }, { 2, 2, height + 48 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 17),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 17)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -11196,7 +11614,7 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 3),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 3)),
                             { 0, 0, height }, { 28, 28, 0 }, { 2, 2, height + 50 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 5, 0, height + 56, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11204,7 +11622,7 @@ namespace SingleRailRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 8),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 8)),
                             { 0, 0, height }, { 28, 28, 0 }, { 2, 2, height + 50 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 6, 0, height + 56, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11212,7 +11630,7 @@ namespace SingleRailRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 13),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 13)),
                             { 0, 0, height }, { 24, 28, 0 }, { 2, 2, height + 50 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 8, 0, height + 56, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11220,7 +11638,7 @@ namespace SingleRailRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 18),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 18)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 7, 0, height + 56, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11235,25 +11653,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 4),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 4)),
                             { 0, 0, height }, { 28, 28, 1 }, { 2, 2, height + 40 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 9),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 9)),
                             { 0, 0, height }, { 28, 28, 1 }, { 2, 2, height + 40 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 14),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 14)),
                             { 0, 0, height }, { 26, 28, 1 }, { 2, 2, height + 40 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 19),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 19)),
                             { 0, 0, height }, { 26, 28, 1 }, { 2, 2, height + 40 });
                         break;
                 }
@@ -11289,25 +11707,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 20),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 20)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height + 4 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 25),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 25)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height + 4 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 30),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 30)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height + 4 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 35),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 35)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height + 4 });
                         break;
                 }
@@ -11331,7 +11749,7 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 21),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 21)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 6, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11339,7 +11757,7 @@ namespace SingleRailRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 26),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 26)),
                             { 0, 0, height }, { 20, 20, 3 }, { 0, 6, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 8, 24, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11347,7 +11765,7 @@ namespace SingleRailRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 31),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 31)),
                             { 0, 0, height }, { 26, 1, 32 }, { 0, 29, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 7, 22, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11355,7 +11773,7 @@ namespace SingleRailRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 36),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 36)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 5, 34, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11374,25 +11792,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 22),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 22)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 27),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 27)),
                             { 0, 0, height }, { 28, 28, 1 }, { 2, 2, height + 48 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 32),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 32)),
                             { 0, 0, height }, { 28, 28, 1 }, { 2, 2, height + 48 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 37),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 37)),
                             { 0, 0, height }, { 48, 1, 64 }, { 0, 31, height });
                         break;
                 }
@@ -11415,7 +11833,7 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 23),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 23)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 8, 0, height + 56, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11423,7 +11841,7 @@ namespace SingleRailRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 28),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 28)),
                             { 0, 0, height }, { 24, 28, 0 }, { 2, 2, height + 50 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 7, 0, height + 56, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11431,7 +11849,7 @@ namespace SingleRailRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 33),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 33)),
                             { 0, 0, height }, { 28, 28, 0 }, { 2, 2, height + 50 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 5, 0, height + 56, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11439,7 +11857,7 @@ namespace SingleRailRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 38),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 38)),
                             { 0, 0, height }, { 28, 28, 0 }, { 2, 2, height + 50 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 6, 0, height + 56, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11453,25 +11871,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 24),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 24)),
                             { 0, 0, height }, { 26, 28, 1 }, { 2, 2, height + 40 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 29),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 29)),
                             { 0, 0, height }, { 26, 28, 1 }, { 2, 2, height + 40 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 34),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 34)),
                             { 0, 0, height }, { 28, 28, 1 }, { 2, 2, height + 40 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 39),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CORKSCREW + 39)),
                             { 0, 0, height }, { 28, 28, 1 }, { 2, 2, height + 40 });
                         break;
                 }
@@ -11537,25 +11955,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 0),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 0)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 5),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 5)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 10),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 10)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 15),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 15)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -11577,25 +11995,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 1),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 1)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 6),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 6)),
                             { 0, 0, height }, { 0, 32, 64 }, { 0, 31, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 11),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 11)),
                             { 0, 0, height }, { 40, 0, 64 }, { 0, 32, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 16),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 16)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -11613,7 +12031,7 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 2),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 2)),
                             { 0, 0, height }, { 32, 32, 0 }, { 0, 0, height + 2 });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 5, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11621,7 +12039,7 @@ namespace SingleRailRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 7),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 7)),
                             { 0, 0, height }, { 1, 32, 96 }, { 29, 0, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 6, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11629,7 +12047,7 @@ namespace SingleRailRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 12),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 12)),
                             { 0, 0, height }, { 1, 32, 96 }, { 31, 0, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 8, 18, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11637,7 +12055,7 @@ namespace SingleRailRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 17),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 17)),
                             { 0, 0, height }, { 32, 32, 0 }, { 0, 0, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 7, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11654,25 +12072,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 3),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 3)),
                             { 0, 0, height }, { 1, 32, 160 }, { 2, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 8),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 8)),
                             { 0, 0, height }, { 0, 32, 160 }, { 30, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 13),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 13)),
                             { 0, 0, height }, { 1, 32, 160 }, { 29, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 18),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 18)),
                             { 0, 0, height }, { 1, 32, 160 }, { 0, 0, height });
                         break;
                 }
@@ -11687,25 +12105,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 4),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 4)),
                             { 0, 0, height }, { 32, 32, 1 }, { 0, 2, height + 48 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 9),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 9)),
                             { 0, 0, height }, { 32, 32, 1 }, { 0, 2, height + 48 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 14),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 14)),
                             { 0, 0, height }, { 32, 32, 1 }, { 0, 0, height + 48 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 19),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 19)),
                             { 0, 0, height }, { 32, 32, 1 }, { 0, 0, height + 48 });
                         break;
                 }
@@ -11737,25 +12155,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 20),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 20)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 25),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 25)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 30),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 30)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 35),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 35)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -11777,25 +12195,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 21),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 21)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 26),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 26)),
                             { 0, 0, height }, { 40, 0, 64 }, { 0, 32, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 31),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 31)),
                             { 0, 0, height }, { 0, 32, 64 }, { 0, 31, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 36),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 36)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -11813,7 +12231,7 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 22),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 22)),
                             { 0, 0, height }, { 32, 32, 0 }, { 0, 0, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 8, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11821,7 +12239,7 @@ namespace SingleRailRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 27),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 27)),
                             { 0, 0, height }, { 0, 32, 96 }, { 30, 0, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 7, 18, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11829,7 +12247,7 @@ namespace SingleRailRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 32),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 32)),
                             { 0, 0, height }, { 0, 32, 96 }, { 29, 0, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 5, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11837,7 +12255,7 @@ namespace SingleRailRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 37),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 37)),
                             { 0, 0, height }, { 32, 32, 0 }, { 0, 0, height + 2 });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 6, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11854,25 +12272,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 23),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 23)),
                             { 0, 0, height }, { 1, 32, 160 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 28),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 28)),
                             { 0, 0, height }, { 0, 32, 160 }, { 29, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 33),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 33)),
                             { 0, 0, height }, { 0, 32, 160 }, { 30, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 38),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 38)),
                             { 0, 0, height }, { 1, 32, 160 }, { 2, 0, height });
                         break;
                 }
@@ -11888,25 +12306,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 24),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 24)),
                             { 0, 0, height }, { 32, 32, 1 }, { 0, 0, height + 48 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 29),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 29)),
                             { 0, 0, height }, { 32, 32, 1 }, { 0, 0, height + 48 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 34),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 34)),
                             { 0, 0, height }, { 32, 32, 1 }, { 0, 0, height + 48 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 39),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_MEDIUM_HALF_LOOP + 39)),
                             { 0, 0, height }, { 32, 32, 1 }, { 0, 0, height + 48 });
                         break;
                 }
@@ -11950,27 +12368,32 @@ namespace SingleRailRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 0),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 0)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 1),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 1)),
                             { 0, 0, height }, { 32, 20, 1 }, { 0, 6, height + 28 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 4),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 4)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 5),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 5)),
                             { 0, 0, height }, { 32, 1, 32 }, { 0, 31, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 8),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 8)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -11978,8 +12401,8 @@ namespace SingleRailRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 12), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 12)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -11998,24 +12421,27 @@ namespace SingleRailRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 2),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 2)),
                             { 0, 0, height }, { 32, 20, 1 }, { 0, 6, height + 28 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 6),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 6)),
                             { 0, 0, height }, { 32, 20, 1 }, { 0, 6, height + 28 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 9),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 9)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 13), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 13)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -12030,33 +12456,35 @@ namespace SingleRailRC
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 3),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 3)),
                             { 0, 0, height }, { 32, 20, 1 }, { 0, 6, height + 28 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 7),
+                            session, direction,
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 7)),
                             { 0, 0, height }, { 32, 20, 1 }, { 0, 6, height + 28 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 10), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 10)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 11), { 0, 0, height },
-                            { 32, 20, 0 }, { 0, 6, height + 33 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 11)),
+                            { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 33 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 14), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 14)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 15), { 0, 0, height },
-                            { 32, 20, 0 }, { 0, 6, height + 33 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 15)),
+                            { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 33 });
                         break;
                 }
                 switch (direction)
@@ -12092,40 +12520,40 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 16), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 16)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 20), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 20)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 24), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 24)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 25), { 0, 0, height },
-                            { 32, 1, 32 }, { 0, 31, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 25)),
+                            { 0, 0, height }, { 32, 1, 32 }, { 0, 31, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 28), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 28)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 29), { 0, 0, height },
-                            { 32, 20, 1 }, { 0, 6, height + 28 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 29)),
+                            { 0, 0, height }, { 32, 20, 1 }, { 0, 6, height + 28 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -12144,26 +12572,26 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 17), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 17)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 21), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 21)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 26), { 0, 0, height },
-                            { 32, 20, 1 }, { 0, 6, height + 28 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 26)),
+                            { 0, 0, height }, { 32, 20, 1 }, { 0, 6, height + 28 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 30), { 0, 0, height },
-                            { 32, 20, 1 }, { 0, 6, height + 28 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 30)),
+                            { 0, 0, height }, { 32, 20, 1 }, { 0, 6, height + 28 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -12179,34 +12607,34 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 18), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 18)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 19), { 0, 0, height },
-                            { 32, 20, 0 }, { 0, 6, height + 33 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 19)),
+                            { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 33 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 22), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 22)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 23), { 0, 0, height },
-                            { 32, 20, 0 }, { 0, 6, height + 33 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 23)),
+                            { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 33 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 27), { 0, 0, height },
-                            { 32, 20, 1 }, { 0, 6, height + 28 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 27)),
+                            { 0, 0, height }, { 32, 20, 1 }, { 0, 6, height + 28 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 31), { 0, 0, height },
-                            { 32, 20, 1 }, { 0, 6, height + 28 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_ZERO_G_ROLL + 31)),
+                            { 0, 0, height }, { 32, 20, 1 }, { 0, 6, height + 28 });
                         break;
                 }
                 switch (direction)
@@ -12256,29 +12684,29 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 0),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 0)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 5),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 5)),
                             { 0, 0, height }, { 32, 0, 96 }, { 0, 30, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 9),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 9)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 10),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 10)),
                             { 0, 0, height }, { 32, 0, 96 }, { 0, 30, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 15),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 15)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -12298,29 +12726,29 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 1),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 1)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 2),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 2)),
                             { 0, 0, height }, { 32, 0, 96 }, { 0, 30, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 6),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 6)),
                             { 0, 0, height }, { 32, 0, 64 }, { 0, 30, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 11),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 11)),
                             { 0, 0, height }, { 32, 0, 64 }, { 0, 2, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 16),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 16)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -12334,29 +12762,29 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 3),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 3)),
                             { 0, 0, height }, { 32, 0, 64 }, { 0, 30, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 7),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 7)),
                             { 0, 0, height }, { 32, 0, 48 }, { 0, 30, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 12),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 12)),
                             { 0, 0, height }, { 32, 0, 48 }, { 0, 2, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 17),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 17)),
                             { 0, 0, height }, { 32, 0, 32 }, { 0, 2, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 18),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 18)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height + 40 });
                         break;
                 }
@@ -12378,7 +12806,7 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 4),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 4)),
                             { 0, 0, height }, { 26, 0, 20 }, { 0, 26, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 7, 0, height + 28, session.TrackColours[SCHEME_SUPPORTS]);
@@ -12386,7 +12814,7 @@ namespace SingleRailRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 8),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 8)),
                             { 0, 0, height }, { 26, 0, 20 }, { 0, 26, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 5, 0, height + 28, session.TrackColours[SCHEME_SUPPORTS]);
@@ -12394,11 +12822,11 @@ namespace SingleRailRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 13),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 13)),
                             { 0, 0, height }, { 32, 0, 32 }, { 0, 2, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 14),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 14)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height + 40 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 6, 0, height + 28, session.TrackColours[SCHEME_SUPPORTS]);
@@ -12406,7 +12834,7 @@ namespace SingleRailRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 19),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 19)),
                             { 0, 0, height }, { 32, 10, 20 }, { 0, 18, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 8, 0, height + 28, session.TrackColours[SCHEME_SUPPORTS]);
@@ -12438,29 +12866,29 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 20),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 20)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 25),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 25)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 26),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 26)),
                             { 0, 0, height }, { 32, 0, 96 }, { 0, 30, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 31),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 31)),
                             { 0, 0, height }, { 32, 0, 96 }, { 0, 30, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 35),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 35)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -12480,29 +12908,29 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 21),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 21)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 27),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 27)),
                             { 0, 0, height }, { 32, 0, 64 }, { 0, 2, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 32),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 32)),
                             { 0, 0, height }, { 32, 0, 64 }, { 0, 30, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 36),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 36)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 37),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 37)),
                             { 0, 0, height }, { 32, 0, 96 }, { 0, 30, height });
                         break;
                 }
@@ -12516,29 +12944,29 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 22),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 22)),
                             { 0, 0, height }, { 32, 0, 32 }, { 0, 2, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 23),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 23)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height + 40 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 28),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 28)),
                             { 0, 0, height }, { 32, 0, 48 }, { 0, 2, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 33),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 33)),
                             { 0, 0, height }, { 32, 0, 48 }, { 0, 30, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 38),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 38)),
                             { 0, 0, height }, { 32, 0, 64 }, { 0, 30, height });
                         break;
                 }
@@ -12561,7 +12989,7 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 24),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 24)),
                             { 0, 0, height }, { 32, 10, 20 }, { 0, 18, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 7, 0, height + 28, session.TrackColours[SCHEME_SUPPORTS]);
@@ -12569,11 +12997,11 @@ namespace SingleRailRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 29),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 29)),
                             { 0, 0, height }, { 32, 0, 32 }, { 0, 2, height });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 30),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 30)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height + 40 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 5, 0, height + 28, session.TrackColours[SCHEME_SUPPORTS]);
@@ -12581,7 +13009,7 @@ namespace SingleRailRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 34),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 34)),
                             { 0, 0, height }, { 26, 0, 20 }, { 0, 26, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 6, 0, height + 28, session.TrackColours[SCHEME_SUPPORTS]);
@@ -12589,7 +13017,7 @@ namespace SingleRailRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 39),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_ZERO_G_ROLL + 39)),
                             { 0, 0, height }, { 26, 0, 20 }, { 0, 26, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 8, 0, height + 28, session.TrackColours[SCHEME_SUPPORTS]);
@@ -12635,26 +13063,26 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_QUARTER_LOOP + 0), { 0, 0, height },
-                            { 2, 20, 31 }, { 4, 6, height + 8 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_QUARTER_LOOP + 0)),
+                            { 0, 0, height }, { 2, 20, 31 }, { 4, 6, height + 8 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_QUARTER_LOOP + 3), { 0, 0, height },
-                            { 2, 20, 31 }, { 24, 6, height + 8 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_QUARTER_LOOP + 3)),
+                            { 0, 0, height }, { 2, 20, 31 }, { 24, 6, height + 8 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_QUARTER_LOOP + 6), { 0, 0, height },
-                            { 2, 20, 31 }, { 24, 6, height + 8 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_QUARTER_LOOP + 6)),
+                            { 0, 0, height }, { 2, 20, 31 }, { 24, 6, height + 8 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_QUARTER_LOOP + 9), { 0, 0, height },
-                            { 2, 20, 31 }, { 4, 6, height + 8 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_QUARTER_LOOP + 9)),
+                            { 0, 0, height }, { 2, 20, 31 }, { 4, 6, height + 8 });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -12667,26 +13095,26 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_QUARTER_LOOP + 1), { 0, 0, height },
-                            { 2, 20, 31 }, { -8, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_QUARTER_LOOP + 1)),
+                            { 0, 0, height }, { 2, 20, 31 }, { -8, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_QUARTER_LOOP + 4), { 0, 0, height },
-                            { 2, 20, 63 }, { 24, 6, height + 8 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_QUARTER_LOOP + 4)),
+                            { 0, 0, height }, { 2, 20, 63 }, { 24, 6, height + 8 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_QUARTER_LOOP + 7), { 0, 0, height },
-                            { 2, 20, 63 }, { 24, 6, height + 8 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_QUARTER_LOOP + 7)),
+                            { 0, 0, height }, { 2, 20, 63 }, { 24, 6, height + 8 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_QUARTER_LOOP + 10), { 0, 0, height },
-                            { 2, 20, 31 }, { -8, 6, height });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_QUARTER_LOOP + 10)),
+                            { 0, 0, height }, { 2, 20, 31 }, { -8, 6, height });
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -12699,26 +13127,26 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_QUARTER_LOOP + 2), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height + 24 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_QUARTER_LOOP + 2)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height + 24 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_QUARTER_LOOP + 5), { 0, 0, height },
-                            { 2, 20, 31 }, { 24, 6, height + 8 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_QUARTER_LOOP + 5)),
+                            { 0, 0, height }, { 2, 20, 31 }, { 24, 6, height + 8 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_QUARTER_LOOP + 8), { 0, 0, height },
-                            { 2, 20, 31 }, { 24, 6, height + 8 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_QUARTER_LOOP + 8)),
+                            { 0, 0, height }, { 2, 20, 31 }, { 24, 6, height + 8 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_QUARTER_LOOP + 11), { 0, 0, height },
-                            { 32, 20, 3 }, { 0, 6, height + 24 });
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_QUARTER_LOOP + 11)),
+                            { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height + 24 });
                         break;
                 }
                 if (direction == 0 || direction == 3)
@@ -12751,29 +13179,29 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 0),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 0)),
                             { 0, 6, height }, { 32, 20, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 2),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 2)),
                             { 0, 6, height }, { 32, 20, 3 });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 3),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 3)),
                             { 0, 6, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 5),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 5)),
                             { 0, 6, height }, { 32, 20, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 7),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 7)),
                             { 0, 6, height }, { 32, 20, 3 });
                         break;
                 }
@@ -12800,25 +13228,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 1),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 1)),
                             { 6, 0, height }, { 20, 32, 3 }, { 0, 6, height - 6 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 4),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 4)),
                             { 6, 0, height }, { 20, 32, 3 }, { 0, 6, height - 6 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 6),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 6)),
                             { 6, 0, height }, { 20, 32, 3 }, { 0, 6, height - 6 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 8),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 8)),
                             { 6, 0, height }, { 20, 32, 3 }, { 0, 6, height - 6 });
                         break;
                 }
@@ -12853,29 +13281,29 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 9),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 9)),
                             { 0, 6, height }, { 32, 20, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 11),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 11)),
                             { 0, 6, height }, { 32, 20, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 13),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 13)),
                             { 0, 6, height }, { 32, 20, 3 });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 14),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 14)),
                             { 0, 6, height }, { 32, 1, 26 }, { 0, 27, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 16),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 16)),
                             { 0, 6, height }, { 32, 20, 3 });
                         break;
                 }
@@ -12902,25 +13330,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 10),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 10)),
                             { 6, 0, height }, { 20, 32, 3 }, { 0, 6, height - 6 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 12),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 12)),
                             { 6, 0, height }, { 20, 32, 3 }, { 0, 6, height - 6 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 15),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 15)),
                             { 6, 0, height }, { 20, 32, 3 }, { 0, 6, height - 6 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 17),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 17)),
                             { 6, 0, height }, { 20, 32, 3 }, { 0, 6, height - 6 });
                         break;
                 }
@@ -12955,25 +13383,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 12),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 12)),
                             { 0, 6, height }, { 32, 20, 3 }, { 0, 6, height - 6 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 15),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 15)),
                             { 0, 6, height }, { 32, 20, 3 }, { 0, 6, height - 6 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 17),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 17)),
                             { 0, 6, height }, { 32, 20, 3 }, { 0, 6, height - 6 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 10),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 10)),
                             { 0, 6, height }, { 32, 20, 3 }, { 0, 6, height - 6 });
                         break;
                 }
@@ -13000,29 +13428,29 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 11),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 11)),
                             { 6, 0, height }, { 20, 32, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 13),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 13)),
                             { 6, 0, height }, { 20, 32, 3 });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 14),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 14)),
                             { 6, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 16),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 16)),
                             { 6, 0, height }, { 20, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 9),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 9)),
                             { 6, 0, height }, { 20, 32, 3 });
                         break;
                 }
@@ -13057,25 +13485,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 8),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 8)),
                             { 0, 6, height }, { 32, 20, 3 }, { 0, 6, height - 6 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 1),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 1)),
                             { 0, 6, height }, { 32, 20, 3 }, { 0, 6, height - 6 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 4),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 4)),
                             { 0, 6, height }, { 32, 20, 3 }, { 0, 6, height - 6 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 6),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 6)),
                             { 0, 6, height }, { 32, 20, 3 }, { 0, 6, height - 6 });
                         break;
                 }
@@ -13102,29 +13530,29 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 7),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 7)),
                             { 6, 0, height }, { 20, 32, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 0),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 0)),
                             { 6, 0, height }, { 20, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 2),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 2)),
                             { 6, 0, height }, { 20, 32, 3 });
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 3),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 3)),
                             { 6, 0, height }, { 1, 32, 26 }, { 27, 0, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 5),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_TURN_BANK_TRANSITION + 5)),
                             { 6, 0, height }, { 20, 32, 3 });
                         break;
                 }
@@ -13159,25 +13587,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 0),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 0)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 7),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 7)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 14),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 14)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 21),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 21)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -13197,7 +13625,7 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 1),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 1)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 15, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -13205,7 +13633,7 @@ namespace SingleRailRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 8),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 8)),
                             { 0, 0, height }, { 32, 20, 9 }, { 0, 6, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -13213,7 +13641,7 @@ namespace SingleRailRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 15),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 15)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -13221,7 +13649,7 @@ namespace SingleRailRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 22),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 22)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -13237,25 +13665,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 2),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 2)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 9),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 9)),
                             { 0, 0, height }, { 32, 16, 0 }, { 0, 0, height + 70 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 16),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 16)),
                             { 0, 0, height }, { 32, 16, 0 }, { 0, 16, height + 70 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 23),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 23)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                 }
@@ -13272,7 +13700,7 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 3),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 3)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 5, 28, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -13280,7 +13708,7 @@ namespace SingleRailRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 10),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 10)),
                             { 0, 0, height }, { 32, 16, 0 }, { 0, 0, height + 200 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 6, 28, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -13288,7 +13716,7 @@ namespace SingleRailRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 17),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 17)),
                             { 0, 0, height }, { 32, 16, 0 }, { 0, 16, height + 200 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 8, 0, height + 28, session.TrackColours[SCHEME_SUPPORTS]);
@@ -13296,7 +13724,7 @@ namespace SingleRailRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 24),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 24)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 7, 28, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -13315,25 +13743,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 4),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 4)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 11),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 11)),
                             { 0, 0, height }, { 16, 16, 0 }, { 0, 16, height + 110 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 18),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 18)),
                             { 0, 0, height }, { 16, 16, 0 }, { 0, 0, height + 100 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 25),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 25)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         break;
                 }
@@ -13348,25 +13776,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 5),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 5)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 12),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 12)),
                             { 0, 0, height }, { 32, 16, 0 }, { 0, 16, height + 200 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 19),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 19)),
                             { 0, 0, height }, { 32, 16, 0 }, { 0, 0, height + 200 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 26),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 26)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 0, height });
                         break;
                 }
@@ -13383,25 +13811,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 6),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 6)),
                             { 0, 0, height }, { 32, 16, 0 }, { 0, 16, height + 32 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 13),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 13)),
                             { 0, 0, height }, { 32, 16, 0 }, { 0, 16, height + 32 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 20),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 20)),
                             { 0, 0, height }, { 32, 16, 0 }, { 0, 0, height + 32 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 27),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 27)),
                             { 0, 0, height }, { 32, 16, 0 }, { 0, 0, height + 32 });
                         break;
                 }
@@ -13431,25 +13859,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 28),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 28)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 35),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 35)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 42),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 42)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 49),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 49)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         break;
                 }
@@ -13469,7 +13897,7 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 29),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 29)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -13477,7 +13905,7 @@ namespace SingleRailRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 36),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 36)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -13485,7 +13913,7 @@ namespace SingleRailRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 43),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 43)),
                             { 0, 0, height }, { 32, 20, 9 }, { 0, 6, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -13493,7 +13921,7 @@ namespace SingleRailRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 50),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 50)),
                             { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 15, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -13509,25 +13937,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 30),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 30)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 37),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 37)),
                             { 0, 0, height }, { 32, 16, 0 }, { 0, 16, height + 70 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 44),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 44)),
                             { 0, 0, height }, { 32, 16, 0 }, { 0, 0, height + 70 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 51),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 51)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 0, height });
                         break;
                 }
@@ -13544,7 +13972,7 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 31),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 31)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 8, 28, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -13552,7 +13980,7 @@ namespace SingleRailRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 38),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 38)),
                             { 0, 0, height }, { 32, 16, 0 }, { 0, 16, height + 200 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 7, 0, height + 28, session.TrackColours[SCHEME_SUPPORTS]);
@@ -13560,7 +13988,7 @@ namespace SingleRailRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 45),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 45)),
                             { 0, 0, height }, { 32, 16, 0 }, { 0, 0, height + 200 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 5, 28, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -13568,7 +13996,7 @@ namespace SingleRailRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 52),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 52)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 0, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 6, 28, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -13587,25 +14015,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 32),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 32)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 39),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 39)),
                             { 0, 0, height }, { 16, 16, 0 }, { 0, 0, height + 100 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 46),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 46)),
                             { 0, 0, height }, { 16, 16, 0 }, { 0, 16, height + 110 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 53),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 53)),
                             { 0, 0, height }, { 16, 16, 3 }, { 16, 16, height });
                         break;
                 }
@@ -13620,25 +14048,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 33),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 33)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 0, height });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 40),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 40)),
                             { 0, 0, height }, { 32, 16, 0 }, { 0, 0, height + 200 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 47),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 47)),
                             { 0, 0, height }, { 32, 16, 0 }, { 0, 16, height + 200 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 54),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 54)),
                             { 0, 0, height }, { 32, 16, 3 }, { 0, 16, height });
                         break;
                 }
@@ -13655,25 +14083,25 @@ namespace SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 34),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 34)),
                             { 0, 0, height }, { 32, 16, 0 }, { 0, 0, height + 32 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 41),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 41)),
                             { 0, 0, height }, { 32, 16, 0 }, { 0, 0, height + 32 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 48),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 48)),
                             { 0, 0, height }, { 32, 16, 0 }, { 0, 16, height + 32 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction,
-                            session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 55),
+                            session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_HALF_LOOP + 55)),
                             { 0, 0, height }, { 32, 16, 0 }, { 0, 16, height + 32 });
                         break;
                 }
@@ -13716,7 +14144,7 @@ namespace SingleRailRC
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 0),
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 0)),
                         { 0, 0, height }, { 32, 27, 4 }, { 0, 2, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -13724,11 +14152,11 @@ namespace SingleRailRC
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 2),
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 2)),
                         { 0, 0, height }, { 1, 24, 43 }, { 29, 4, height + 2 });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 1),
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 1)),
                         { 0, 0, height }, { 32, 2, 43 }, { 0, 4, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 0, height + 4, session.TrackColours[SCHEME_SUPPORTS]);
@@ -13736,11 +14164,11 @@ namespace SingleRailRC
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 4),
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 4)),
                         { 0, 0, height }, { 1, 24, 43 }, { 29, 4, height + 2 });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 3),
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 3)),
                         { 0, 0, height }, { 32, 2, 43 }, { 0, 4, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 0, height + 4, session.TrackColours[SCHEME_SUPPORTS]);
@@ -13748,7 +14176,7 @@ namespace SingleRailRC
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 5),
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 5)),
                         { 0, 0, height }, { 32, 27, 4 }, { 0, 2, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -13762,7 +14190,7 @@ namespace SingleRailRC
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 0),
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 0)),
                         { 0, 0, height }, { 32, 27, 4 }, { 0, 2, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -13770,11 +14198,11 @@ namespace SingleRailRC
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 2),
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 2)),
                         { 0, 0, height }, { 1, 24, 43 }, { 29, 4, height + 2 });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 1),
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 1)),
                         { 0, 0, height }, { 32, 2, 43 }, { 0, 4, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 0, height + 4, session.TrackColours[SCHEME_SUPPORTS]);
@@ -13782,11 +14210,11 @@ namespace SingleRailRC
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 4),
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 4)),
                         { 0, 0, height }, { 1, 24, 43 }, { 29, 4, height + 2 });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 3),
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 3)),
                         { 0, 0, height }, { 32, 2, 43 }, { 0, 4, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 0, height + 4, session.TrackColours[SCHEME_SUPPORTS]);
@@ -13794,7 +14222,7 @@ namespace SingleRailRC
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 5),
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 5)),
                         { 0, 0, height }, { 32, 27, 4 }, { 0, 2, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -13825,33 +14253,33 @@ namespace SingleRailRC
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 6),
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 6)),
                         { 0, 0, height }, { 32, 27, 4 }, { 0, 2, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 7),
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 7)),
                         { 0, 0, height }, { 1, 24, 43 }, { 29, 4, height + 2 });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 8),
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 8)),
                         { 0, 0, height }, { 32, 2, 43 }, { 0, 4, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 10),
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 10)),
                         { 0, 0, height }, { 1, 24, 43 }, { 29, 4, height + 2 });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 9),
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 9)),
                         { 0, 0, height }, { 32, 2, 43 }, { 0, 4, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 11),
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 11)),
                         { 0, 0, height }, { 32, 27, 4 }, { 0, 2, height });
                     break;
             }
@@ -13864,33 +14292,33 @@ namespace SingleRailRC
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 6),
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 6)),
                         { 0, 0, height }, { 32, 27, 4 }, { 0, 2, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 7),
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 7)),
                         { 0, 0, height }, { 32, 2, 43 }, { 0, 4, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 8),
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 8)),
                         { 0, 0, height }, { 1, 24, 43 }, { 29, 4, height + 2 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 10),
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 10)),
                         { 0, 0, height }, { 1, 24, 43 }, { 29, 4, height + 2 });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 9),
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 9)),
                         { 0, 0, height }, { 32, 2, 43 }, { 0, 4, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 11),
+                        session.TrackColours[SCHEME_TRACK].WithIndex((SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 11)),
                         { 0, 0, height }, { 32, 27, 4 }, { 0, 2, height });
                     break;
             }
@@ -13937,7 +14365,8 @@ namespace SingleRailRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 15),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 15)),
                                 { -16, -16, height }, { 32, 32, 4 }, { -16, -16, height });
                             break;
                     }
@@ -13949,7 +14378,8 @@ namespace SingleRailRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 15),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 15)),
                                 { -16, -16, height }, { 32, 32, 4 }, { -16, -16, height });
                             break;
                     }
@@ -13967,7 +14397,8 @@ namespace SingleRailRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 12),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 12)),
                                 { -16, -16, height }, { 32, 32, 4 }, { -16, -16, height });
                             break;
                     }
@@ -13979,7 +14410,8 @@ namespace SingleRailRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 12),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 12)),
                                 { -16, -16, height }, { 32, 32, 4 }, { -16, -16, height });
                             break;
                     }
@@ -13997,7 +14429,8 @@ namespace SingleRailRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 14),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 14)),
                                 { -16, -16, height }, { 32, 32, 4 }, { -16, -16, height });
                             break;
                     }
@@ -14009,7 +14442,8 @@ namespace SingleRailRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 14),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 14)),
                                 { -16, -16, height }, { 32, 32, 4 }, { -16, -16, height });
                             break;
                     }
@@ -14031,7 +14465,8 @@ namespace SingleRailRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 13),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 13)),
                                 { -16, -16, height }, { 32, 32, 4 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES, 0, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -14057,7 +14492,8 @@ namespace SingleRailRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 13),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 13)),
                                 { -16, -16, height }, { 32, 32, 4 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES, 0, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -14094,7 +14530,8 @@ namespace SingleRailRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 19),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 19)),
                                 { -16, -16, height }, { 32, 32, 4 }, { -16, -16, height });
                             break;
                     }
@@ -14106,7 +14543,8 @@ namespace SingleRailRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 19),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 19)),
                                 { -16, -16, height }, { 32, 32, 4 }, { -16, -16, height });
                             break;
                     }
@@ -14124,7 +14562,8 @@ namespace SingleRailRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 16),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 16)),
                                 { -16, -16, height }, { 32, 32, 4 }, { -16, -16, height });
                             break;
                     }
@@ -14136,7 +14575,8 @@ namespace SingleRailRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 16),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 16)),
                                 { -16, -16, height }, { 32, 32, 4 }, { -16, -16, height });
                             break;
                     }
@@ -14154,7 +14594,8 @@ namespace SingleRailRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 18),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 18)),
                                 { -16, -16, height }, { 32, 32, 4 }, { -16, -16, height });
                             break;
                     }
@@ -14166,7 +14607,8 @@ namespace SingleRailRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 18),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 18)),
                                 { -16, -16, height }, { 32, 32, 4 }, { -16, -16, height });
                             break;
                     }
@@ -14188,7 +14630,8 @@ namespace SingleRailRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 17),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 17)),
                                 { -16, -16, height }, { 32, 32, 4 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES, 0, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -14214,7 +14657,8 @@ namespace SingleRailRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 17),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 17)),
                                 { -16, -16, height }, { 32, 32, 4 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES, 0, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -14251,7 +14695,8 @@ namespace SingleRailRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 17),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 17)),
                                 { -16, -16, height }, { 32, 32, 4 }, { -16, -16, height });
                             break;
                     }
@@ -14263,7 +14708,8 @@ namespace SingleRailRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 17),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 17)),
                                 { -16, -16, height }, { 32, 32, 4 }, { -16, -16, height });
                             break;
                     }
@@ -14281,7 +14727,8 @@ namespace SingleRailRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 18),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 18)),
                                 { -16, -16, height }, { 32, 32, 4 }, { -16, -16, height });
                             break;
                     }
@@ -14293,7 +14740,8 @@ namespace SingleRailRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 18),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 18)),
                                 { -16, -16, height }, { 32, 32, 4 }, { -16, -16, height });
                             break;
                     }
@@ -14311,7 +14759,8 @@ namespace SingleRailRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 16),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 16)),
                                 { -16, -16, height }, { 32, 32, 4 }, { -16, -16, height });
                             break;
                     }
@@ -14323,7 +14772,8 @@ namespace SingleRailRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 16),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 16)),
                                 { -16, -16, height }, { 32, 32, 4 }, { -16, -16, height });
                             break;
                     }
@@ -14345,7 +14795,8 @@ namespace SingleRailRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 19),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 19)),
                                 { -16, -16, height }, { 32, 32, 4 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES, 0, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -14371,7 +14822,8 @@ namespace SingleRailRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 19),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 19)),
                                 { -16, -16, height }, { 32, 32, 4 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES, 0, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -14408,7 +14860,8 @@ namespace SingleRailRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 13),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 13)),
                                 { -16, -16, height }, { 32, 32, 4 }, { -16, -16, height });
                             break;
                     }
@@ -14420,7 +14873,8 @@ namespace SingleRailRC
                         case 3:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 13),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 13)),
                                 { -16, -16, height }, { 32, 32, 4 }, { -16, -16, height });
                             break;
                     }
@@ -14438,7 +14892,8 @@ namespace SingleRailRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 14),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 14)),
                                 { -16, -16, height }, { 32, 32, 4 }, { -16, -16, height });
                             break;
                     }
@@ -14450,7 +14905,8 @@ namespace SingleRailRC
                         case 0:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 14),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 14)),
                                 { -16, -16, height }, { 32, 32, 4 }, { -16, -16, height });
                             break;
                     }
@@ -14468,7 +14924,8 @@ namespace SingleRailRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 12),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 12)),
                                 { -16, -16, height }, { 32, 32, 4 }, { -16, -16, height });
                             break;
                     }
@@ -14480,7 +14937,8 @@ namespace SingleRailRC
                         case 2:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 12),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 12)),
                                 { -16, -16, height }, { 32, 32, 4 }, { -16, -16, height });
                             break;
                     }
@@ -14502,7 +14960,8 @@ namespace SingleRailRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 15),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_LIFT_TRACK_SMALL_FLAT_TO_STEEP + 15)),
                                 { -16, -16, height }, { 32, 32, 4 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES, 0, 5, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -14528,7 +14987,8 @@ namespace SingleRailRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours[SCHEME_TRACK] | (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 15),
+                                session.TrackColours[SCHEME_TRACK].WithIndex(
+                                    (SPR_G2_SINGLE_RAIL_TRACK_SMALL_FLAT_TO_STEEP + 15)),
                                 { -16, -16, height }, { 32, 32, 4 }, { -16, -16, height });
                             metal_b_supports_paint_setup(
                                 session, METAL_SUPPORTS_TUBES, 0, 5, height, session.TrackColours[SCHEME_SUPPORTS]);

--- a/src/openrct2/ride/coaster/StandUpRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/StandUpRollerCoaster.cpp
@@ -41,19 +41,19 @@ static void stand_up_rc_track_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25383, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25383), { 0, 6, height }, { 32, 20, 3 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25384, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25384), { 0, 6, height }, { 32, 20, 3 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25453, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25453), { 0, 6, height }, { 32, 20, 3 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25454, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25454), { 0, 6, height }, { 32, 20, 3 });
                 break;
         }
         if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -68,12 +68,12 @@ static void stand_up_rc_track_flat(
             case 0:
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25229, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25229), { 0, 6, height }, { 32, 20, 3 });
                 break;
             case 1:
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25230, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25230), { 0, 6, height }, { 32, 20, 3 });
                 break;
         }
         if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -103,17 +103,18 @@ static void stand_up_rc_track_station(
     {
         bool isClosed = trackElement.BlockBrakeClosed();
         PaintAddImageAsParentRotated(
-            session, direction, _StandUpBlockBrakeImages[direction][isClosed] | session.TrackColours[SCHEME_TRACK],
+            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(_StandUpBlockBrakeImages[direction][isClosed]),
             { 0, 6, height }, { 32, 20, 1 }, { 0, 6, height + 3 });
     }
     else
     {
         PaintAddImageAsParentRotated(
-            session, direction, imageIds[direction][0] | session.TrackColours[SCHEME_TRACK], { 0, 6, height }, { 32, 20, 1 },
-            { 0, 6, height + 3 });
+            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]), { 0, 6, height },
+            { 32, 20, 1 }, { 0, 6, height + 3 });
     }
     PaintAddImageAsParentRotated(
-        session, direction, imageIds[direction][1] | session.TrackColours[SCHEME_MISC], { 0, 0, height }, { 32, 32, 1 });
+        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][1]), { 0, 0, height },
+        { 32, 32, 1 });
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], 0);
     track_paint_util_draw_station_2(session, ride, direction, height, trackElement, 9, 11);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -132,19 +133,19 @@ static void stand_up_rc_track_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25385, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25385), { 0, 6, height }, { 32, 20, 3 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25397, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25397), { 0, 6, height }, { 32, 20, 3 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25389, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25389), { 0, 6, height }, { 32, 20, 3 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25399, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25399), { 0, 6, height }, { 32, 20, 3 });
                 break;
         }
         if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -158,19 +159,19 @@ static void stand_up_rc_track_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25231, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25231), { 0, 6, height }, { 32, 20, 3 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25243, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25243), { 0, 6, height }, { 32, 20, 3 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25235, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25235), { 0, 6, height }, { 32, 20, 3 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25245, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25245), { 0, 6, height }, { 32, 20, 3 });
                 break;
         }
         if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -202,21 +203,21 @@ static void stand_up_rc_track_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25386, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25386), { 0, 6, height }, { 32, 20, 3 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25398, { 0, 6, height }, { 1, 10, 75 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25398), { 0, 6, height }, { 1, 10, 75 },
                     { 29, 10, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25390, { 0, 6, height }, { 1, 10, 75 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25390), { 0, 6, height }, { 1, 10, 75 },
                     { 29, 10, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25400, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25400), { 0, 6, height }, { 32, 20, 3 });
                 break;
         }
         if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -230,21 +231,21 @@ static void stand_up_rc_track_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25232, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25232), { 0, 6, height }, { 32, 20, 3 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25244, { 0, 6, height }, { 1, 10, 75 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25244), { 0, 6, height }, { 1, 10, 75 },
                     { 29, 10, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25236, { 0, 6, height }, { 1, 10, 75 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25236), { 0, 6, height }, { 1, 10, 75 },
                     { 29, 10, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25246, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25246), { 0, 6, height }, { 32, 20, 3 });
                 break;
         }
         if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -276,19 +277,19 @@ static void stand_up_rc_track_flat_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25387, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25387), { 0, 6, height }, { 32, 20, 3 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25401, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25401), { 0, 6, height }, { 32, 20, 3 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25391, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25391), { 0, 6, height }, { 32, 20, 3 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25403, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25403), { 0, 6, height }, { 32, 20, 3 });
                 break;
         }
         if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -302,19 +303,19 @@ static void stand_up_rc_track_flat_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25233, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25233), { 0, 6, height }, { 32, 20, 3 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25247, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25247), { 0, 6, height }, { 32, 20, 3 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25237, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25237), { 0, 6, height }, { 32, 20, 3 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25249, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25249), { 0, 6, height }, { 32, 20, 3 });
                 break;
         }
         if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -346,27 +347,27 @@ static void stand_up_rc_track_25_deg_up_to_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25388, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25388), { 0, 6, height }, { 32, 20, 3 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25411, { 0, 6, height }, { 32, 10, 43 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25411), { 0, 6, height }, { 32, 10, 43 },
                     { 0, 10, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25402, { 0, 6, height }, { 32, 2, 43 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25402), { 0, 6, height }, { 32, 2, 43 },
                     { 0, 4, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25409, { 0, 6, height }, { 32, 10, 43 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25409), { 0, 6, height }, { 32, 10, 43 },
                     { 0, 10, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25392, { 0, 6, height }, { 32, 2, 43 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25392), { 0, 6, height }, { 32, 2, 43 },
                     { 0, 4, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25404, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25404), { 0, 6, height }, { 32, 20, 3 });
                 break;
         }
         if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -380,27 +381,27 @@ static void stand_up_rc_track_25_deg_up_to_60_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25234, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25234), { 0, 6, height }, { 32, 20, 3 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25277, { 0, 6, height }, { 32, 10, 43 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25277), { 0, 6, height }, { 32, 10, 43 },
                     { 0, 10, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25248, { 0, 6, height }, { 32, 2, 43 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25248), { 0, 6, height }, { 32, 2, 43 },
                     { 0, 4, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25275, { 0, 6, height }, { 32, 10, 43 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25275), { 0, 6, height }, { 32, 10, 43 },
                     { 0, 10, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25238, { 0, 6, height }, { 32, 2, 43 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25238), { 0, 6, height }, { 32, 2, 43 },
                     { 0, 4, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25250, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25250), { 0, 6, height }, { 32, 20, 3 });
                 break;
         }
         if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -432,27 +433,27 @@ static void stand_up_rc_track_60_deg_up_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25396, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25396), { 0, 6, height }, { 32, 20, 3 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25412, { 0, 6, height }, { 32, 10, 43 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25412), { 0, 6, height }, { 32, 10, 43 },
                     { 0, 10, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25408, { 0, 6, height }, { 32, 2, 43 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25408), { 0, 6, height }, { 32, 2, 43 },
                     { 0, 4, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25410, { 0, 6, height }, { 32, 10, 43 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25410), { 0, 6, height }, { 32, 10, 43 },
                     { 0, 10, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25394, { 0, 6, height }, { 32, 2, 43 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25394), { 0, 6, height }, { 32, 2, 43 },
                     { 0, 4, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25406, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25406), { 0, 6, height }, { 32, 20, 3 });
                 break;
         }
         if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -466,27 +467,27 @@ static void stand_up_rc_track_60_deg_up_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25242, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25242), { 0, 6, height }, { 32, 20, 3 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25278, { 0, 6, height }, { 32, 10, 43 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25278), { 0, 6, height }, { 32, 10, 43 },
                     { 0, 10, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25254, { 0, 6, height }, { 32, 2, 43 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25254), { 0, 6, height }, { 32, 2, 43 },
                     { 0, 4, height });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25276, { 0, 6, height }, { 32, 10, 43 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25276), { 0, 6, height }, { 32, 10, 43 },
                     { 0, 10, height });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25240, { 0, 6, height }, { 32, 2, 43 },
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25240), { 0, 6, height }, { 32, 2, 43 },
                     { 0, 4, height });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25252, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25252), { 0, 6, height }, { 32, 20, 3 });
                 break;
         }
         if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -518,19 +519,19 @@ static void stand_up_rc_track_25_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25395, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25395), { 0, 6, height }, { 32, 20, 3 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25407, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25407), { 0, 6, height }, { 32, 20, 3 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25393, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25393), { 0, 6, height }, { 32, 20, 3 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25405, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25405), { 0, 6, height }, { 32, 20, 3 });
                 break;
         }
         if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -544,19 +545,19 @@ static void stand_up_rc_track_25_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25241, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25241), { 0, 6, height }, { 32, 20, 3 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25253, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25253), { 0, 6, height }, { 32, 20, 3 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25239, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25239), { 0, 6, height }, { 32, 20, 3 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25251, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25251), { 0, 6, height }, { 32, 20, 3 });
                 break;
         }
         if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -637,19 +638,23 @@ static void stand_up_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25264, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25264), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25269, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25269), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25274, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25274), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25259, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25259), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -669,19 +674,23 @@ static void stand_up_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25263, { 0, 0, height }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25263), { 0, 0, height },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25268, { 0, 0, height }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25268), { 0, 0, height },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25273, { 0, 16, height }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25273), { 0, 16, height },
+                        { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25258, { 0, 16, height }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25258), { 0, 16, height },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -696,19 +705,23 @@ static void stand_up_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25262, { 0, 16, height }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25262), { 0, 16, height },
+                        { 16, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25267, { 16, 16, height }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25267), { 16, 16, height },
+                        { 16, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25272, { 16, 0, height }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25272), { 16, 0, height },
+                        { 16, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25257, { 0, 0, height }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25257), { 0, 0, height },
+                        { 16, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -723,19 +736,23 @@ static void stand_up_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25261, { 16, 0, height }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25261), { 16, 0, height },
+                        { 16, 32, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25266, { 0, 0, height }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25266), { 0, 0, height },
+                        { 16, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25271, { 0, 0, height }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25271), { 0, 0, height },
+                        { 16, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25256, { 16, 0, height }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25256), { 16, 0, height },
+                        { 16, 32, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -750,19 +767,23 @@ static void stand_up_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25260, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25260), { 6, 0, height },
+                        { 20, 32, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25265, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25265), { 6, 0, height },
+                        { 20, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25270, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25270), { 6, 0, height },
+                        { 20, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25255, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25255), { 6, 0, height },
+                        { 20, 32, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -800,19 +821,19 @@ static void stand_up_rc_track_flat_to_left_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25281, { 0, 6, height }, { 32, 20, 3 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25281), { 0, 6, height }, { 32, 20, 3 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25286, { 0, 6, height }, { 32, 20, 3 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25286), { 0, 6, height }, { 32, 20, 3 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25280, { 0, 6, height }, { 32, 20, 3 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25280), { 0, 6, height }, { 32, 20, 3 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25283, { 0, 6, height }, { 32, 20, 3 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25283), { 0, 6, height }, { 32, 20, 3 });
             break;
     }
     if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -834,19 +855,19 @@ static void stand_up_rc_track_flat_to_right_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25279, { 0, 6, height }, { 32, 20, 3 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25279), { 0, 6, height }, { 32, 20, 3 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25284, { 0, 6, height }, { 32, 20, 3 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25284), { 0, 6, height }, { 32, 20, 3 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25282, { 0, 6, height }, { 32, 20, 3 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25282), { 0, 6, height }, { 32, 20, 3 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25285, { 0, 6, height }, { 32, 20, 3 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25285), { 0, 6, height }, { 32, 20, 3 });
             break;
     }
     if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -868,19 +889,19 @@ static void stand_up_rc_track_left_bank_to_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25282, { 0, 6, height }, { 32, 20, 3 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25282), { 0, 6, height }, { 32, 20, 3 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25285, { 0, 6, height }, { 32, 20, 3 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25285), { 0, 6, height }, { 32, 20, 3 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25279, { 0, 6, height }, { 32, 20, 3 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25279), { 0, 6, height }, { 32, 20, 3 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25284, { 0, 6, height }, { 32, 20, 3 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25284), { 0, 6, height }, { 32, 20, 3 });
             break;
     }
     if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -902,19 +923,19 @@ static void stand_up_rc_track_right_bank_to_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25280, { 0, 6, height }, { 32, 20, 3 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25280), { 0, 6, height }, { 32, 20, 3 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25283, { 0, 6, height }, { 32, 20, 3 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25283), { 0, 6, height }, { 32, 20, 3 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25281, { 0, 6, height }, { 32, 20, 3 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25281), { 0, 6, height }, { 32, 20, 3 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25286, { 0, 6, height }, { 32, 20, 3 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25286), { 0, 6, height }, { 32, 20, 3 });
             break;
     }
     if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -939,26 +960,26 @@ static void stand_up_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25464, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25464), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25475, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25475), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25469, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25469), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25474, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25474), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25459, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25459), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -978,23 +999,23 @@ static void stand_up_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25463, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25463), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25468, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25468), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25473, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25473), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25458, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25458), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1009,23 +1030,23 @@ static void stand_up_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25462, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25462), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25467, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25467), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25472, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25472), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25457, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25457), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1040,23 +1061,23 @@ static void stand_up_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25461, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25461), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25466, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25466), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25471, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25471), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25456, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25456), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1071,26 +1092,26 @@ static void stand_up_rc_track_banked_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25460, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25460), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25465, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25465), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25470, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25470), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25476, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25476), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25455, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25455), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1128,19 +1149,19 @@ static void stand_up_rc_track_left_bank_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25315, { 0, 6, height }, { 32, 20, 3 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25315), { 0, 6, height }, { 32, 20, 3 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25316, { 0, 6, height }, { 32, 20, 3 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25316), { 0, 6, height }, { 32, 20, 3 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25317, { 0, 6, height }, { 32, 20, 3 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25317), { 0, 6, height }, { 32, 20, 3 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25318, { 0, 6, height }, { 32, 20, 3 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25318), { 0, 6, height }, { 32, 20, 3 });
             break;
     }
     if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -1169,19 +1190,19 @@ static void stand_up_rc_track_right_bank_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25319, { 0, 6, height }, { 32, 20, 3 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25319), { 0, 6, height }, { 32, 20, 3 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25320, { 0, 6, height }, { 32, 20, 3 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25320), { 0, 6, height }, { 32, 20, 3 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25321, { 0, 6, height }, { 32, 20, 3 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25321), { 0, 6, height }, { 32, 20, 3 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25322, { 0, 6, height }, { 32, 20, 3 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25322), { 0, 6, height }, { 32, 20, 3 });
             break;
     }
     if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -1210,19 +1231,19 @@ static void stand_up_rc_track_25_deg_up_to_left_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25311, { 0, 6, height }, { 32, 20, 3 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25311), { 0, 6, height }, { 32, 20, 3 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25312, { 0, 6, height }, { 32, 20, 3 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25312), { 0, 6, height }, { 32, 20, 3 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25313, { 0, 6, height }, { 32, 20, 3 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25313), { 0, 6, height }, { 32, 20, 3 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25314, { 0, 6, height }, { 32, 20, 3 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25314), { 0, 6, height }, { 32, 20, 3 });
             break;
     }
     if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -1251,19 +1272,19 @@ static void stand_up_rc_track_25_deg_up_to_right_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25307, { 0, 6, height }, { 32, 20, 3 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25307), { 0, 6, height }, { 32, 20, 3 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25308, { 0, 6, height }, { 32, 20, 3 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25308), { 0, 6, height }, { 32, 20, 3 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25309, { 0, 6, height }, { 32, 20, 3 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25309), { 0, 6, height }, { 32, 20, 3 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25310, { 0, 6, height }, { 32, 20, 3 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25310), { 0, 6, height }, { 32, 20, 3 });
             break;
     }
     if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -1324,19 +1345,19 @@ static void stand_up_rc_track_left_bank(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25323, { 0, 6, height }, { 32, 20, 3 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25323), { 0, 6, height }, { 32, 20, 3 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25324, { 0, 6, height }, { 32, 20, 3 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25324), { 0, 6, height }, { 32, 20, 3 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25325, { 0, 6, height }, { 32, 20, 3 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25325), { 0, 6, height }, { 32, 20, 3 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25326, { 0, 6, height }, { 32, 20, 3 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25326), { 0, 6, height }, { 32, 20, 3 });
             break;
     }
     if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -1371,19 +1392,23 @@ static void stand_up_rc_track_left_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25433, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25433), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25438, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25438), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25443, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25443), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25448, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25448), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -1395,19 +1420,23 @@ static void stand_up_rc_track_left_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25347, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25347), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25352, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25352), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25357, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25357), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25362, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25362), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -1431,19 +1460,23 @@ static void stand_up_rc_track_left_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25434, { 0, 0, height }, { 32, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25434), { 0, 0, height },
+                            { 32, 16, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25439, { 0, 0, height }, { 32, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25439), { 0, 0, height },
+                            { 32, 16, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25444, { 0, 16, height }, { 32, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25444), { 0, 16, height },
+                            { 32, 16, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25449, { 0, 16, height }, { 32, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25449), { 0, 16, height },
+                            { 32, 16, 3 });
                         break;
                 }
             }
@@ -1453,19 +1486,23 @@ static void stand_up_rc_track_left_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25348, { 0, 0, height }, { 32, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25348), { 0, 0, height },
+                            { 32, 16, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25353, { 0, 0, height }, { 32, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25353), { 0, 0, height },
+                            { 32, 16, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25358, { 0, 16, height }, { 32, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25358), { 0, 16, height },
+                            { 32, 16, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25363, { 0, 16, height }, { 32, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25363), { 0, 16, height },
+                            { 32, 16, 3 });
                         break;
                 }
             }
@@ -1483,19 +1520,23 @@ static void stand_up_rc_track_left_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25435, { 0, 16, height }, { 16, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25435), { 0, 16, height },
+                            { 16, 16, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25440, { 16, 16, height }, { 16, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25440), { 16, 16, height },
+                            { 16, 16, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25445, { 16, 0, height }, { 16, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25445), { 16, 0, height },
+                            { 16, 16, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25450, { 0, 0, height }, { 16, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25450), { 0, 0, height },
+                            { 16, 16, 3 });
                         break;
                 }
             }
@@ -1505,19 +1546,23 @@ static void stand_up_rc_track_left_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25349, { 0, 16, height }, { 16, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25349), { 0, 16, height },
+                            { 16, 16, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25354, { 16, 16, height }, { 16, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25354), { 16, 16, height },
+                            { 16, 16, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25359, { 16, 0, height }, { 16, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25359), { 16, 0, height },
+                            { 16, 16, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25364, { 0, 0, height }, { 16, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25364), { 0, 0, height },
+                            { 16, 16, 3 });
                         break;
                 }
             }
@@ -1535,19 +1580,23 @@ static void stand_up_rc_track_left_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25436, { 16, 0, height }, { 16, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25436), { 16, 0, height },
+                            { 16, 32, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25441, { 0, 0, height }, { 16, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25441), { 0, 0, height },
+                            { 16, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25446, { 0, 0, height }, { 16, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25446), { 0, 0, height },
+                            { 16, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25451, { 16, 0, height }, { 16, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25451), { 16, 0, height },
+                            { 16, 32, 3 });
                         break;
                 }
             }
@@ -1557,19 +1606,23 @@ static void stand_up_rc_track_left_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25350, { 16, 0, height }, { 16, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25350), { 16, 0, height },
+                            { 16, 32, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25355, { 0, 0, height }, { 16, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25355), { 0, 0, height },
+                            { 16, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25360, { 0, 0, height }, { 16, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25360), { 0, 0, height },
+                            { 16, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25365, { 16, 0, height }, { 16, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25365), { 16, 0, height },
+                            { 16, 32, 3 });
                         break;
                 }
             }
@@ -1587,19 +1640,23 @@ static void stand_up_rc_track_left_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25437, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25437), { 6, 0, height },
+                            { 20, 32, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25442, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25442), { 6, 0, height },
+                            { 20, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25447, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25447), { 6, 0, height },
+                            { 20, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25452, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25452), { 6, 0, height },
+                            { 20, 32, 3 });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -1611,19 +1668,23 @@ static void stand_up_rc_track_left_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25351, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25351), { 6, 0, height },
+                            { 20, 32, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25356, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25356), { 6, 0, height },
+                            { 20, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25361, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25361), { 6, 0, height },
+                            { 20, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25366, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25366), { 6, 0, height },
+                            { 20, 32, 3 });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -1659,19 +1720,23 @@ static void stand_up_rc_track_right_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25413, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25413), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25418, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25418), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25423, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25423), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25428, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25428), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -1683,19 +1748,23 @@ static void stand_up_rc_track_right_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25327, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25327), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25332, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25332), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25337, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25337), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25342, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25342), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -1719,19 +1788,23 @@ static void stand_up_rc_track_right_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25414, { 0, 16, height }, { 32, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25414), { 0, 16, height },
+                            { 32, 16, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25419, { 0, 16, height }, { 32, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25419), { 0, 16, height },
+                            { 32, 16, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25424, { 0, 0, height }, { 32, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25424), { 0, 0, height },
+                            { 32, 16, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25429, { 0, 0, height }, { 32, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25429), { 0, 0, height },
+                            { 32, 16, 3 });
                         break;
                 }
             }
@@ -1741,19 +1814,23 @@ static void stand_up_rc_track_right_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25328, { 0, 16, height }, { 32, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25328), { 0, 16, height },
+                            { 32, 16, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25333, { 0, 16, height }, { 32, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25333), { 0, 16, height },
+                            { 32, 16, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25338, { 0, 0, height }, { 32, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25338), { 0, 0, height },
+                            { 32, 16, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25343, { 0, 0, height }, { 32, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25343), { 0, 0, height },
+                            { 32, 16, 3 });
                         break;
                 }
             }
@@ -1771,19 +1848,23 @@ static void stand_up_rc_track_right_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25415, { 0, 0, height }, { 16, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25415), { 0, 0, height },
+                            { 16, 16, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25420, { 16, 0, height }, { 16, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25420), { 16, 0, height },
+                            { 16, 16, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25425, { 16, 16, height }, { 16, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25425), { 16, 16, height },
+                            { 16, 16, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25430, { 0, 16, height }, { 16, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25430), { 0, 16, height },
+                            { 16, 16, 3 });
                         break;
                 }
             }
@@ -1793,19 +1874,23 @@ static void stand_up_rc_track_right_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25329, { 0, 0, height }, { 16, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25329), { 0, 0, height },
+                            { 16, 16, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25334, { 16, 0, height }, { 16, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25334), { 16, 0, height },
+                            { 16, 16, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25339, { 16, 16, height }, { 16, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25339), { 16, 16, height },
+                            { 16, 16, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25344, { 0, 16, height }, { 16, 16, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25344), { 0, 16, height },
+                            { 16, 16, 3 });
                         break;
                 }
             }
@@ -1823,19 +1908,23 @@ static void stand_up_rc_track_right_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25416, { 16, 0, height }, { 16, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25416), { 16, 0, height },
+                            { 16, 32, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25421, { 0, 0, height }, { 16, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25421), { 0, 0, height },
+                            { 16, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25426, { 0, 0, height }, { 16, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25426), { 0, 0, height },
+                            { 16, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25431, { 16, 0, height }, { 16, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25431), { 16, 0, height },
+                            { 16, 32, 3 });
                         break;
                 }
             }
@@ -1845,19 +1934,23 @@ static void stand_up_rc_track_right_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25330, { 16, 0, height }, { 16, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25330), { 16, 0, height },
+                            { 16, 32, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25335, { 0, 0, height }, { 16, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25335), { 0, 0, height },
+                            { 16, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25340, { 0, 0, height }, { 16, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25340), { 0, 0, height },
+                            { 16, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25345, { 16, 0, height }, { 16, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25345), { 16, 0, height },
+                            { 16, 32, 3 });
                         break;
                 }
             }
@@ -1875,19 +1968,23 @@ static void stand_up_rc_track_right_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25417, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25417), { 6, 0, height },
+                            { 20, 32, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25422, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25422), { 6, 0, height },
+                            { 20, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25427, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25427), { 6, 0, height },
+                            { 20, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25432, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25432), { 6, 0, height },
+                            { 20, 32, 3 });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -1899,19 +1996,23 @@ static void stand_up_rc_track_right_quarter_turn_5_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25331, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25331), { 6, 0, height },
+                            { 20, 32, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25336, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25336), { 6, 0, height },
+                            { 20, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25341, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25341), { 6, 0, height },
+                            { 20, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25346, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25346), { 6, 0, height },
+                            { 20, 32, 3 });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -1963,19 +2064,23 @@ static void stand_up_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25371, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25371), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25378, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25378), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25374, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25374), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25375, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25375), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1992,23 +2097,27 @@ static void stand_up_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25372, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25372), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25377, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25377), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 6, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25373, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25373), { 0, 6, height },
+                        { 32, 26, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25376, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25376), { 0, 6, height },
+                        { 32, 26, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2023,21 +2132,25 @@ static void stand_up_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25373, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25373), { 0, 6, height },
+                        { 32, 26, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25376, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25376), { 0, 6, height },
+                        { 32, 26, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25372, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25372), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25377, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25377), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 6, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2054,19 +2167,23 @@ static void stand_up_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25374, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25374), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25375, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25375), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25371, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25371), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25378, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25378), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2098,19 +2215,23 @@ static void stand_up_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25367, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25367), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25382, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25382), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25370, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25370), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25379, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25379), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2127,23 +2248,27 @@ static void stand_up_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25368, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25368), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25381, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25381), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25369, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25369), { 0, 0, height },
+                        { 32, 26, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25380, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25380), { 0, 0, height },
+                        { 32, 26, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2158,21 +2283,25 @@ static void stand_up_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25369, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25369), { 0, 0, height },
+                        { 32, 26, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25380, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25380), { 0, 0, height },
+                        { 32, 26, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25368, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25368), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25381, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25381), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2189,19 +2318,23 @@ static void stand_up_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25370, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25370), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25379, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25379), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25367, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25367), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25382, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25382), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2233,19 +2366,23 @@ static void stand_up_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25477, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25477), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25485, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25485), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25484, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25484), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25492, { 0, 6, height }, { 32, 20, 7 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25492), { 0, 6, height },
+                        { 32, 20, 7 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2265,25 +2402,29 @@ static void stand_up_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25478, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25478), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25486, { 0, 14, height }, { 32, 2, 63 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25486), { 0, 14, height },
+                        { 32, 2, 63 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 15, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25483, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25483), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25491, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25491), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2300,19 +2441,23 @@ static void stand_up_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25479, { 16, 0, height }, { 5, 16, 119 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25479), { 16, 0, height },
+                        { 5, 16, 119 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25487, { 12, 0, height }, { 3, 16, 119 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25487), { 12, 0, height },
+                        { 3, 16, 119 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25482, { 10, 16, height }, { 4, 16, 119 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25482), { 10, 16, height },
+                        { 4, 16, 119 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25490, { 16, 16, height }, { 4, 16, 119 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25490), { 16, 16, height },
+                        { 4, 16, 119 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2324,19 +2469,23 @@ static void stand_up_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25480, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25480), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25488, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25488), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25481, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25481), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25489, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25489), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2357,19 +2506,23 @@ static void stand_up_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25481, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25481), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25489, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25489), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25480, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25480), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25488, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25488), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2384,19 +2537,23 @@ static void stand_up_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25482, { 10, 16, height }, { 4, 16, 119 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25482), { 10, 16, height },
+                        { 4, 16, 119 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25490, { 16, 16, height }, { 4, 16, 119 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25490), { 16, 16, height },
+                        { 4, 16, 119 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25479, { 16, 0, height }, { 5, 16, 119 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25479), { 16, 0, height },
+                        { 5, 16, 119 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25487, { 12, 0, height }, { 3, 16, 119 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25487), { 12, 0, height },
+                        { 3, 16, 119 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2408,25 +2565,29 @@ static void stand_up_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25483, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25483), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25491, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25491), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25478, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25478), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25486, { 0, 14, height }, { 32, 2, 63 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25486), { 0, 14, height },
+                        { 32, 2, 63 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 15, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2443,19 +2604,23 @@ static void stand_up_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25484, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25484), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25492, { 0, 6, height }, { 32, 20, 7 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25492), { 0, 6, height },
+                        { 32, 20, 7 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25477, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25477), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25485, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25485), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2490,19 +2655,23 @@ static void stand_up_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25508, { 0, 6, height }, { 32, 20, 7 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25508), { 0, 6, height },
+                        { 32, 20, 7 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25500, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25500), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25501, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25501), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25493, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25493), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2517,25 +2686,29 @@ static void stand_up_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25507, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25507), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25499, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25499), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25502, { 0, 14, height }, { 32, 2, 63 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25502), { 0, 14, height },
+                        { 32, 2, 63 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 15, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25494, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25494), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2547,19 +2720,23 @@ static void stand_up_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25506, { 16, 16, height }, { 4, 16, 119 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25506), { 16, 16, height },
+                        { 4, 16, 119 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25498, { 10, 16, height }, { 4, 16, 119 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25498), { 10, 16, height },
+                        { 4, 16, 119 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25503, { 12, 0, height }, { 3, 16, 119 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25503), { 12, 0, height },
+                        { 3, 16, 119 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25495, { 16, 0, height }, { 5, 16, 119 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25495), { 16, 0, height },
+                        { 5, 16, 119 });
                     break;
             }
             paint_util_set_general_support_height(session, height + 168, 0x20);
@@ -2569,19 +2746,23 @@ static void stand_up_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25505, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25505), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25497, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25497), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25504, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25504), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25496, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25496), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_general_support_height(session, height + 48, 0x20);
@@ -2597,19 +2778,23 @@ static void stand_up_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25504, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25504), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25496, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25496), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25505, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25505), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25497, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25497), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_general_support_height(session, height + 48, 0x20);
@@ -2619,19 +2804,23 @@ static void stand_up_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25503, { 12, 0, height }, { 3, 16, 119 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25503), { 12, 0, height },
+                        { 3, 16, 119 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25495, { 16, 0, height }, { 5, 16, 119 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25495), { 16, 0, height },
+                        { 5, 16, 119 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25506, { 16, 16, height }, { 4, 16, 119 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25506), { 16, 16, height },
+                        { 4, 16, 119 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25498, { 10, 16, height }, { 4, 16, 119 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25498), { 10, 16, height },
+                        { 4, 16, 119 });
                     break;
             }
             paint_util_set_general_support_height(session, height + 168, 0x20);
@@ -2641,25 +2830,29 @@ static void stand_up_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25502, { 0, 14, height }, { 32, 2, 63 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25502), { 0, 14, height },
+                        { 32, 2, 63 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 15, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25494, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25494), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25507, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25507), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25499, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25499), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2671,19 +2864,23 @@ static void stand_up_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25501, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25501), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25493, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25493), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25508, { 0, 6, height }, { 32, 20, 7 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25508), { 0, 6, height },
+                        { 32, 20, 7 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25500, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25500), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2715,19 +2912,23 @@ static void stand_up_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25514, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25514), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25517, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25517), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25520, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25520), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25511, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25511), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2747,19 +2948,23 @@ static void stand_up_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25513, { 16, 0, height }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25513), { 16, 0, height },
+                        { 16, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25516, { 0, 0, height }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25516), { 0, 0, height },
+                        { 16, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25519, { 0, 16, height }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25519), { 0, 16, height },
+                        { 16, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25510, { 16, 16, height }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25510), { 16, 16, height },
+                        { 16, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2771,19 +2976,23 @@ static void stand_up_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25512, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25512), { 6, 0, height },
+                        { 20, 32, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25515, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25515), { 6, 0, height },
+                        { 20, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25518, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25518), { 6, 0, height },
+                        { 20, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25509, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25509), { 6, 0, height },
+                        { 20, 32, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2824,26 +3033,26 @@ static void stand_up_rc_track_left_quarter_turn_3_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25526, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25526), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25533, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25533), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25529, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25529), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25532, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25532), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25523, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25523), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2863,23 +3072,23 @@ static void stand_up_rc_track_left_quarter_turn_3_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25525, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25525), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25528, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25528), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25531, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25531), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25522, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25522), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2891,26 +3100,26 @@ static void stand_up_rc_track_left_quarter_turn_3_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25524, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25524), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25527, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25527), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25530, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25530), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25534, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25534), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25521, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25521), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2953,19 +3162,23 @@ static void stand_up_rc_track_left_quarter_turn_3_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25562, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25562), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25564, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25564), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25566, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25566), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25560, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25560), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -2977,19 +3190,23 @@ static void stand_up_rc_track_left_quarter_turn_3_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25546, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25546), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25548, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25548), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25550, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25550), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25544, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25544), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -3016,19 +3233,23 @@ static void stand_up_rc_track_left_quarter_turn_3_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25561, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25561), { 6, 0, height },
+                            { 20, 32, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25563, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25563), { 6, 0, height },
+                            { 20, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25565, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25565), { 6, 0, height },
+                            { 20, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25559, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25559), { 6, 0, height },
+                            { 20, 32, 3 });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -3040,19 +3261,23 @@ static void stand_up_rc_track_left_quarter_turn_3_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25545, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25545), { 6, 0, height },
+                            { 20, 32, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25547, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25547), { 6, 0, height },
+                            { 20, 32, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25549, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25549), { 6, 0, height },
+                            { 20, 32, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25543, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25543), { 6, 0, height },
+                            { 20, 32, 3 });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -3088,19 +3313,23 @@ static void stand_up_rc_track_right_quarter_turn_3_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25551, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25551), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25553, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25553), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25555, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25555), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25557, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25557), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -3112,19 +3341,23 @@ static void stand_up_rc_track_right_quarter_turn_3_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25535, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25535), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25537, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25537), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25539, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25539), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25541, { 0, 6, height }, { 32, 20, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25541), { 0, 6, height },
+                            { 32, 20, 3 });
                         break;
                 }
                 metal_a_supports_paint_setup(
@@ -3151,25 +3384,29 @@ static void stand_up_rc_track_right_quarter_turn_3_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25552, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25552), { 6, 0, height },
+                            { 20, 32, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25554, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25554), { 6, 0, height },
+                            { 20, 32, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25556, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25556), { 6, 0, height },
+                            { 20, 32, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25558, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25558), { 6, 0, height },
+                            { 20, 32, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -3181,25 +3418,29 @@ static void stand_up_rc_track_right_quarter_turn_3_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25536, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25536), { 6, 0, height },
+                            { 20, 32, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25538, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25538), { 6, 0, height },
+                            { 20, 32, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25540, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25540), { 6, 0, height },
+                            { 20, 32, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25542, { 6, 0, height }, { 20, 32, 3 });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25542), { 6, 0, height },
+                            { 20, 32, 3 });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -3251,19 +3492,23 @@ static void stand_up_rc_track_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25575, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25575), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25583, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25583), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25582, { 0, 6, height }, { 32, 20, 9 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25582), { 0, 6, height },
+                        { 32, 20, 9 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25590, { 0, 6, height }, { 32, 20, 7 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25590), { 0, 6, height },
+                        { 32, 20, 7 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3280,27 +3525,29 @@ static void stand_up_rc_track_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25576, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25576), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25584, { 0, 14, height }, { 32, 2, 63 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25584), { 0, 14, height },
+                        { 32, 2, 63 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 15, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25581, { 0, 6, height }, { 32, 2, 3 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25581), { 0, 6, height }, { 32, 2, 3 },
                         { 0, 20, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25589, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25589), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3313,20 +3560,23 @@ static void stand_up_rc_track_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25577, { 16, 0, height }, { 2, 16, 119 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25577), { 16, 0, height },
+                        { 2, 16, 119 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25585, { 12, 0, height }, { 3, 16, 119 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25585), { 12, 0, height },
+                        { 3, 16, 119 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25580, { 10, 16, height }, { 4, 12, 119 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25580), { 10, 16, height },
+                        { 4, 12, 119 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25588, { 16, 16, height }, { 2, 16, 119 },
-                        { 15, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25588), { 16, 16, height },
+                        { 2, 16, 119 }, { 15, 6, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3341,19 +3591,23 @@ static void stand_up_rc_track_half_loop_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25578, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25578), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25586, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25586), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25579, { 0, 16, height + 32 }, { 32, 12, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25579), { 0, 16, height + 32 },
+                        { 32, 12, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25587, { 0, 16, height + 32 }, { 32, 12, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25587), { 0, 16, height + 32 },
+                        { 32, 12, 3 });
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -3387,23 +3641,23 @@ static void stand_up_rc_track_left_corkscrew_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25591, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25591), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 4 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25594, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25594), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 4 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25597, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25597), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 4 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25600, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25600), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 4 });
                     break;
             }
 
@@ -3420,23 +3674,23 @@ static void stand_up_rc_track_left_corkscrew_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25592, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25592), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25595, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25595), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25598, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25598), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25601, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25601), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -3447,23 +3701,23 @@ static void stand_up_rc_track_left_corkscrew_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25593, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25593), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 24 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25596, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25596), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 24 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25599, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25599), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 24 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25602, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25602), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 24 });
                     break;
             }
 
@@ -3499,23 +3753,23 @@ static void stand_up_rc_track_right_corkscrew_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25603, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25603), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 4 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25606, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25606), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 4 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25609, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25609), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 4 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25612, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 4 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25612), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 4 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3533,23 +3787,23 @@ static void stand_up_rc_track_right_corkscrew_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25604, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25604), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25607, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25607), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25610, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25610), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25613, { 0, 0, height }, { 20, 20, 3 },
-                        { 6, 6, height + 10 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25613), { 0, 0, height },
+                        { 20, 20, 3 }, { 6, 6, height + 10 });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -3560,23 +3814,23 @@ static void stand_up_rc_track_right_corkscrew_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25605, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25605), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 24 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25608, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25608), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 24 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25611, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25611), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 24 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25614, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 24 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25614), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 24 });
                     break;
             }
 
@@ -3628,26 +3882,26 @@ static void stand_up_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25844, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25844), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25851, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25851), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25847, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25847), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25850, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25850), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25841, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25841), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3668,23 +3922,23 @@ static void stand_up_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25843, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25843), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25846, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25846), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25849, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25849), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25840, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25840), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3696,26 +3950,26 @@ static void stand_up_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25842, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25842), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25845, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25845), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25848, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25848), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25852, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25852), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25839, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25839), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 8 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3738,26 +3992,26 @@ static void stand_up_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25841, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25841), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25844, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25844), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25851, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25851), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25847, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25847), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25850, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25850), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3783,23 +4037,23 @@ static void stand_up_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25840, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25840), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25843, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25843), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25846, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25846), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25849, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25849), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3811,26 +4065,26 @@ static void stand_up_rc_track_left_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25839, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25839), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25842, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25842), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25845, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25845), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25848, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25848), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25852, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25852), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3858,26 +4112,26 @@ static void stand_up_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25825, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25825), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25828, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25828), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25831, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25831), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25834, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25834), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25838, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25838), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3898,23 +4152,23 @@ static void stand_up_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25826, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25826), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25829, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25829), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25832, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25832), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25835, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25835), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3926,26 +4180,26 @@ static void stand_up_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25827, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25827), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25830, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25830), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25837, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25837), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25833, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25833), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25836, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25836), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3968,26 +4222,26 @@ static void stand_up_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25828, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25828), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25831, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25831), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25834, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25834), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25838, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25838), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25825, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25825), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4013,23 +4267,23 @@ static void stand_up_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25829, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25829), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25832, { 0, 0, height }, { 16, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25832), { 0, 0, height },
+                        { 16, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25835, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25835), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25826, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25826), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4041,26 +4295,26 @@ static void stand_up_rc_track_right_half_banked_helix_up_small(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25830, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25830), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25837, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25837), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25833, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25833), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25836, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25836), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25827, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25827), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4116,26 +4370,26 @@ static void stand_up_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25812, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25812), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25823, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25823), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25817, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25817), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25822, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25822), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25807, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25807), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4156,23 +4410,23 @@ static void stand_up_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25811, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25811), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25816, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25816), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25821, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25821), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25806, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25806), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4187,23 +4441,23 @@ static void stand_up_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25810, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25810), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25815, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25815), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25820, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25820), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25805, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25805), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4218,23 +4472,23 @@ static void stand_up_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25809, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25809), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25814, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25814), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25819, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25819), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25804, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25804), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4249,26 +4503,26 @@ static void stand_up_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25808, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25808), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25813, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25813), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25818, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25818), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25824, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25824), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25803, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25803), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 8 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4291,26 +4545,26 @@ static void stand_up_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25807, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25807), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25812, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25812), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25823, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25823), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25817, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25817), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25822, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25822), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4336,23 +4590,23 @@ static void stand_up_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25806, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25806), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25811, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25811), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25816, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25816), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25821, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25821), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4367,23 +4621,23 @@ static void stand_up_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25805, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25805), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25810, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25810), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25815, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25815), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25820, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25820), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4398,23 +4652,23 @@ static void stand_up_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25804, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25804), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25809, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25809), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25814, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25814), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25819, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25819), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4429,26 +4683,26 @@ static void stand_up_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25803, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25803), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25808, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25808), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25813, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25813), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25818, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25818), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25824, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25824), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4476,26 +4730,26 @@ static void stand_up_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25781, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25781), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25786, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25786), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25791, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25791), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25796, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25796), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25802, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25802), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4516,23 +4770,23 @@ static void stand_up_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25782, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25782), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25787, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25787), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25792, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25792), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25797, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25797), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4547,23 +4801,23 @@ static void stand_up_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25783, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25783), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25788, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25788), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25793, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25793), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25798, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25798), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4578,23 +4832,23 @@ static void stand_up_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25784, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25784), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25789, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25789), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25794, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25794), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25799, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25799), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4609,26 +4863,26 @@ static void stand_up_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25785, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25785), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height + 8 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25790, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25790), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25801, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25801), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25795, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25795), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25800, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25800), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4651,26 +4905,26 @@ static void stand_up_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25786, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25786), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25791, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25791), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25796, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25796), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25802, { 0, 0, height }, { 1, 32, 26 },
-                        { 27, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25802), { 0, 0, height },
+                        { 1, 32, 26 }, { 27, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25781, { 0, 0, height }, { 20, 32, 3 },
-                        { 6, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25781), { 0, 0, height },
+                        { 20, 32, 3 }, { 6, 0, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4696,23 +4950,23 @@ static void stand_up_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25787, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25787), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25792, { 0, 0, height }, { 16, 32, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25792), { 0, 0, height },
+                        { 16, 32, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25797, { 0, 0, height }, { 16, 32, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25797), { 0, 0, height },
+                        { 16, 32, 3 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25782, { 0, 0, height }, { 16, 32, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25782), { 0, 0, height },
+                        { 16, 32, 3 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4727,23 +4981,23 @@ static void stand_up_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25788, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25788), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25793, { 0, 0, height }, { 16, 16, 1 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25793), { 0, 0, height },
+                        { 16, 16, 1 }, { 16, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25798, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25798), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25783, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25783), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4758,23 +5012,23 @@ static void stand_up_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25789, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25789), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25794, { 0, 0, height }, { 32, 16, 1 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25794), { 0, 0, height },
+                        { 32, 16, 1 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25799, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25799), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25784, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25784), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4789,26 +5043,26 @@ static void stand_up_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25790, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25790), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25801, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25801), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25795, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25795), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25800, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25800), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25785, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height + 8 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25785), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height + 8 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4862,12 +5116,12 @@ static void stand_up_rc_track_brakes(
         case 0:
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25569, { 0, 6, height }, { 32, 20, 3 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25569), { 0, 6, height }, { 32, 20, 3 });
             break;
         case 1:
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25570, { 0, 6, height }, { 32, 20, 3 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25570), { 0, 6, height }, { 32, 20, 3 });
             break;
     }
     if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -4889,38 +5143,38 @@ static void stand_up_rc_track_on_ride_photo(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25229, { 0, 6, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25229), { 0, 6, height }, { 32, 20, 1 },
                 { 0, 6, height + 3 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25230, { 0, 6, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25230), { 0, 6, height }, { 32, 20, 1 },
                 { 0, 6, height + 3 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25229, { 0, 6, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25229), { 0, 6, height }, { 32, 20, 1 },
                 { 0, 6, height + 3 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 32, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 32, 1 });
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25230, { 0, 6, height }, { 32, 20, 1 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25230), { 0, 6, height }, { 32, 20, 1 },
                 { 0, 6, height + 3 });
             break;
     }
@@ -4942,23 +5196,23 @@ static void stand_up_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25643, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25643), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25647, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25647), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25651, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25651), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25655, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25655), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4975,23 +5229,23 @@ static void stand_up_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25644, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25644), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25648, { 0, 0, height }, { 34, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25648), { 0, 0, height },
+                        { 34, 16, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25652, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25652), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25656, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25656), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5006,23 +5260,23 @@ static void stand_up_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25645, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25645), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25649, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25649), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25653, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25653), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25657, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25657), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5040,29 +5294,29 @@ static void stand_up_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25646, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25646), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25650, { 0, 0, height }, { 16, 18, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25650), { 0, 0, height },
+                        { 16, 18, 3 }, { 0, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25654, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25654), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25658, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25658), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -5089,23 +5343,23 @@ static void stand_up_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25627, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25627), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25631, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25631), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25635, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25635), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25639, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25639), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -5122,23 +5376,23 @@ static void stand_up_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25628, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25628), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25632, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25632), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25636, { 0, 0, height }, { 34, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25636), { 0, 0, height },
+                        { 34, 16, 3 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25640, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25640), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5153,23 +5407,23 @@ static void stand_up_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25629, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25629), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25633, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25633), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25637, { 0, 0, height }, { 28, 28, 3 },
-                        { 4, 4, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25637), { 0, 0, height },
+                        { 28, 28, 3 }, { 4, 4, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25641, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25641), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5187,29 +5441,29 @@ static void stand_up_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25630, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25630), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25634, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25634), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25638, { 0, 0, height }, { 16, 18, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25638), { 0, 0, height },
+                        { 16, 18, 3 }, { 0, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25642, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25642), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -5254,23 +5508,23 @@ static void stand_up_rc_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25675, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25675), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25679, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25679), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25683, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25683), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25687, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25687), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -5287,23 +5541,23 @@ static void stand_up_rc_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25676, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25676), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25680, { 0, 0, height }, { 34, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25680), { 0, 0, height },
+                        { 34, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25684, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25684), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25688, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25688), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5318,23 +5572,23 @@ static void stand_up_rc_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25677, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25677), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25681, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25681), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25685, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25685), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25689, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25689), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5352,29 +5606,29 @@ static void stand_up_rc_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25678, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25678), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25682, { 0, 0, height }, { 16, 18, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25682), { 0, 0, height },
+                        { 16, 18, 0 }, { 0, 16, height + 27 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25686, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25686), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25690, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25690), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -5401,23 +5655,23 @@ static void stand_up_rc_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25659, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25659), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25663, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25663), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25667, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25667), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25671, { 0, 0, height }, { 32, 1, 26 },
-                        { 0, 27, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25671), { 0, 0, height },
+                        { 32, 1, 26 }, { 0, 27, height });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -5434,23 +5688,23 @@ static void stand_up_rc_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25660, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25660), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25664, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25664), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25668, { 0, 0, height }, { 34, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25668), { 0, 0, height },
+                        { 34, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25672, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25672), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5465,23 +5719,23 @@ static void stand_up_rc_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25661, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25661), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25665, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25665), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25669, { 0, 0, height }, { 28, 28, 0 },
-                        { 4, 4, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25669), { 0, 0, height },
+                        { 28, 28, 0 }, { 4, 4, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25673, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25673), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5499,29 +5753,29 @@ static void stand_up_rc_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25662, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25662), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25666, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25666), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25670, { 0, 0, height }, { 16, 18, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25670), { 0, 0, height },
+                        { 16, 18, 0 }, { 0, 16, height + 27 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25674, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25674), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -5568,8 +5822,8 @@ static void stand_up_rc_track_diag_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25756, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25756), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5579,8 +5833,8 @@ static void stand_up_rc_track_diag_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25694, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25694), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5595,8 +5849,8 @@ static void stand_up_rc_track_diag_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25753, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25753), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5606,8 +5860,8 @@ static void stand_up_rc_track_diag_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25691, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25691), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5622,8 +5876,8 @@ static void stand_up_rc_track_diag_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25755, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25755), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5633,8 +5887,8 @@ static void stand_up_rc_track_diag_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25693, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25693), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5653,8 +5907,8 @@ static void stand_up_rc_track_diag_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25754, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25754), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5678,8 +5932,8 @@ static void stand_up_rc_track_diag_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25692, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25692), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5714,8 +5968,8 @@ static void stand_up_rc_track_diag_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25768, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25768), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5725,8 +5979,8 @@ static void stand_up_rc_track_diag_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25706, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25706), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5741,8 +5995,8 @@ static void stand_up_rc_track_diag_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25765, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25765), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5752,8 +6006,8 @@ static void stand_up_rc_track_diag_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25703, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25703), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5768,8 +6022,8 @@ static void stand_up_rc_track_diag_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25767, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25767), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5779,8 +6033,8 @@ static void stand_up_rc_track_diag_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25705, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25705), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5799,8 +6053,8 @@ static void stand_up_rc_track_diag_25_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25766, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25766), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5824,8 +6078,8 @@ static void stand_up_rc_track_diag_25_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25704, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25704), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5860,8 +6114,8 @@ static void stand_up_rc_track_diag_60_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25780, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25780), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5871,8 +6125,8 @@ static void stand_up_rc_track_diag_60_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25718, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25718), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5887,8 +6141,8 @@ static void stand_up_rc_track_diag_60_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25777, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25777), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5898,8 +6152,8 @@ static void stand_up_rc_track_diag_60_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25715, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25715), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5914,8 +6168,8 @@ static void stand_up_rc_track_diag_60_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25779, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25779), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5925,8 +6179,8 @@ static void stand_up_rc_track_diag_60_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25717, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25717), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -5945,8 +6199,8 @@ static void stand_up_rc_track_diag_60_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25778, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25778), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 36, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -5970,8 +6224,8 @@ static void stand_up_rc_track_diag_60_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25716, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25716), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 36, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6006,8 +6260,8 @@ static void stand_up_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25760, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25760), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6017,8 +6271,8 @@ static void stand_up_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25698, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25698), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6033,8 +6287,8 @@ static void stand_up_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25757, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25757), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6044,8 +6298,8 @@ static void stand_up_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25695, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25695), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6060,8 +6314,8 @@ static void stand_up_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25759, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25759), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6071,8 +6325,8 @@ static void stand_up_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25697, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25697), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6091,8 +6345,8 @@ static void stand_up_rc_track_diag_flat_to_25_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25758, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25758), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6116,8 +6370,8 @@ static void stand_up_rc_track_diag_flat_to_25_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25696, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25696), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6152,8 +6406,8 @@ static void stand_up_rc_track_diag_25_deg_up_to_60_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25772, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25772), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6163,8 +6417,8 @@ static void stand_up_rc_track_diag_25_deg_up_to_60_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25710, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25710), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6179,8 +6433,8 @@ static void stand_up_rc_track_diag_25_deg_up_to_60_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25769, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25769), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6190,8 +6444,8 @@ static void stand_up_rc_track_diag_25_deg_up_to_60_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25707, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25707), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6206,8 +6460,8 @@ static void stand_up_rc_track_diag_25_deg_up_to_60_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25771, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25771), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6217,8 +6471,8 @@ static void stand_up_rc_track_diag_25_deg_up_to_60_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25709, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25709), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6237,8 +6491,8 @@ static void stand_up_rc_track_diag_25_deg_up_to_60_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25770, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25770), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6262,8 +6516,8 @@ static void stand_up_rc_track_diag_25_deg_up_to_60_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25708, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25708), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6298,8 +6552,8 @@ static void stand_up_rc_track_diag_60_deg_up_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25776, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25776), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6309,8 +6563,8 @@ static void stand_up_rc_track_diag_60_deg_up_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25714, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25714), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6325,8 +6579,8 @@ static void stand_up_rc_track_diag_60_deg_up_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25773, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25773), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6336,8 +6590,8 @@ static void stand_up_rc_track_diag_60_deg_up_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25711, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25711), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6352,8 +6606,8 @@ static void stand_up_rc_track_diag_60_deg_up_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25775, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25775), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6363,8 +6617,8 @@ static void stand_up_rc_track_diag_60_deg_up_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25713, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25713), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6383,8 +6637,8 @@ static void stand_up_rc_track_diag_60_deg_up_to_25_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25774, { -16, -16, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25774), { -16, -16, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 21, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6408,8 +6662,8 @@ static void stand_up_rc_track_diag_60_deg_up_to_25_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25712, { -16, -16, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25712), { -16, -16, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 21, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6444,8 +6698,8 @@ static void stand_up_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25764, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25764), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6455,8 +6709,8 @@ static void stand_up_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25702, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25702), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6471,8 +6725,8 @@ static void stand_up_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25761, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25761), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6482,8 +6736,8 @@ static void stand_up_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25699, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25699), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6498,8 +6752,8 @@ static void stand_up_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25763, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25763), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6509,8 +6763,8 @@ static void stand_up_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25701, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25701), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6529,8 +6783,8 @@ static void stand_up_rc_track_diag_25_deg_up_to_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25762, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25762), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6554,8 +6808,8 @@ static void stand_up_rc_track_diag_25_deg_up_to_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25700, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25700), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6590,8 +6844,8 @@ static void stand_up_rc_track_diag_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25766, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25766), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6601,8 +6855,8 @@ static void stand_up_rc_track_diag_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25704, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25704), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6617,8 +6871,8 @@ static void stand_up_rc_track_diag_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25767, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25767), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6628,8 +6882,8 @@ static void stand_up_rc_track_diag_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25705, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25705), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6644,8 +6898,8 @@ static void stand_up_rc_track_diag_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25765, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25765), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6655,8 +6909,8 @@ static void stand_up_rc_track_diag_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25703, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25703), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6675,8 +6929,8 @@ static void stand_up_rc_track_diag_25_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25768, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25768), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6700,8 +6954,8 @@ static void stand_up_rc_track_diag_25_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25706, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25706), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6736,8 +6990,8 @@ static void stand_up_rc_track_diag_60_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25778, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25778), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6747,8 +7001,8 @@ static void stand_up_rc_track_diag_60_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25716, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25716), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6763,8 +7017,8 @@ static void stand_up_rc_track_diag_60_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25779, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25779), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6774,8 +7028,8 @@ static void stand_up_rc_track_diag_60_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25717, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25717), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6790,8 +7044,8 @@ static void stand_up_rc_track_diag_60_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25777, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25777), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6801,8 +7055,8 @@ static void stand_up_rc_track_diag_60_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25715, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25715), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6821,8 +7075,8 @@ static void stand_up_rc_track_diag_60_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25780, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25780), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 28, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6846,8 +7100,8 @@ static void stand_up_rc_track_diag_60_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25718, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25718), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 28, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6882,8 +7136,8 @@ static void stand_up_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25762, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25762), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6893,8 +7147,8 @@ static void stand_up_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25700, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25700), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6908,8 +7162,8 @@ static void stand_up_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25763, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25763), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6919,8 +7173,8 @@ static void stand_up_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25701, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25701), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6934,8 +7188,8 @@ static void stand_up_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25761, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25761), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6945,8 +7199,8 @@ static void stand_up_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25699, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25699), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -6964,8 +7218,8 @@ static void stand_up_rc_track_diag_flat_to_25_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25764, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25764), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -6989,8 +7243,8 @@ static void stand_up_rc_track_diag_flat_to_25_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25702, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25702), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7026,8 +7280,8 @@ static void stand_up_rc_track_diag_25_deg_down_to_60_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25774, { -16, -16, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25774), { -16, -16, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         break;
                 }
             }
@@ -7037,8 +7291,8 @@ static void stand_up_rc_track_diag_25_deg_down_to_60_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25712, { -16, -16, height }, { 16, 16, 3 },
-                            { 0, 0, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25712), { -16, -16, height },
+                            { 16, 16, 3 }, { 0, 0, height });
                         break;
                 }
             }
@@ -7053,8 +7307,8 @@ static void stand_up_rc_track_diag_25_deg_down_to_60_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25775, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25775), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7064,8 +7318,8 @@ static void stand_up_rc_track_diag_25_deg_down_to_60_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25713, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25713), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7080,8 +7334,8 @@ static void stand_up_rc_track_diag_25_deg_down_to_60_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25773, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25773), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7091,8 +7345,8 @@ static void stand_up_rc_track_diag_25_deg_down_to_60_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25711, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25711), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7111,8 +7365,8 @@ static void stand_up_rc_track_diag_25_deg_down_to_60_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25776, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25776), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 17, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7136,8 +7390,8 @@ static void stand_up_rc_track_diag_25_deg_down_to_60_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25714, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25714), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 17, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7172,8 +7426,8 @@ static void stand_up_rc_track_diag_60_deg_down_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25770, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25770), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7183,8 +7437,8 @@ static void stand_up_rc_track_diag_60_deg_down_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25708, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25708), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7199,8 +7453,8 @@ static void stand_up_rc_track_diag_60_deg_down_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25771, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25771), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7210,8 +7464,8 @@ static void stand_up_rc_track_diag_60_deg_down_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25709, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25709), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7226,8 +7480,8 @@ static void stand_up_rc_track_diag_60_deg_down_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25769, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25769), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7237,8 +7491,8 @@ static void stand_up_rc_track_diag_60_deg_down_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25707, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25707), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7257,8 +7511,8 @@ static void stand_up_rc_track_diag_60_deg_down_to_25_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25772, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25772), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7282,8 +7536,8 @@ static void stand_up_rc_track_diag_60_deg_down_to_25_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25710, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25710), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7318,8 +7572,8 @@ static void stand_up_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25758, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25758), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7329,8 +7583,8 @@ static void stand_up_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25696, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25696), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7345,8 +7599,8 @@ static void stand_up_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25759, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25759), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7356,8 +7610,8 @@ static void stand_up_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25697, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25697), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7372,8 +7626,8 @@ static void stand_up_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25757, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25757), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7383,8 +7637,8 @@ static void stand_up_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25695, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25695), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -7403,8 +7657,8 @@ static void stand_up_rc_track_diag_25_deg_down_to_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25760, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25760), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7428,8 +7682,8 @@ static void stand_up_rc_track_diag_25_deg_down_to_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 25698, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25698), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -7462,8 +7716,8 @@ static void stand_up_rc_track_diag_flat_to_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25726, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25726), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7475,11 +7729,11 @@ static void stand_up_rc_track_diag_flat_to_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25723, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25723), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25727, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25727), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7491,8 +7745,8 @@ static void stand_up_rc_track_diag_flat_to_left_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25725, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25725), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7508,8 +7762,8 @@ static void stand_up_rc_track_diag_flat_to_left_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25724, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25724), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7541,8 +7795,8 @@ static void stand_up_rc_track_diag_flat_to_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25731, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25731), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7554,8 +7808,8 @@ static void stand_up_rc_track_diag_flat_to_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25728, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25728), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7567,11 +7821,11 @@ static void stand_up_rc_track_diag_flat_to_right_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25730, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25730), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25732, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25732), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7587,8 +7841,8 @@ static void stand_up_rc_track_diag_flat_to_right_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25729, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25729), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7620,8 +7874,8 @@ static void stand_up_rc_track_diag_left_bank_to_flat(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25729, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25729), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7633,11 +7887,11 @@ static void stand_up_rc_track_diag_left_bank_to_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25730, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25730), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25732, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25732), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7649,8 +7903,8 @@ static void stand_up_rc_track_diag_left_bank_to_flat(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25728, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25728), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7666,8 +7920,8 @@ static void stand_up_rc_track_diag_left_bank_to_flat(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25731, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25731), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7699,8 +7953,8 @@ static void stand_up_rc_track_diag_right_bank_to_flat(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25724, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25724), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7712,8 +7966,8 @@ static void stand_up_rc_track_diag_right_bank_to_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25725, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25725), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7725,11 +7979,11 @@ static void stand_up_rc_track_diag_right_bank_to_flat(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25723, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25723), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25727, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25727), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7745,8 +7999,8 @@ static void stand_up_rc_track_diag_right_bank_to_flat(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25726, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25726), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7778,8 +8032,8 @@ static void stand_up_rc_track_diag_left_bank_to_25_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25746, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25746), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7791,11 +8045,11 @@ static void stand_up_rc_track_diag_left_bank_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25743, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25743), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25747, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25747), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7807,8 +8061,8 @@ static void stand_up_rc_track_diag_left_bank_to_25_deg_up(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25745, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25745), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7824,8 +8078,8 @@ static void stand_up_rc_track_diag_left_bank_to_25_deg_up(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25744, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25744), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7857,8 +8111,8 @@ static void stand_up_rc_track_diag_right_bank_to_25_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25751, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25751), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7870,8 +8124,8 @@ static void stand_up_rc_track_diag_right_bank_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25748, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25748), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7883,11 +8137,11 @@ static void stand_up_rc_track_diag_right_bank_to_25_deg_up(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25750, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25750), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25752, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25752), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7903,8 +8157,8 @@ static void stand_up_rc_track_diag_right_bank_to_25_deg_up(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25749, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25749), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7936,8 +8190,8 @@ static void stand_up_rc_track_diag_25_deg_up_to_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25736, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25736), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7949,11 +8203,11 @@ static void stand_up_rc_track_diag_25_deg_up_to_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25733, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25733), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25737, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25737), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7965,8 +8219,8 @@ static void stand_up_rc_track_diag_25_deg_up_to_left_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25735, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25735), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7982,8 +8236,8 @@ static void stand_up_rc_track_diag_25_deg_up_to_left_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25734, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25734), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8015,8 +8269,8 @@ static void stand_up_rc_track_diag_25_deg_up_to_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25741, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25741), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8028,8 +8282,8 @@ static void stand_up_rc_track_diag_25_deg_up_to_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25738, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25738), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8041,11 +8295,11 @@ static void stand_up_rc_track_diag_25_deg_up_to_right_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25740, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25740), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25742, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25742), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8061,8 +8315,8 @@ static void stand_up_rc_track_diag_25_deg_up_to_right_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25739, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25739), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8094,8 +8348,8 @@ static void stand_up_rc_track_diag_left_bank_to_25_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25739, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25739), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8106,11 +8360,11 @@ static void stand_up_rc_track_diag_left_bank_to_25_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25740, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25740), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25742, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25742), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8121,8 +8375,8 @@ static void stand_up_rc_track_diag_left_bank_to_25_deg_down(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25738, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25738), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8137,8 +8391,8 @@ static void stand_up_rc_track_diag_left_bank_to_25_deg_down(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25741, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25741), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8171,8 +8425,8 @@ static void stand_up_rc_track_diag_right_bank_to_25_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25734, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25734), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8183,8 +8437,8 @@ static void stand_up_rc_track_diag_right_bank_to_25_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25735, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25735), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8195,11 +8449,11 @@ static void stand_up_rc_track_diag_right_bank_to_25_deg_down(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16676, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16676), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 16680, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(16680), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8214,8 +8468,8 @@ static void stand_up_rc_track_diag_right_bank_to_25_deg_down(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25736, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25736), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8248,8 +8502,8 @@ static void stand_up_rc_track_diag_25_deg_down_to_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25749, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25749), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8261,11 +8515,11 @@ static void stand_up_rc_track_diag_25_deg_down_to_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25750, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25750), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25752, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25752), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8277,8 +8531,8 @@ static void stand_up_rc_track_diag_25_deg_down_to_left_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25748, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25748), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8294,8 +8548,8 @@ static void stand_up_rc_track_diag_25_deg_down_to_left_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25751, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25751), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8327,8 +8581,8 @@ static void stand_up_rc_track_diag_25_deg_down_to_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25744, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25744), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8340,8 +8594,8 @@ static void stand_up_rc_track_diag_25_deg_down_to_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25745, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25745), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8353,11 +8607,11 @@ static void stand_up_rc_track_diag_25_deg_down_to_right_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25743, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25743), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25747, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25747), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8373,8 +8627,8 @@ static void stand_up_rc_track_diag_25_deg_down_to_right_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25746, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25746), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_b_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8406,8 +8660,8 @@ static void stand_up_rc_track_diag_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25722, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25722), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8419,8 +8673,8 @@ static void stand_up_rc_track_diag_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25719, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25719), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8432,8 +8686,8 @@ static void stand_up_rc_track_diag_left_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25721, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25721), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8449,8 +8703,8 @@ static void stand_up_rc_track_diag_left_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25720, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25720), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8482,8 +8736,8 @@ static void stand_up_rc_track_diag_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25720, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25720), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8495,8 +8749,8 @@ static void stand_up_rc_track_diag_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25721, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25721), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8508,8 +8762,8 @@ static void stand_up_rc_track_diag_right_bank(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25719, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25719), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -8525,8 +8779,8 @@ static void stand_up_rc_track_diag_right_bank(
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25722, { -16, -16, height }, { 32, 32, 3 },
-                        { -16, -16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25722), { -16, -16, height },
+                        { 32, 32, 3 }, { -16, -16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_TUBES, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8553,7 +8807,7 @@ static void stand_up_rc_track_block_brakes(
 {
     bool isClosed = trackElement.BlockBrakeClosed();
     PaintAddImageAsParentRotated(
-        session, direction, session.TrackColours[SCHEME_TRACK] | _StandUpBlockBrakeImages[direction][isClosed],
+        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(_StandUpBlockBrakeImages[direction][isClosed]),
         { 0, 6, height }, { 32, 20, 3 });
 
     if (track_paint_util_should_paint_supports(session.MapPosition))

--- a/src/openrct2/ride/coaster/Steeplechase.cpp
+++ b/src/openrct2/ride/coaster/Steeplechase.cpp
@@ -30,14 +30,14 @@ static void steeplechase_track_flat(
             case 0:
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28635, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28635), { 0, 6, height }, { 32, 20, 3 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_STICK, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28636, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28636), { 0, 6, height }, { 32, 20, 3 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_STICK_ALT, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -50,14 +50,14 @@ static void steeplechase_track_flat(
             case 0:
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28633, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28633), { 0, 6, height }, { 32, 20, 3 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_STICK, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28634, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28634), { 0, 6, height }, { 32, 20, 3 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_STICK_ALT, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -81,11 +81,11 @@ static void steeplechase_track_station(
     };
 
     PaintAddImageAsParentRotated(
-        session, direction, imageIds[direction][1] | session.TrackColours[SCHEME_MISC], { 0, 0, height - 2 }, { 32, 28, 3 },
-        { 0, 2, height });
+        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][1]), { 0, 0, height - 2 },
+        { 32, 28, 3 }, { 0, 2, height });
     PaintAddImageAsChildRotated(
-        session, direction, imageIds[direction][0] | session.TrackColours[SCHEME_TRACK], { 0, 6, height }, { 32, 20, 3 },
-        { 0, 0, height });
+        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]), { 0, 6, height },
+        { 32, 20, 3 }, { 0, 0, height });
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], 3);
     track_paint_util_draw_station(session, ride, direction, height, trackElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -104,25 +104,25 @@ static void steeplechase_track_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28649, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28649), { 0, 6, height }, { 32, 20, 3 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_STICK, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28655, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28655), { 0, 6, height }, { 32, 20, 3 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_STICK_ALT, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28651, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28651), { 0, 6, height }, { 32, 20, 3 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_STICK, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28656, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28656), { 0, 6, height }, { 32, 20, 3 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_STICK_ALT, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -134,25 +134,25 @@ static void steeplechase_track_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28637, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28637), { 0, 6, height }, { 32, 20, 3 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_STICK, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28643, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28643), { 0, 6, height }, { 32, 20, 3 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_STICK_ALT, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28639, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28639), { 0, 6, height }, { 32, 20, 3 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_STICK, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28644, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28644), { 0, 6, height }, { 32, 20, 3 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_STICK_ALT, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -182,25 +182,25 @@ static void steeplechase_track_flat_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28650, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28650), { 0, 6, height }, { 32, 20, 3 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_STICK, 4, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28657, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28657), { 0, 6, height }, { 32, 20, 3 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_STICK_ALT, 4, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28652, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28652), { 0, 6, height }, { 32, 20, 3 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_STICK, 4, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28658, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28658), { 0, 6, height }, { 32, 20, 3 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_STICK_ALT, 4, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -212,25 +212,25 @@ static void steeplechase_track_flat_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28638, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28638), { 0, 6, height }, { 32, 20, 3 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_STICK, 4, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28645, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28645), { 0, 6, height }, { 32, 20, 3 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_STICK_ALT, 4, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28640, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28640), { 0, 6, height }, { 32, 20, 3 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_STICK, 4, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28646, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28646), { 0, 6, height }, { 32, 20, 3 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_STICK_ALT, 4, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -260,25 +260,25 @@ static void steeplechase_track_25_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28654, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28654), { 0, 6, height }, { 32, 20, 3 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_STICK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28660, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28660), { 0, 6, height }, { 32, 20, 3 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_STICK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28653, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28653), { 0, 6, height }, { 32, 20, 3 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_STICK, 4, 5, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28659, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28659), { 0, 6, height }, { 32, 20, 3 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_STICK_ALT, 4, 5, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -290,25 +290,25 @@ static void steeplechase_track_25_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28642, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28642), { 0, 6, height }, { 32, 20, 3 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_STICK, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28648, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28648), { 0, 6, height }, { 32, 20, 3 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_STICK_ALT, 4, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28641, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28641), { 0, 6, height }, { 32, 20, 3 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_STICK, 4, 5, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 28647, { 0, 6, height }, { 32, 20, 3 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28647), { 0, 6, height }, { 32, 20, 3 });
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_STICK_ALT, 4, 5, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
@@ -363,25 +363,29 @@ static void steeplechase_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28698, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28698), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK, 4, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28703, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28703), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK_ALT, 4, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28708, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28708), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK, 4, 0, height - 3, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28693, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28693), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK_ALT, 4, 0, height - 1, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -402,19 +406,23 @@ static void steeplechase_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28697, { 0, 0, height }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28697), { 0, 0, height },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28702, { 0, 0, height }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28702), { 0, 0, height },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28707, { 0, 16, height }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28707), { 0, 16, height },
+                        { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28692, { 0, 16, height }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28692), { 0, 16, height },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -429,19 +437,23 @@ static void steeplechase_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28696, { 0, 16, height }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28696), { 0, 16, height },
+                        { 16, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28701, { 16, 16, height }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28701), { 16, 16, height },
+                        { 16, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28706, { 16, 0, height }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28706), { 16, 0, height },
+                        { 16, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28691, { 0, 0, height }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28691), { 0, 0, height },
+                        { 16, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -456,19 +468,23 @@ static void steeplechase_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28695, { 16, 0, height }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28695), { 16, 0, height },
+                        { 16, 32, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28700, { 0, 0, height }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28700), { 0, 0, height },
+                        { 16, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28705, { 0, 0, height }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28705), { 0, 0, height },
+                        { 16, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28690, { 16, 0, height }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28690), { 16, 0, height },
+                        { 16, 32, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -483,25 +499,29 @@ static void steeplechase_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28694, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28694), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK_ALT, 4, 0, height - 3, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28699, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28699), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28704, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28704), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK_ALT, 4, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28689, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28689), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK, 4, 0, height - 2, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -543,25 +563,29 @@ static void steeplechase_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28665, { 0, 6, height }, { 33, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28665), { 0, 6, height },
+                        { 33, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28672, { 0, 6, height }, { 33, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28672), { 0, 6, height },
+                        { 33, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK_ALT, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28668, { 0, 6, height }, { 33, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28668), { 0, 6, height },
+                        { 33, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28669, { 0, 6, height }, { 33, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28669), { 0, 6, height },
+                        { 33, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK_ALT, 4, 0, height - 2, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -579,23 +603,27 @@ static void steeplechase_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28666, { 0, 0, height }, { 33, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28666), { 0, 0, height },
+                        { 33, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28671, { 0, 0, height }, { 33, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28671), { 0, 0, height },
+                        { 33, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK_ALT, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28667, { 0, 6, height }, { 33, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28667), { 0, 6, height },
+                        { 33, 26, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28670, { 0, 6, height }, { 33, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28670), { 0, 6, height },
+                        { 33, 26, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -610,21 +638,25 @@ static void steeplechase_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28667, { 0, 6, height }, { 33, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28667), { 0, 6, height },
+                        { 33, 26, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28670, { 0, 6, height }, { 33, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28670), { 0, 6, height },
+                        { 33, 26, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28666, { 0, 0, height }, { 33, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28666), { 0, 0, height },
+                        { 33, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28671, { 0, 0, height }, { 33, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28671), { 0, 0, height },
+                        { 33, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK_ALT, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -641,25 +673,29 @@ static void steeplechase_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28668, { 0, 6, height }, { 33, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28668), { 0, 6, height },
+                        { 33, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28669, { 0, 6, height }, { 33, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28669), { 0, 6, height },
+                        { 33, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK_ALT, 4, 0, height - 2, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28665, { 0, 6, height }, { 33, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28665), { 0, 6, height },
+                        { 33, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28672, { 0, 6, height }, { 33, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28672), { 0, 6, height },
+                        { 33, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK_ALT, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -692,25 +728,29 @@ static void steeplechase_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28661, { 0, 6, height }, { 33, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28661), { 0, 6, height },
+                        { 33, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28676, { 0, 6, height }, { 33, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28676), { 0, 6, height },
+                        { 33, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK_ALT, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28664, { 0, 6, height }, { 33, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28664), { 0, 6, height },
+                        { 33, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28673, { 0, 6, height }, { 33, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28673), { 0, 6, height },
+                        { 33, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK_ALT, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -728,23 +768,27 @@ static void steeplechase_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28662, { 0, 6, height }, { 33, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28662), { 0, 6, height },
+                        { 33, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK, 8, 0, height - 2, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28675, { 0, 6, height }, { 33, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28675), { 0, 6, height },
+                        { 33, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK_ALT, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28663, { 0, 0, height }, { 33, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28663), { 0, 0, height },
+                        { 33, 26, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28674, { 0, 0, height }, { 33, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28674), { 0, 0, height },
+                        { 33, 26, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -759,21 +803,25 @@ static void steeplechase_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28663, { 0, 0, height }, { 33, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28663), { 0, 0, height },
+                        { 33, 26, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28674, { 0, 0, height }, { 33, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28674), { 0, 0, height },
+                        { 33, 26, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28662, { 0, 6, height }, { 33, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28662), { 0, 6, height },
+                        { 33, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK, 8, 0, height - 2, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28675, { 0, 6, height }, { 33, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28675), { 0, 6, height },
+                        { 33, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK_ALT, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -790,25 +838,29 @@ static void steeplechase_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28664, { 0, 6, height }, { 33, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28664), { 0, 6, height },
+                        { 33, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28673, { 0, 6, height }, { 33, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28673), { 0, 6, height },
+                        { 33, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK_ALT, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28661, { 0, 6, height }, { 33, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28661), { 0, 6, height },
+                        { 33, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28676, { 0, 6, height }, { 33, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28676), { 0, 6, height },
+                        { 33, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK_ALT, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -841,25 +893,29 @@ static void steeplechase_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28682, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28682), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK, 4, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28685, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28685), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK_ALT, 4, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28688, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28688), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28679, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28679), { 0, 6, height },
+                        { 32, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK_ALT, 4, 0, height - 3, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -880,19 +936,23 @@ static void steeplechase_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28681, { 16, 0, height }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28681), { 16, 0, height },
+                        { 16, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28684, { 0, 0, height }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28684), { 0, 0, height },
+                        { 16, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28687, { 0, 16, height }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28687), { 0, 16, height },
+                        { 16, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28678, { 16, 16, height }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28678), { 16, 16, height },
+                        { 16, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -904,25 +964,29 @@ static void steeplechase_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28680, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28680), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK_ALT, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28683, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28683), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK, 4, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28686, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28686), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK_ALT, 4, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28677, { 6, 0, height }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28677), { 6, 0, height },
+                        { 20, 32, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK, 4, 0, height - 3, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -962,13 +1026,13 @@ static void steeplechase_track_brakes(
         case 0:
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 28635, { 0, 6, height }, { 32, 20, 3 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28635), { 0, 6, height }, { 32, 20, 3 });
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_STICK, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 28636, { 0, 6, height }, { 32, 20, 3 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28636), { 0, 6, height }, { 32, 20, 3 });
             metal_a_supports_paint_setup(
                 session, METAL_SUPPORTS_STICK_ALT, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -991,29 +1055,29 @@ static void steeplechase_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28725, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28725), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28729, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28729), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK_ALT, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28733, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28733), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28737, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28737), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK_ALT, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -1031,23 +1095,23 @@ static void steeplechase_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28726, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28726), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28730, { 0, 0, height }, { 34, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28730), { 0, 0, height },
+                        { 34, 16, 3 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28734, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28734), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28738, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28738), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1062,23 +1126,23 @@ static void steeplechase_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28727, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28727), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28731, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28731), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28735, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28735), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28739, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28739), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1096,29 +1160,29 @@ static void steeplechase_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28728, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28728), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28732, { 0, 0, height }, { 16, 18, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28732), { 0, 0, height },
+                        { 16, 18, 3 }, { 0, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK_ALT, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28736, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28736), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28740, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28740), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK_ALT, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -1145,29 +1209,29 @@ static void steeplechase_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28709, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28709), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28713, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28713), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK_ALT, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28717, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28717), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28721, { 0, 0, height }, { 32, 20, 3 },
-                        { 0, 6, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28721), { 0, 0, height },
+                        { 32, 20, 3 }, { 0, 6, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK_ALT, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -1185,23 +1249,23 @@ static void steeplechase_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28710, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28710), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28714, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28714), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28718, { 0, 0, height }, { 34, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28718), { 0, 0, height },
+                        { 34, 16, 3 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28722, { 0, 0, height }, { 32, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28722), { 0, 0, height },
+                        { 32, 16, 3 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1216,23 +1280,23 @@ static void steeplechase_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28711, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28711), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28715, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28715), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28719, { 0, 0, height }, { 28, 28, 3 },
-                        { 4, 4, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28719), { 0, 0, height },
+                        { 28, 28, 3 }, { 4, 4, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28723, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28723), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1250,29 +1314,29 @@ static void steeplechase_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28712, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28712), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28716, { 0, 0, height }, { 16, 16, 3 },
-                        { 0, 0, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28716), { 0, 0, height },
+                        { 16, 16, 3 }, { 0, 0, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK_ALT, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28720, { 0, 0, height }, { 16, 18, 3 },
-                        { 0, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28720), { 0, 0, height },
+                        { 16, 18, 3 }, { 0, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28724, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28724), { 0, 0, height },
+                        { 16, 16, 3 }, { 16, 16, height });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK_ALT, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -1319,8 +1383,8 @@ static void steeplechase_track_diag_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28760, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28760), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -1330,8 +1394,8 @@ static void steeplechase_track_diag_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28744, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28744), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -1346,8 +1410,8 @@ static void steeplechase_track_diag_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28757, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28757), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -1357,8 +1421,8 @@ static void steeplechase_track_diag_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28741, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28741), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -1373,8 +1437,8 @@ static void steeplechase_track_diag_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28759, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28759), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -1384,8 +1448,8 @@ static void steeplechase_track_diag_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28743, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28743), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -1404,8 +1468,8 @@ static void steeplechase_track_diag_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28758, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28758), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_STICK_ALT, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -1429,8 +1493,8 @@ static void steeplechase_track_diag_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28742, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28742), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_a_supports_paint_setup(
                             session, METAL_SUPPORTS_STICK_ALT, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -1465,8 +1529,8 @@ static void steeplechase_track_diag_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28772, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28772), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -1476,8 +1540,8 @@ static void steeplechase_track_diag_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28756, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28756), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -1492,8 +1556,8 @@ static void steeplechase_track_diag_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28769, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28769), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -1503,8 +1567,8 @@ static void steeplechase_track_diag_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28753, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28753), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -1519,8 +1583,8 @@ static void steeplechase_track_diag_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28771, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28771), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -1530,8 +1594,8 @@ static void steeplechase_track_diag_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28755, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28755), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -1550,8 +1614,8 @@ static void steeplechase_track_diag_25_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28770, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28770), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_STICK_ALT, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -1575,8 +1639,8 @@ static void steeplechase_track_diag_25_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28754, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28754), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_STICK_ALT, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -1611,8 +1675,8 @@ static void steeplechase_track_diag_flat_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28764, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28764), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -1622,8 +1686,8 @@ static void steeplechase_track_diag_flat_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28748, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28748), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -1638,8 +1702,8 @@ static void steeplechase_track_diag_flat_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28761, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28761), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -1649,8 +1713,8 @@ static void steeplechase_track_diag_flat_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28745, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28745), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -1665,8 +1729,8 @@ static void steeplechase_track_diag_flat_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28763, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28763), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -1676,8 +1740,8 @@ static void steeplechase_track_diag_flat_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28747, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28747), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -1696,8 +1760,8 @@ static void steeplechase_track_diag_flat_to_25_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28762, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28762), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_STICK_ALT, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -1721,8 +1785,8 @@ static void steeplechase_track_diag_flat_to_25_deg_up(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28746, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28746), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_STICK_ALT, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -1757,8 +1821,8 @@ static void steeplechase_track_diag_25_deg_up_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28768, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28768), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -1768,8 +1832,8 @@ static void steeplechase_track_diag_25_deg_up_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28752, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28752), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -1784,8 +1848,8 @@ static void steeplechase_track_diag_25_deg_up_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28765, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28765), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -1795,8 +1859,8 @@ static void steeplechase_track_diag_25_deg_up_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28749, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28749), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -1811,8 +1875,8 @@ static void steeplechase_track_diag_25_deg_up_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28767, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28767), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -1822,8 +1886,8 @@ static void steeplechase_track_diag_25_deg_up_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28751, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28751), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -1842,8 +1906,8 @@ static void steeplechase_track_diag_25_deg_up_to_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28766, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28766), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_STICK_ALT, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -1867,8 +1931,8 @@ static void steeplechase_track_diag_25_deg_up_to_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28750, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28750), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_STICK_ALT, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -1903,8 +1967,8 @@ static void steeplechase_track_diag_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28770, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28770), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -1914,8 +1978,8 @@ static void steeplechase_track_diag_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28754, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28754), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -1930,8 +1994,8 @@ static void steeplechase_track_diag_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28771, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28771), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -1941,8 +2005,8 @@ static void steeplechase_track_diag_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28755, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28755), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -1957,8 +2021,8 @@ static void steeplechase_track_diag_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28769, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28769), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -1968,8 +2032,8 @@ static void steeplechase_track_diag_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28753, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28753), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -1988,8 +2052,8 @@ static void steeplechase_track_diag_25_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28772, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28772), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_STICK_ALT, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -2013,8 +2077,8 @@ static void steeplechase_track_diag_25_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28756, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28756), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_STICK_ALT, 0, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -2049,8 +2113,8 @@ static void steeplechase_track_diag_flat_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28766, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28766), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -2060,8 +2124,8 @@ static void steeplechase_track_diag_flat_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28750, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28750), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -2075,8 +2139,8 @@ static void steeplechase_track_diag_flat_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28767, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28767), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -2086,8 +2150,8 @@ static void steeplechase_track_diag_flat_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28751, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28751), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -2101,8 +2165,8 @@ static void steeplechase_track_diag_flat_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28765, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28765), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -2112,8 +2176,8 @@ static void steeplechase_track_diag_flat_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28749, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28749), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -2131,8 +2195,8 @@ static void steeplechase_track_diag_flat_to_25_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28768, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28768), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_STICK_ALT, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -2156,8 +2220,8 @@ static void steeplechase_track_diag_flat_to_25_deg_down(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28752, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28752), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_STICK_ALT, 0, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -2193,8 +2257,8 @@ static void steeplechase_track_diag_25_deg_down_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28762, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28762), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -2204,8 +2268,8 @@ static void steeplechase_track_diag_25_deg_down_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28746, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28746), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -2220,8 +2284,8 @@ static void steeplechase_track_diag_25_deg_down_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28763, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28763), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -2231,8 +2295,8 @@ static void steeplechase_track_diag_25_deg_down_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28747, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28747), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -2247,8 +2311,8 @@ static void steeplechase_track_diag_25_deg_down_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28761, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28761), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -2258,8 +2322,8 @@ static void steeplechase_track_diag_25_deg_down_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28745, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28745), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         break;
                 }
             }
@@ -2278,8 +2342,8 @@ static void steeplechase_track_diag_25_deg_down_to_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28764, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28764), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_STICK_ALT, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -2303,8 +2367,8 @@ static void steeplechase_track_diag_25_deg_down_to_flat(
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 28748, { -16, -16, height }, { 32, 32, 3 },
-                            { -16, -16, height });
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28748), { -16, -16, height },
+                            { 32, 32, 3 }, { -16, -16, height });
                         metal_b_supports_paint_setup(
                             session, METAL_SUPPORTS_STICK_ALT, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -2335,13 +2399,13 @@ static void steeplechase_track_block_brakes(
         case 0:
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 28635, { 0, 6, height }, { 32, 20, 3 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28635), { 0, 6, height }, { 32, 20, 3 });
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_STICK, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 28636, { 0, 6, height }, { 32, 20, 3 });
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(28636), { 0, 6, height }, { 32, 20, 3 });
             metal_a_supports_paint_setup(
                 session, METAL_SUPPORTS_STICK_ALT, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;

--- a/src/openrct2/ride/coaster/SuspendedSwingingCoaster.cpp
+++ b/src/openrct2/ride/coaster/SuspendedSwingingCoaster.cpp
@@ -30,14 +30,14 @@ static void suspended_swinging_rc_track_flat(
             case 0:
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25963, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 29 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25963), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 29 });
                 break;
             case 1:
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25964, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 29 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25964), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 29 });
                 break;
         }
     }
@@ -48,14 +48,14 @@ static void suspended_swinging_rc_track_flat(
             case 0:
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25961, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 29 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25961), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 29 });
                 break;
             case 1:
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25962, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 29 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25962), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 29 });
                 break;
         }
     }
@@ -84,13 +84,13 @@ static void suspended_swinging_rc_track_station(
     };
 
     PaintAddImageAsParentRotated(
-        session, direction, imageIds[direction][0] | session.TrackColours[SCHEME_MISC], { 0, 0, height }, { 32, 28, 1 },
-        { 0, 2, height });
+        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][0]), { 0, 0, height },
+        { 32, 28, 1 }, { 0, 2, height });
     PaintAddImageAsParentRotated(
-        session, direction, imageIds[direction][1] | session.TrackColours[SCHEME_TRACK], { 0, 0, height + 29 }, { 32, 20, 3 },
-        { 0, 6, height + 29 });
+        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][1]), { 0, 0, height + 29 },
+        { 32, 20, 3 }, { 0, 6, height + 29 });
     PaintAddImageAsChildRotated(
-        session, direction, imageIds[direction][2] | session.TrackColours[SCHEME_SUPPORTS], { 0, 6, height + 29 },
+        session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(imageIds[direction][2]), { 0, 6, height + 29 },
         { 32, 20, 3 }, { 0, 6, height + 29 });
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], 0);
     track_paint_util_draw_station_inverted(session, ride, direction, height, trackElement, STATION_VARIANT_TALL);
@@ -110,23 +110,23 @@ static void suspended_swinging_rc_track_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26001, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 45 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26001), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 45 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26002, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 45 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26002), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 45 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26003, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 45 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26003), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 45 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26004, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 45 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26004), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 45 });
                 break;
         }
     }
@@ -136,23 +136,23 @@ static void suspended_swinging_rc_track_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25973, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 45 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25973), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 45 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25974, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 45 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25974), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 45 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25975, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 45 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25975), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 45 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25976, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 45 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25976), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 45 });
                 break;
         }
     }
@@ -202,22 +202,22 @@ static void suspended_swinging_rc_track_60_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25989, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25989), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 93 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25990, { 0, 0, height + 29 }, { 32, 2, 81 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25990), { 0, 0, height + 29 }, { 32, 2, 81 },
                 { 0, 4, height + 11 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25991, { 0, 0, height + 29 }, { 32, 2, 81 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25991), { 0, 0, height + 29 }, { 32, 2, 81 },
                 { 0, 4, height + 11 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25992, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25992), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 93 });
             break;
     }
@@ -245,23 +245,23 @@ static void suspended_swinging_rc_track_flat_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25993, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25993), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25994, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25994), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25995, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25995), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25996, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25996), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
         }
     }
@@ -271,23 +271,23 @@ static void suspended_swinging_rc_track_flat_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25965, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25965), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25966, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25966), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25967, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25967), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25968, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25968), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
         }
     }
@@ -337,28 +337,28 @@ static void suspended_swinging_rc_track_25_deg_up_to_60_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25977, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25977), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 61 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25981, { 0, 0, height + 29 }, { 32, 10, 49 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25981), { 0, 0, height + 29 }, { 32, 10, 49 },
                 { 0, 10, height + 11 });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25978, { 0, 0, height + 29 }, { 32, 2, 49 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25978), { 0, 0, height + 29 }, { 32, 2, 49 },
                 { 0, 4, height + 11 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25982, { 0, 0, height + 29 }, { 32, 10, 49 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25982), { 0, 0, height + 29 }, { 32, 10, 49 },
                 { 0, 10, height + 11 });
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25979, { 0, 0, height + 29 }, { 32, 2, 49 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25979), { 0, 0, height + 29 }, { 32, 2, 49 },
                 { 0, 4, height + 11 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25980, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25980), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 61 });
             break;
     }
@@ -386,29 +386,29 @@ static void suspended_swinging_rc_track_60_deg_up_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25983, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 61 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25983), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 61 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25987, { 0, 0, height + 29 }, { 32, 10, 49 },
-                    { 0, 10, height + 11 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25987), { 0, 0, height + 29 },
+                    { 32, 10, 49 }, { 0, 10, height + 11 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26090, { 0, 0, height + 29 }, { 32, 2, 49 },
-                    { 0, 4, height + 11 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26090), { 0, 0, height + 29 },
+                    { 32, 2, 49 }, { 0, 4, height + 11 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25988, { 0, 0, height + 29 }, { 32, 10, 49 },
-                    { 0, 10, height + 11 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25988), { 0, 0, height + 29 },
+                    { 32, 10, 49 }, { 0, 10, height + 11 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25985, { 0, 0, height + 29 }, { 32, 2, 49 },
-                    { 0, 4, height + 11 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25985), { 0, 0, height + 29 },
+                    { 32, 2, 49 }, { 0, 4, height + 11 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25986, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 61 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25986), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 61 });
                 break;
         }
     }
@@ -418,29 +418,29 @@ static void suspended_swinging_rc_track_60_deg_up_to_25_deg_up(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25983, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 61 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25983), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 61 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25987, { 0, 0, height + 29 }, { 32, 10, 49 },
-                    { 0, 10, height + 11 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25987), { 0, 0, height + 29 },
+                    { 32, 10, 49 }, { 0, 10, height + 11 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25984, { 0, 0, height + 29 }, { 32, 2, 49 },
-                    { 0, 4, height + 11 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25984), { 0, 0, height + 29 },
+                    { 32, 2, 49 }, { 0, 4, height + 11 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25988, { 0, 0, height + 29 }, { 32, 10, 49 },
-                    { 0, 10, height + 11 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25988), { 0, 0, height + 29 },
+                    { 32, 10, 49 }, { 0, 10, height + 11 });
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25985, { 0, 0, height + 29 }, { 32, 2, 49 },
-                    { 0, 4, height + 11 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25985), { 0, 0, height + 29 },
+                    { 32, 2, 49 }, { 0, 4, height + 11 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25986, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 61 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25986), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 61 });
                 break;
         }
     }
@@ -492,23 +492,23 @@ static void suspended_swinging_rc_track_25_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25997, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25997), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25998, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25998), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25999, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25999), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 26000, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26000), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
         }
     }
@@ -518,23 +518,23 @@ static void suspended_swinging_rc_track_25_deg_up_to_flat(
         {
             case 0:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25969, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25969), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25970, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25970), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25971, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25971), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK] | 25972, { 0, 0, height + 29 }, { 32, 20, 3 },
-                    { 0, 6, height + 37 });
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25972), { 0, 0, height + 29 },
+                    { 32, 20, 3 }, { 0, 6, height + 37 });
                 break;
         }
     }
@@ -635,23 +635,23 @@ static void suspended_swinging_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26014, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26014), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26019, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26019), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26024, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26024), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26009, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26009), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
             }
 
@@ -675,21 +675,23 @@ static void suspended_swinging_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26013, { 0, 0, height + 29 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26013), { 0, 0, height + 29 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26018, { 0, 0, height + 29 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26018), { 0, 0, height + 29 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26023, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26023), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26008, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26008), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -704,22 +706,23 @@ static void suspended_swinging_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26012, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26012), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 16, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26017, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26017), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 16, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26022, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26022), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 0, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26007, { 0, 0, height + 29 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26007), { 0, 0, height + 29 },
+                        { 16, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -734,21 +737,23 @@ static void suspended_swinging_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26011, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 16, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26011), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 16, 0, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26016, { 0, 0, height + 29 }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26016), { 0, 0, height + 29 },
+                        { 16, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26021, { 0, 0, height + 29 }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26021), { 0, 0, height + 29 },
+                        { 16, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26006, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 16, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26006), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 16, 0, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -763,23 +768,23 @@ static void suspended_swinging_rc_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26010, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26010), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26015, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26015), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26020, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26020), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26005, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26005), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 29 });
                     break;
             }
 
@@ -824,19 +829,23 @@ static void suspended_swinging_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26097, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26097), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26102, { 0, 6, height + 29 }, { 32, 20, 11 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26102), { 0, 6, height + 29 },
+                        { 32, 20, 11 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26107, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26107), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26112, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26112), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
             }
 
@@ -860,19 +869,23 @@ static void suspended_swinging_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26098, { 0, 0, height + 29 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26098), { 0, 0, height + 29 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26103, { 0, 0, height + 29 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26103), { 0, 0, height + 29 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26108, { 0, 16, height + 29 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26108), { 0, 16, height + 29 },
+                        { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26113, { 0, 16, height + 29 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26113), { 0, 16, height + 29 },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -887,19 +900,23 @@ static void suspended_swinging_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26099, { 0, 16, height + 29 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26099), { 0, 16, height + 29 },
+                        { 16, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26104, { 16, 16, height + 29 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26104), { 16, 16, height + 29 },
+                        { 16, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26109, { 16, 0, height + 29 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26109), { 16, 0, height + 29 },
+                        { 16, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26114, { 0, 0, height + 29 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26114), { 0, 0, height + 29 },
+                        { 16, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -914,20 +931,23 @@ static void suspended_swinging_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26100, { 16, 0, height + 29 }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26100), { 16, 0, height + 29 },
+                        { 16, 32, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26105, { 0, 0, height + 29 }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26105), { 0, 0, height + 29 },
+                        { 16, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26110, { 0, 0, height + 29 }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26110), { 0, 0, height + 29 },
+                        { 16, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26115, { 16, 0, height + 29 }, { 16, 32, 3 },
-                        { 16, 0, height + 37 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26115), { 16, 0, height + 29 },
+                        { 16, 32, 3 }, { 16, 0, height + 37 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -942,19 +962,23 @@ static void suspended_swinging_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26101, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26101), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26106, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26106), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26111, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26111), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26116, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26116), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
             }
 
@@ -990,19 +1014,23 @@ static void suspended_swinging_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26077, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26077), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26082, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26082), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26087, { 0, 6, height + 29 }, { 32, 20, 11 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26087), { 0, 6, height + 29 },
+                        { 32, 20, 11 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26092, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26092), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
             }
 
@@ -1026,19 +1054,23 @@ static void suspended_swinging_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26078, { 0, 16, height + 29 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26078), { 0, 16, height + 29 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26083, { 0, 16, height + 29 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26083), { 0, 16, height + 29 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26088, { 0, 0, height + 29 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26088), { 0, 0, height + 29 },
+                        { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26093, { 0, 0, height + 29 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26093), { 0, 0, height + 29 },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1053,19 +1085,23 @@ static void suspended_swinging_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26079, { 0, 0, height + 29 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26079), { 0, 0, height + 29 },
+                        { 16, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26084, { 16, 0, height + 29 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26084), { 16, 0, height + 29 },
+                        { 16, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26089, { 16, 16, height + 29 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26089), { 16, 16, height + 29 },
+                        { 16, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26094, { 0, 16, height + 29 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26094), { 0, 16, height + 29 },
+                        { 16, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1080,20 +1116,23 @@ static void suspended_swinging_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26080, { 16, 0, height + 29 }, { 16, 32, 3 },
-                        { 16, 0, height + 37 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26080), { 16, 0, height + 29 },
+                        { 16, 32, 3 }, { 16, 0, height + 37 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26085, { 0, 0, height + 29 }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26085), { 0, 0, height + 29 },
+                        { 16, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26090, { 0, 0, height + 29 }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26090), { 0, 0, height + 29 },
+                        { 16, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26095, { 16, 0, height + 29 }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26095), { 16, 0, height + 29 },
+                        { 16, 32, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1108,19 +1147,23 @@ static void suspended_swinging_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26081, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26081), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26086, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26086), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26091, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26091), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26096, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26096), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
             }
 
@@ -1176,19 +1219,23 @@ static void suspended_swinging_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26139, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26139), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26146, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26146), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26142, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26142), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26143, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26143), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
             }
 
@@ -1208,19 +1255,23 @@ static void suspended_swinging_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26140, { 0, 0, height + 29 }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26140), { 0, 0, height + 29 },
+                        { 32, 26, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26145, { 0, 0, height + 29 }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26145), { 0, 0, height + 29 },
+                        { 32, 26, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26141, { 0, 6, height + 29 }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26141), { 0, 6, height + 29 },
+                        { 32, 26, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26144, { 0, 6, height + 29 }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26144), { 0, 6, height + 29 },
+                        { 32, 26, 3 });
                     break;
             }
 
@@ -1248,19 +1299,23 @@ static void suspended_swinging_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26141, { 0, 6, height + 29 }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26141), { 0, 6, height + 29 },
+                        { 32, 26, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26144, { 0, 6, height + 29 }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26144), { 0, 6, height + 29 },
+                        { 32, 26, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26140, { 0, 0, height + 29 }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26140), { 0, 0, height + 29 },
+                        { 32, 26, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26145, { 0, 0, height + 29 }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26145), { 0, 0, height + 29 },
+                        { 32, 26, 3 });
                     break;
             }
 
@@ -1288,19 +1343,23 @@ static void suspended_swinging_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26142, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26142), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26143, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26143), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26139, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26139), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26146, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26146), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
             }
 
@@ -1335,19 +1394,23 @@ static void suspended_swinging_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26135, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26135), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26150, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26150), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26138, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26138), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26147, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26147), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
             }
 
@@ -1367,19 +1430,23 @@ static void suspended_swinging_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26136, { 0, 6, height + 29 }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26136), { 0, 6, height + 29 },
+                        { 32, 26, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26149, { 0, 6, height + 29 }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26149), { 0, 6, height + 29 },
+                        { 32, 26, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26137, { 0, 0, height + 29 }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26137), { 0, 0, height + 29 },
+                        { 32, 26, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26148, { 0, 0, height + 29 }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26148), { 0, 0, height + 29 },
+                        { 32, 26, 3 });
                     break;
             }
 
@@ -1407,19 +1474,23 @@ static void suspended_swinging_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26137, { 0, 0, height + 29 }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26137), { 0, 0, height + 29 },
+                        { 32, 26, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26148, { 0, 0, height + 29 }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26148), { 0, 0, height + 29 },
+                        { 32, 26, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26136, { 0, 6, height + 29 }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26136), { 0, 6, height + 29 },
+                        { 32, 26, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26149, { 0, 6, height + 29 }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26149), { 0, 6, height + 29 },
+                        { 32, 26, 3 });
                     break;
             }
 
@@ -1447,19 +1518,23 @@ static void suspended_swinging_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26138, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26138), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26147, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26147), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26135, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26135), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26150, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26150), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
             }
 
@@ -1494,23 +1569,23 @@ static void suspended_swinging_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26070, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26070), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26073, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26073), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26076, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26076), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26067, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26067), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
             }
 
@@ -1534,22 +1609,23 @@ static void suspended_swinging_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26069, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26069), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 0, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26072, { 0, 0, height + 29 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26072), { 0, 0, height + 29 },
+                        { 16, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26075, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26075), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 16, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26066, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26066), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 16, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1561,23 +1637,23 @@ static void suspended_swinging_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26068, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26068), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26071, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26071), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26074, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26074), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26065, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26065), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 29 });
                     break;
             }
 
@@ -1622,19 +1698,23 @@ static void suspended_swinging_rc_track_left_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26130, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26130), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26132, { 0, 6, height + 29 }, { 32, 20, 11 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26132), { 0, 6, height + 29 },
+                        { 32, 20, 11 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26134, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26134), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26128, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26128), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
             }
 
@@ -1661,19 +1741,23 @@ static void suspended_swinging_rc_track_left_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26129, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26129), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26131, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26131), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26133, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26133), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26127, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26127), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
             }
 
@@ -1709,19 +1793,23 @@ static void suspended_swinging_rc_track_right_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26119, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26119), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26121, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26121), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26123, { 0, 6, height + 29 }, { 32, 20, 11 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26123), { 0, 6, height + 29 },
+                        { 32, 20, 11 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26125, { 0, 6, height + 29 }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26125), { 0, 6, height + 29 },
+                        { 32, 20, 3 });
                     break;
             }
 
@@ -1748,19 +1836,23 @@ static void suspended_swinging_rc_track_right_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26120, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26120), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26122, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26122), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26124, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26124), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26126, { 6, 0, height + 29 }, { 20, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26126), { 6, 0, height + 29 },
+                        { 20, 32, 3 });
                     break;
             }
 
@@ -1814,13 +1906,13 @@ static void suspended_swinging_rc_track_brakes(
         case 0:
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26117, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26117), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
         case 1:
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26118, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26118), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
     }
@@ -1848,23 +1940,23 @@ static void suspended_swinging_rc_track_left_quarter_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26054, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26054), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 35 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26059, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26059), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 35 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26064, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26064), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 35 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26049, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26049), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 35 });
                     break;
             }
 
@@ -1888,23 +1980,23 @@ static void suspended_swinging_rc_track_left_quarter_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26053, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26053), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 0, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26058, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26058), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 0, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26063, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26063), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26048, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26048), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 43 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1919,23 +2011,23 @@ static void suspended_swinging_rc_track_left_quarter_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26052, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26052), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 16, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26057, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26057), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 16, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26062, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26062), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 0, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26047, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26047), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 0, height + 43 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1950,23 +2042,23 @@ static void suspended_swinging_rc_track_left_quarter_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26051, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 16, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26051), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 16, 0, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26056, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26056), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 0, 0, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26061, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26061), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 0, 0, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26046, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 16, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26046), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 16, 0, height + 43 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1981,23 +2073,23 @@ static void suspended_swinging_rc_track_left_quarter_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26050, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26050), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26055, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26055), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26060, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26060), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26045, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26045), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 43 });
                     break;
             }
 
@@ -2033,23 +2125,23 @@ static void suspended_swinging_rc_track_right_quarter_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26025, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26025), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 35 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26030, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26030), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 35 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26035, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26035), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 35 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26040, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26040), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 35 });
                     break;
             }
 
@@ -2073,23 +2165,23 @@ static void suspended_swinging_rc_track_right_quarter_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26026, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26026), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26031, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26031), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26036, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26036), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 0, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26041, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26041), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 0, height + 43 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2104,23 +2196,23 @@ static void suspended_swinging_rc_track_right_quarter_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26027, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26027), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 0, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26032, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26032), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 0, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26037, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26037), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 16, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26042, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26042), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 16, height + 43 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2135,23 +2227,23 @@ static void suspended_swinging_rc_track_right_quarter_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26028, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 16, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26028), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 16, 0, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26033, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26033), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 0, 0, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26038, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26038), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 0, 0, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26043, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 16, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26043), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 16, 0, height + 43 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2166,23 +2258,23 @@ static void suspended_swinging_rc_track_right_quarter_helix_large_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26029, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26029), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26034, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26034), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26039, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26039), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26044, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26044), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 43 });
                     break;
             }
 
@@ -2218,23 +2310,23 @@ static void suspended_swinging_rc_track_left_quarter_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26034, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26034), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26039, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26039), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26044, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26044), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26029, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26029), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 43 });
                     break;
             }
 
@@ -2258,23 +2350,23 @@ static void suspended_swinging_rc_track_left_quarter_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26033, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26033), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 0, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26038, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26038), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 0, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26043, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26043), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26028, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26028), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 43 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2289,23 +2381,23 @@ static void suspended_swinging_rc_track_left_quarter_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26032, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26032), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 16, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26037, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26037), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 16, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26042, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26042), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 0, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26027, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26027), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 0, height + 43 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2320,23 +2412,23 @@ static void suspended_swinging_rc_track_left_quarter_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26031, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 16, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26031), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 16, 0, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26036, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26036), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 0, 0, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26041, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26041), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 0, 0, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26026, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 16, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26026), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 16, 0, height + 43 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2351,23 +2443,23 @@ static void suspended_swinging_rc_track_left_quarter_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26030, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26030), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 35 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26035, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26035), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 35 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26040, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26040), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 35 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26025, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26025), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 35 });
                     break;
             }
 
@@ -2403,23 +2495,23 @@ static void suspended_swinging_rc_track_right_quarter_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26045, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26045), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26050, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26050), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26055, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26055), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26060, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26060), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 43 });
                     break;
             }
 
@@ -2443,23 +2535,23 @@ static void suspended_swinging_rc_track_right_quarter_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26046, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26046), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26051, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26051), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26056, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26056), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 0, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26061, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26061), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 0, height + 43 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2474,23 +2566,23 @@ static void suspended_swinging_rc_track_right_quarter_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26047, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26047), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 0, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26052, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26052), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 0, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26057, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26057), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 16, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26062, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 16, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26062), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 16, height + 43 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2505,23 +2597,23 @@ static void suspended_swinging_rc_track_right_quarter_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26048, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 16, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26048), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 16, 0, height + 43 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26053, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26053), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 0, 0, height + 43 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26058, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 0, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26058), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 0, 0, height + 43 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26063, { 0, 0, height + 29 }, { 16, 32, 3 },
-                        { 16, 0, height + 43 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26063), { 0, 0, height + 29 },
+                        { 16, 32, 3 }, { 16, 0, height + 43 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2536,23 +2628,23 @@ static void suspended_swinging_rc_track_right_quarter_helix_large_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26049, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26049), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 35 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26054, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26054), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 35 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26059, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26059), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 35 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26064, { 0, 0, height + 29 }, { 20, 32, 3 },
-                        { 6, 0, height + 35 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26064), { 0, 0, height + 29 },
+                        { 20, 32, 3 }, { 6, 0, height + 35 });
                     break;
             }
 
@@ -2588,23 +2680,23 @@ static void suspended_swinging_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26167, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26167), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26171, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26171), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26175, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26175), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26179, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26179), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
             }
 
@@ -2624,23 +2716,23 @@ static void suspended_swinging_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26168, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26168), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 0, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26172, { 0, 0, height + 29 }, { 34, 16, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26172), { 0, 0, height + 29 },
+                        { 34, 16, 3 }, { 0, 0, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26176, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26176), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26180, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26180), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2655,23 +2747,23 @@ static void suspended_swinging_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26169, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26169), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 16, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26173, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26173), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 16, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26177, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26177), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 0, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26181, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26181), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 0, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2689,23 +2781,23 @@ static void suspended_swinging_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26170, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26170), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 16, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26174, { 0, 0, height + 29 }, { 16, 18, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26174), { 0, 0, height + 29 },
+                        { 16, 18, 3 }, { 0, 16, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26178, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26178), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 0, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26182, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26182), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 0, height + 29 });
                     break;
             }
 
@@ -2751,23 +2843,23 @@ static void suspended_swinging_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26151, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26151), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26155, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26155), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26159, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26159), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26163, { 0, 0, height + 29 }, { 32, 20, 3 },
-                        { 0, 6, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26163), { 0, 0, height + 29 },
+                        { 32, 20, 3 }, { 0, 6, height + 29 });
                     break;
             }
 
@@ -2787,23 +2879,23 @@ static void suspended_swinging_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26152, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26152), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26156, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26156), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 16, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26160, { 0, 0, height + 29 }, { 34, 16, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26160), { 0, 0, height + 29 },
+                        { 34, 16, 3 }, { 0, 0, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26164, { 0, 0, height + 29 }, { 32, 16, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26164), { 0, 0, height + 29 },
+                        { 32, 16, 3 }, { 0, 0, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2818,23 +2910,23 @@ static void suspended_swinging_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26153, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26153), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 0, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26157, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26157), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 0, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26161, { 0, 0, height + 29 }, { 28, 28, 3 },
-                        { 4, 4, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26161), { 0, 0, height + 29 },
+                        { 28, 28, 3 }, { 4, 4, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26165, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26165), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 16, height + 29 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2852,23 +2944,23 @@ static void suspended_swinging_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26154, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26154), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 0, height + 29 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26158, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 0, 0, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26158), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 0, 0, height + 29 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26162, { 0, 0, height + 29 }, { 16, 18, 3 },
-                        { 0, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26162), { 0, 0, height + 29 },
+                        { 16, 18, 3 }, { 0, 16, height + 29 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26166, { 0, 0, height + 29 }, { 16, 16, 3 },
-                        { 16, 16, height + 29 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26166), { 0, 0, height + 29 },
+                        { 16, 16, 3 }, { 16, 16, height + 29 });
                     break;
             }
 
@@ -2934,7 +3026,7 @@ static void suspended_swinging_rc_track_diag_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26214, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26214), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 29 });
                         break;
                 }
@@ -2945,7 +3037,7 @@ static void suspended_swinging_rc_track_diag_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26186, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26186), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 29 });
                         break;
                 }
@@ -2961,7 +3053,7 @@ static void suspended_swinging_rc_track_diag_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26211, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26211), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 29 });
                         break;
                 }
@@ -2972,7 +3064,7 @@ static void suspended_swinging_rc_track_diag_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26183, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26183), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 29 });
                         break;
                 }
@@ -2988,7 +3080,7 @@ static void suspended_swinging_rc_track_diag_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26213, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26213), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 29 });
                         break;
                 }
@@ -2999,7 +3091,7 @@ static void suspended_swinging_rc_track_diag_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26185, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26185), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 29 });
                         break;
                 }
@@ -3015,7 +3107,7 @@ static void suspended_swinging_rc_track_diag_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26212, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26212), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 29 });
                         break;
                 }
@@ -3026,7 +3118,7 @@ static void suspended_swinging_rc_track_diag_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26184, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26184), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 29 });
                         break;
                 }
@@ -3073,7 +3165,7 @@ static void suspended_swinging_rc_track_diag_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26226, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26226), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -3084,7 +3176,7 @@ static void suspended_swinging_rc_track_diag_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26198, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26198), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -3100,7 +3192,7 @@ static void suspended_swinging_rc_track_diag_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26223, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26223), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -3111,7 +3203,7 @@ static void suspended_swinging_rc_track_diag_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26195, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26195), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -3127,7 +3219,7 @@ static void suspended_swinging_rc_track_diag_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26225, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26225), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -3138,7 +3230,7 @@ static void suspended_swinging_rc_track_diag_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26197, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26197), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -3154,7 +3246,7 @@ static void suspended_swinging_rc_track_diag_25_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26224, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26224), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -3165,7 +3257,7 @@ static void suspended_swinging_rc_track_diag_25_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26196, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26196), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -3210,7 +3302,7 @@ static void suspended_swinging_rc_track_diag_60_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26210, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26210), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 93 });
                     break;
             }
@@ -3223,7 +3315,7 @@ static void suspended_swinging_rc_track_diag_60_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26207, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26207), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 93 });
                     break;
             }
@@ -3236,7 +3328,7 @@ static void suspended_swinging_rc_track_diag_60_deg_up(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26209, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26209), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 93 });
                     break;
             }
@@ -3249,7 +3341,7 @@ static void suspended_swinging_rc_track_diag_60_deg_up(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26208, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26208), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -3295,7 +3387,7 @@ static void suspended_swinging_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26218, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26218), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -3306,7 +3398,7 @@ static void suspended_swinging_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26190, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26190), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -3322,7 +3414,7 @@ static void suspended_swinging_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26215, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26215), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -3333,7 +3425,7 @@ static void suspended_swinging_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26187, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26187), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -3349,7 +3441,7 @@ static void suspended_swinging_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26217, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26217), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -3360,7 +3452,7 @@ static void suspended_swinging_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26189, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26189), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -3376,7 +3468,7 @@ static void suspended_swinging_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26216, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26216), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -3387,7 +3479,7 @@ static void suspended_swinging_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26188, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26188), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -3432,7 +3524,7 @@ static void suspended_swinging_rc_track_diag_25_deg_up_to_60_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26202, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26202), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 61 });
                     break;
             }
@@ -3445,7 +3537,7 @@ static void suspended_swinging_rc_track_diag_25_deg_up_to_60_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26199, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26199), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 61 });
                     break;
             }
@@ -3458,7 +3550,7 @@ static void suspended_swinging_rc_track_diag_25_deg_up_to_60_deg_up(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26201, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26201), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 61 });
                     break;
             }
@@ -3471,7 +3563,7 @@ static void suspended_swinging_rc_track_diag_25_deg_up_to_60_deg_up(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26200, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26200), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 61 });
                     break;
             }
@@ -3515,7 +3607,7 @@ static void suspended_swinging_rc_track_diag_60_deg_up_to_25_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26206, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26206), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 61 });
                     break;
             }
@@ -3528,7 +3620,7 @@ static void suspended_swinging_rc_track_diag_60_deg_up_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26203, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26203), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 61 });
                     break;
             }
@@ -3541,7 +3633,7 @@ static void suspended_swinging_rc_track_diag_60_deg_up_to_25_deg_up(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26205, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26205), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 61 });
                     break;
             }
@@ -3554,7 +3646,7 @@ static void suspended_swinging_rc_track_diag_60_deg_up_to_25_deg_up(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26204, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26204), { -16, -16, height + 29 },
                         { 16, 16, 3 }, { 0, 0, height + 61 });
                     break;
             }
@@ -3600,7 +3692,7 @@ static void suspended_swinging_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26222, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26222), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -3611,7 +3703,7 @@ static void suspended_swinging_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26194, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26194), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -3627,7 +3719,7 @@ static void suspended_swinging_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26219, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26219), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -3638,7 +3730,7 @@ static void suspended_swinging_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26191, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26191), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -3654,7 +3746,7 @@ static void suspended_swinging_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26221, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26221), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -3665,7 +3757,7 @@ static void suspended_swinging_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26193, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26193), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -3681,7 +3773,7 @@ static void suspended_swinging_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26220, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26220), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -3692,7 +3784,7 @@ static void suspended_swinging_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26192, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26192), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -3739,7 +3831,7 @@ static void suspended_swinging_rc_track_diag_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26224, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26224), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -3750,7 +3842,7 @@ static void suspended_swinging_rc_track_diag_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26196, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26196), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -3766,7 +3858,7 @@ static void suspended_swinging_rc_track_diag_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26225, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26225), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -3777,7 +3869,7 @@ static void suspended_swinging_rc_track_diag_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26197, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26197), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -3793,7 +3885,7 @@ static void suspended_swinging_rc_track_diag_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26223, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26223), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -3804,7 +3896,7 @@ static void suspended_swinging_rc_track_diag_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26195, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26195), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -3820,7 +3912,7 @@ static void suspended_swinging_rc_track_diag_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26226, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26226), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -3831,7 +3923,7 @@ static void suspended_swinging_rc_track_diag_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26198, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26198), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 45 });
                         break;
                 }
@@ -3876,7 +3968,7 @@ static void suspended_swinging_rc_track_diag_60_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26208, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26208), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 29 });
                     break;
             }
@@ -3889,7 +3981,7 @@ static void suspended_swinging_rc_track_diag_60_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26209, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26209), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 93 });
                     break;
             }
@@ -3902,7 +3994,7 @@ static void suspended_swinging_rc_track_diag_60_deg_down(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26207, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26207), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 93 });
                     break;
             }
@@ -3915,7 +4007,7 @@ static void suspended_swinging_rc_track_diag_60_deg_down(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26210, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26210), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 93 });
                     break;
             }
@@ -3940,7 +4032,7 @@ static void suspended_swinging_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26220, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26220), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -3951,7 +4043,7 @@ static void suspended_swinging_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26192, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26192), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -3966,7 +4058,7 @@ static void suspended_swinging_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26221, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26221), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -3977,7 +4069,7 @@ static void suspended_swinging_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26193, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26193), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -3992,7 +4084,7 @@ static void suspended_swinging_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26219, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26219), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -4003,7 +4095,7 @@ static void suspended_swinging_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26191, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26191), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -4018,7 +4110,7 @@ static void suspended_swinging_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26222, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26222), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -4029,7 +4121,7 @@ static void suspended_swinging_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26194, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26194), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -4074,7 +4166,7 @@ static void suspended_swinging_rc_track_diag_25_deg_down_to_60_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26204, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26204), { -16, -16, height + 29 },
                         { 16, 16, 3 }, { 0, 0, height + 61 });
                     break;
             }
@@ -4087,7 +4179,7 @@ static void suspended_swinging_rc_track_diag_25_deg_down_to_60_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26205, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26205), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 61 });
                     break;
             }
@@ -4100,7 +4192,7 @@ static void suspended_swinging_rc_track_diag_25_deg_down_to_60_deg_down(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26203, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26203), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 61 });
                     break;
             }
@@ -4113,7 +4205,7 @@ static void suspended_swinging_rc_track_diag_25_deg_down_to_60_deg_down(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26206, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26206), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 61 });
                     break;
             }
@@ -4157,7 +4249,7 @@ static void suspended_swinging_rc_track_diag_60_deg_down_to_25_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26200, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26200), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 61 });
                     break;
             }
@@ -4170,7 +4262,7 @@ static void suspended_swinging_rc_track_diag_60_deg_down_to_25_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26201, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26201), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 61 });
                     break;
             }
@@ -4183,7 +4275,7 @@ static void suspended_swinging_rc_track_diag_60_deg_down_to_25_deg_down(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26199, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26199), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 61 });
                     break;
             }
@@ -4196,7 +4288,7 @@ static void suspended_swinging_rc_track_diag_60_deg_down_to_25_deg_down(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 26202, { -16, -16, height + 29 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26202), { -16, -16, height + 29 },
                         { 32, 32, 3 }, { -16, -16, height + 61 });
                     break;
             }
@@ -4242,7 +4334,7 @@ static void suspended_swinging_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26216, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26216), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -4253,7 +4345,7 @@ static void suspended_swinging_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26188, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26188), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -4269,7 +4361,7 @@ static void suspended_swinging_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26217, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26217), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -4280,7 +4372,7 @@ static void suspended_swinging_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26189, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26189), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -4296,7 +4388,7 @@ static void suspended_swinging_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26215, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26215), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -4307,7 +4399,7 @@ static void suspended_swinging_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26187, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26187), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -4323,7 +4415,7 @@ static void suspended_swinging_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26218, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26218), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -4334,7 +4426,7 @@ static void suspended_swinging_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK] | 26190, { -16, -16, height + 29 },
+                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26190), { -16, -16, height + 29 },
                             { 32, 32, 3 }, { -16, -16, height + 37 });
                         break;
                 }
@@ -4377,13 +4469,13 @@ static void suspended_swinging_rc_track_block_brakes(
         case 0:
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26117, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26117), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
         case 1:
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 26118, { 0, 0, height + 29 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(26118), { 0, 0, height + 29 }, { 32, 20, 3 },
                 { 0, 6, height + 29 });
             break;
     }

--- a/src/openrct2/ride/coaster/VirginiaReel.cpp
+++ b/src/openrct2/ride/coaster/VirginiaReel.cpp
@@ -232,7 +232,7 @@ static void paint_virginia_reel_track_flat(
         sprites = virginia_reel_track_pieces_flat_lift_hill;
     }
 
-    uint32_t imageId = sprites[direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(sprites[direction]);
     if (direction & 1)
     {
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 27, 32, 2 }, { 2, 0, height });
@@ -261,7 +261,7 @@ static void paint_virginia_reel_track_25_deg_up(
         sprites = virginia_reel_track_pieces_25_deg_up_lift_hill;
     }
 
-    uint32_t imageId = sprites[direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(sprites[direction]);
     paint_struct* ps;
 
     if (direction & 1)
@@ -313,7 +313,7 @@ static void paint_virginia_reel_track_flat_to_25_deg_up(
         sprites = virginia_reel_track_pieces_flat_to_25_deg_up_lift_hill;
     }
 
-    uint32_t imageId = sprites[direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(sprites[direction]);
     paint_struct* ps;
     switch (direction)
     {
@@ -360,7 +360,7 @@ static void paint_virginia_reel_track_25_deg_up_to_flat(
         sprites = virginia_reel_track_pieces_25_deg_up_to_flat_lift_hill;
     }
 
-    uint32_t imageId = sprites[direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(sprites[direction]);
     paint_struct* ps;
 
     if (direction & 1)
@@ -430,24 +430,24 @@ static void paint_virginia_reel_station(
     paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId;
+    ImageId imageId;
 
     if (direction == 0 || direction == 2)
     {
-        imageId = SPR_STATION_BASE_B_SW_NE | session.TrackColours[SCHEME_MISC];
+        imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_STATION_BASE_B_SW_NE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height - 2 }, { 32, 28, 2 }, { 0, 2, height });
 
-        imageId = SPR_VIRGINIA_REEL_FLAT_SW_NE | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_VIRGINIA_REEL_FLAT_SW_NE);
         PaintAddImageAsChild(session, imageId, { 0, 0, height }, { 32, 20, 2 }, { 0, 0, height });
 
         paint_util_push_tunnel_left(session, height, TUNNEL_SQUARE_FLAT);
     }
     else if (direction == 1 || direction == 3)
     {
-        imageId = SPR_STATION_BASE_B_NW_SE | session.TrackColours[SCHEME_MISC];
+        imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_STATION_BASE_B_NW_SE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height - 2 }, { 28, 32, 2 }, { 2, 0, height });
 
-        imageId = SPR_VIRGINIA_REEL_FLAT_NW_SE | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_VIRGINIA_REEL_FLAT_NW_SE);
         PaintAddImageAsChild(session, imageId, { 0, 0, height }, { 20, 32, 2 }, { 0, 0, height });
 
         paint_util_push_tunnel_right(session, height, TUNNEL_SQUARE_FLAT);

--- a/src/openrct2/ride/coaster/WildMouse.cpp
+++ b/src/openrct2/ride/coaster/WildMouse.cpp
@@ -176,7 +176,7 @@ static void wild_mouse_track_flat(
     };
 
     uint8_t isChained = trackElement.HasChain() ? 1 : 0;
-    uint32_t imageId = imageIds[direction][isChained] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][isChained]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
     if (track_paint_util_should_paint_supports(session.MapPosition))
     {
@@ -201,20 +201,21 @@ static void wild_mouse_track_station(
 
     int32_t trackType = trackElement.GetTrackType();
     PaintAddImageAsParentRotated(
-        session, direction, baseImageIds[direction] | session.TrackColours[SCHEME_MISC], { 0, 0, height - 2 }, { 32, 28, 2 },
-        { 0, 2, height });
+        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(baseImageIds[direction]), { 0, 0, height - 2 },
+        { 32, 28, 2 }, { 0, 2, height });
     if (trackType == TrackElemType::EndStation)
     {
         bool isClosed = trackElement.BlockBrakeClosed();
         PaintAddImageAsChildRotated(
-            session, direction, _wild_mouse_block_brakes_image_ids[direction][isClosed] | session.TrackColours[SCHEME_TRACK],
+            session, direction,
+            session.TrackColours[SCHEME_TRACK].WithIndex(_wild_mouse_block_brakes_image_ids[direction][isClosed]),
             { 0, 0, height }, { 32, 20, 2 }, { 0, 0, height });
     }
     else
     {
         PaintAddImageAsChildRotated(
-            session, direction, _wild_mouse_brakes_image_ids[direction] | session.TrackColours[SCHEME_TRACK], { 0, 0, height },
-            { 32, 20, 2 }, { 0, 0, height });
+            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(_wild_mouse_brakes_image_ids[direction]),
+            { 0, 0, height }, { 32, 20, 2 }, { 0, 0, height });
     }
     track_paint_util_draw_station_metal_supports(session, direction, height, session.TrackColours[SCHEME_SUPPORTS]);
     track_paint_util_draw_station(session, ride, direction, height, trackElement);
@@ -236,7 +237,7 @@ static void wild_mouse_track_25_deg_up(
     };
 
     uint8_t isChained = trackElement.HasChain() ? 1 : 0;
-    uint32_t imageId = imageIds[direction][isChained] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][isChained]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
     if (track_paint_util_should_paint_supports(session.MapPosition))
     {
@@ -268,7 +269,7 @@ static void wild_mouse_track_60_deg_up(
     };
 
     uint8_t isChained = trackElement.HasChain() ? 1 : 0;
-    uint32_t imageId = imageIds[direction][isChained] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][isChained]);
     if (direction == 0 || direction == 3)
     {
         PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
@@ -314,7 +315,7 @@ static void wild_mouse_track_flat_to_25_deg_up(
     };
 
     uint8_t isChained = trackElement.HasChain() ? 1 : 0;
-    uint32_t imageId = imageIds[direction][isChained] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][isChained]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
     if (track_paint_util_should_paint_supports(session.MapPosition))
     {
@@ -352,8 +353,8 @@ static void wild_mouse_track_25_deg_up_to_60_deg_up(
     };
 
     uint8_t isChained = trackElement.HasChain() ? 1 : 0;
-    uint32_t imageId = imageIds[direction][isChained] | session.TrackColours[SCHEME_TRACK];
-    uint32_t frontImageId = frontImageIds[direction][isChained] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][isChained]);
+    auto frontImageId = session.TrackColours[SCHEME_TRACK].WithIndex(frontImageIds[direction][isChained]);
     if (direction == 0 || direction == 3)
     {
         PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
@@ -399,8 +400,8 @@ static void wild_mouse_track_60_deg_up_to_25_deg_up(
     };
 
     uint8_t isChained = trackElement.HasChain() ? 1 : 0;
-    uint32_t imageId = imageIds[direction][isChained] | session.TrackColours[SCHEME_TRACK];
-    uint32_t frontImageId = frontImageIds[direction][isChained] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][isChained]);
+    auto frontImageId = session.TrackColours[SCHEME_TRACK].WithIndex(frontImageIds[direction][isChained]);
     if (direction == 0 || direction == 3)
     {
         PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
@@ -440,7 +441,7 @@ static void wild_mouse_track_25_deg_up_to_flat(
     };
 
     uint8_t isChained = trackElement.HasChain() ? 1 : 0;
-    uint32_t imageId = imageIds[direction][isChained] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][isChained]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
     if (track_paint_util_should_paint_supports(session.MapPosition))
     {
@@ -593,7 +594,7 @@ static void wild_mouse_track_right_quarter_turn_3_25_deg_down(
         const sprite_bb* sbb = &imageIds[direction][part];
         const auto& offset = sbb->offset;
         PaintAddImageAsParent(
-            session, sbb->sprite_id | session.TrackColours[SCHEME_TRACK], { offset.x, offset.y, height + offset.z },
+            session, session.TrackColours[SCHEME_TRACK].WithIndex(sbb->sprite_id), { offset.x, offset.y, height + offset.z },
             sbb->bb_size);
     }
 
@@ -660,7 +661,7 @@ static void wild_mouse_track_right_quarter_turn_3_25_deg_up(
         int32_t part = trackSequence == 0 ? 0 : 1;
         const sprite_bb* sbb = &imageIds[direction][part];
         PaintAddImageAsParent(
-            session, sbb->sprite_id | session.TrackColours[SCHEME_TRACK],
+            session, session.TrackColours[SCHEME_TRACK].WithIndex(sbb->sprite_id),
             { sbb->offset.x, sbb->offset.y, height + sbb->offset.z }, sbb->bb_size);
     }
 
@@ -728,7 +729,7 @@ static void wild_mouse_track_left_quarter_turn_1(
         SPR_WILD_MOUSE_QUARTER_TURN_1_SE_NW,
     };
 
-    uint32_t imageId = imageIds[direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction]);
     switch (direction)
     {
         case 0:
@@ -778,8 +779,8 @@ static void wild_mouse_track_flat_to_60_deg_up(
     };
 
     uint8_t isChained = trackElement.HasChain() ? 1 : 0;
-    uint32_t imageId = imageIds[direction][isChained] | session.TrackColours[SCHEME_TRACK];
-    uint32_t frontImageId = frontImageIds[direction][isChained] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][isChained]);
+    auto frontImageId = session.TrackColours[SCHEME_TRACK].WithIndex(frontImageIds[direction][isChained]);
     if (direction == 0 || direction == 3)
     {
         PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 27, 2 }, { 0, 2, height });
@@ -825,8 +826,8 @@ static void wild_mouse_track_60_deg_up_to_flat(
     };
 
     uint8_t isChained = trackElement.HasChain() ? 1 : 0;
-    uint32_t imageId = imageIds[direction][isChained] | session.TrackColours[SCHEME_TRACK];
-    uint32_t frontImageId = frontImageIds[direction][isChained] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][isChained]);
+    auto frontImageId = session.TrackColours[SCHEME_TRACK].WithIndex(frontImageIds[direction][isChained]);
     if (direction == 0 || direction == 3)
     {
         PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 27, 2 }, { 0, 2, height });
@@ -881,7 +882,7 @@ static void wild_mouse_track_brakes(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId = _wild_mouse_brakes_image_ids[direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(_wild_mouse_brakes_image_ids[direction]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
     if (track_paint_util_should_paint_supports(session.MapPosition))
     {
@@ -905,7 +906,7 @@ static void wild_mouse_track_rotation_control_toggle(
         SPR_WILD_MOUSE_ROTATION_CONTROL_TOGGLE_NW_SE,
     };
 
-    uint32_t imageId = imageIds[direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
     if (track_paint_util_should_paint_supports(session.MapPosition))
     {
@@ -923,7 +924,7 @@ static void wild_mouse_track_block_brakes(
     const TrackElement& trackElement)
 {
     bool isClosed = trackElement.BlockBrakeClosed();
-    uint32_t imageId = _wild_mouse_block_brakes_image_ids[direction][isClosed] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(_wild_mouse_block_brakes_image_ids[direction][isClosed]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
     if (track_paint_util_should_paint_supports(session.MapPosition))
     {

--- a/src/openrct2/ride/coaster/WoodenRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/WoodenRollerCoaster.cpp
@@ -448,7 +448,7 @@ static constexpr const uint32_t _wooden_rc_station_block_brakes_image_ids[4][2] 
     { SPR_G2_WOODEN_RC_STATION_BLOCK_BRAKE_OPEN_NW_SE, SPR_G2_WOODEN_RC_STATION_BLOCK_BRAKE_CLOSED_NW_SE },
 };
 
-uint32_t wooden_rc_get_rails_colour(paint_session& session)
+ImageId wooden_rc_get_rails_colour(paint_session& session)
 {
     return session.TrackColours[SCHEME_TRACK];
 }
@@ -2170,44 +2170,44 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23781, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23781), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24647, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24647), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23786, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23786), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24652, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24652), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23812, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23812), { 0, 0, height },
                         { 32, 27, 0 }, { 0, 2, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24678, { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24678), { 0, 0, height },
+                        { 32, 27, 0 }, { 0, 2, height + 67 });
                     wooden_a_supports_paint_setup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23791, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23791), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24657, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24657), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23796, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23796), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24662, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24662), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2228,50 +2228,50 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23782, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23782), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24648, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24648), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23787, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23787), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24653, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24653), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23813, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23813), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24679, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24679), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23792, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23792), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24658, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24658), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23797, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23797), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24663, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24663), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23819, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23819), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24685, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24685), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height + 67 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2287,50 +2287,50 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23783, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23783), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24649, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24649), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23788, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23788), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24654, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24654), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23814, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23814), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 59 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24680, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 59 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24680), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 16, height + 59 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23793, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23793), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24659, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24659), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23798, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23798), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24664, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24664), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23820, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23820), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 59 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24686, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 59 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24686), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 0, height + 59 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2352,56 +2352,56 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23784, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23784), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24650, { 0, 0, height }, { 16, 32, 2 },
-                        { 16, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24650), { 0, 0, height },
+                        { 16, 32, 2 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23789, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23789), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24655, { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24655), { 0, 0, height },
+                        { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23815, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23815), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24681, { 0, 0, height }, { 16, 32, 0 },
-                        { 0, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24681), { 0, 0, height },
+                        { 16, 32, 0 }, { 0, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23794, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23794), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24660, { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24660), { 0, 0, height },
+                        { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23817, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23817), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24683, { 0, 0, height }, { 16, 32, 0 },
-                        { 0, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24683), { 0, 0, height },
+                        { 16, 32, 0 }, { 0, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23799, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23799), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24665, { 0, 0, height }, { 16, 32, 2 },
-                        { 16, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24665), { 0, 0, height },
+                        { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23821, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23821), { 0, 0, height },
                         { 16, 32, 0 }, { 16, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24687, { 0, 0, height }, { 16, 32, 0 },
-                        { 16, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24687), { 0, 0, height },
+                        { 16, 32, 0 }, { 16, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2417,56 +2417,56 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23785, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23785), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24651, { 0, 0, height }, { 27, 32, 2 },
-                        { 2, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24651), { 0, 0, height },
+                        { 27, 32, 2 }, { 2, 0, height });
                     wooden_a_supports_paint_setup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23790, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23790), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24656, { 0, 0, height }, { 27, 32, 2 },
-                        { 2, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24656), { 0, 0, height },
+                        { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23816, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23816), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24682, { 0, 0, height }, { 27, 32, 0 },
-                        { 2, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24682), { 0, 0, height },
+                        { 27, 32, 0 }, { 2, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23795, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23795), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24661, { 0, 0, height }, { 27, 32, 2 },
-                        { 2, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24661), { 0, 0, height },
+                        { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23818, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23818), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24684, { 0, 0, height }, { 27, 32, 0 },
-                        { 2, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24684), { 0, 0, height },
+                        { 27, 32, 0 }, { 2, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23800, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23800), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24666, { 0, 0, height }, { 27, 32, 2 },
-                        { 2, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24666), { 0, 0, height },
+                        { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23822, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23822), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24688, { 0, 0, height }, { 27, 32, 0 },
-                        { 2, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24688), { 0, 0, height },
+                        { 27, 32, 0 }, { 2, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2498,44 +2498,44 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23761, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23761), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24627, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24627), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23766, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23766), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24632, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24632), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23771, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23771), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24637, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24637), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23807, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23807), { 0, 0, height },
                         { 32, 27, 0 }, { 0, 2, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24673, { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24673), { 0, 0, height },
+                        { 32, 27, 0 }, { 0, 2, height + 67 });
                     wooden_a_supports_paint_setup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23776, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23776), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24642, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24642), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2556,50 +2556,50 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23762, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23762), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24628, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24628), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23801, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23801), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24667, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24667), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height + 67 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23767, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23767), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24633, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24633), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23772, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23772), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24638, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24638), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23808, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23808), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24674, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24674), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23777, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23777), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24643, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24643), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2615,50 +2615,50 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23763, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23763), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24629, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24629), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23802, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23802), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 59 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24668, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 59 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24668), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 0, height + 59 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23768, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23768), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24634, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24634), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23773, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23773), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24639, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24639), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23809, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23809), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 59 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24675, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 59 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24675), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 16, height + 59 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23778, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23778), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24644, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24644), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2680,56 +2680,56 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23764, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23764), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24630, { 0, 0, height }, { 16, 32, 2 },
-                        { 16, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24630), { 0, 0, height },
+                        { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23803, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23803), { 0, 0, height },
                         { 16, 32, 0 }, { 16, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24669, { 0, 0, height }, { 16, 32, 0 },
-                        { 16, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24669), { 0, 0, height },
+                        { 16, 32, 0 }, { 16, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23769, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23769), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24635, { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24635), { 0, 0, height },
+                        { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23805, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23805), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24671, { 0, 0, height }, { 16, 32, 0 },
-                        { 0, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24671), { 0, 0, height },
+                        { 16, 32, 0 }, { 0, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23774, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23774), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24640, { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24640), { 0, 0, height },
+                        { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23810, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23810), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24676, { 0, 0, height }, { 16, 32, 0 },
-                        { 0, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24676), { 0, 0, height },
+                        { 16, 32, 0 }, { 0, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23779, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23779), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24645, { 0, 0, height }, { 16, 32, 2 },
-                        { 16, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24645), { 0, 0, height },
+                        { 16, 32, 2 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2745,56 +2745,56 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23765, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23765), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24631, { 0, 0, height }, { 27, 32, 2 },
-                        { 2, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24631), { 0, 0, height },
+                        { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23804, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23804), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24670, { 0, 0, height }, { 27, 32, 0 },
-                        { 2, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24670), { 0, 0, height },
+                        { 27, 32, 0 }, { 2, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23770, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23770), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24636, { 0, 0, height }, { 27, 32, 2 },
-                        { 2, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24636), { 0, 0, height },
+                        { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23806, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23806), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24672, { 0, 0, height }, { 27, 32, 0 },
-                        { 2, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24672), { 0, 0, height },
+                        { 27, 32, 0 }, { 2, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23775, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23775), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24641, { 0, 0, height }, { 27, 32, 2 },
-                        { 2, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24641), { 0, 0, height },
+                        { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23811, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23811), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24677, { 0, 0, height }, { 27, 32, 0 },
-                        { 2, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24677), { 0, 0, height },
+                        { 27, 32, 0 }, { 2, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23780, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23780), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24646, { 0, 0, height }, { 27, 32, 2 },
-                        { 2, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24646), { 0, 0, height },
+                        { 27, 32, 2 }, { 2, 0, height });
                     wooden_a_supports_paint_setup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2848,50 +2848,50 @@ static void wooden_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23725, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23725), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24591, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24591), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23729, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23729), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24595, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24595), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23741, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23741), { 0, 0, height },
                         { 32, 25, 0 }, { 0, 3, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24607, { 0, 0, height }, { 32, 25, 0 },
-                        { 0, 3, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24607), { 0, 0, height },
+                        { 32, 25, 0 }, { 0, 3, height + 27 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23728, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23728), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24594, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24594), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23732, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23732), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24598, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24598), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23744, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23744), { 0, 0, height },
                         { 32, 27, 0 }, { 0, 2, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24610, { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24610), { 0, 0, height },
+                        { 32, 27, 0 }, { 0, 2, height + 27 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2907,50 +2907,50 @@ static void wooden_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23726, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23726), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24592, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24592), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23730, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23730), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24596, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24596), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23742, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23742), { 0, 0, height },
                         { 32, 26, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24608, { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24608), { 0, 0, height },
+                        { 32, 26, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23727, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23727), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24593, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24593), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23731, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23731), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24597, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24597), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23743, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23743), { 0, 0, height },
                         { 32, 26, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24609, { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24609), { 0, 0, height },
+                        { 32, 26, 0 }, { 0, 6, height + 27 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2966,50 +2966,50 @@ static void wooden_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23727, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23727), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24593, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24593), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23731, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23731), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24597, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24597), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23743, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23743), { 0, 0, height },
                         { 32, 26, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24609, { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24609), { 0, 0, height },
+                        { 32, 26, 0 }, { 0, 6, height + 27 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23726, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23726), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24592, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24592), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23730, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23730), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24596, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24596), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23742, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23742), { 0, 0, height },
                         { 32, 26, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24608, { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24608), { 0, 0, height },
+                        { 32, 26, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3025,50 +3025,50 @@ static void wooden_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23728, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23728), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24594, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24594), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23732, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23732), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24598, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24598), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23744, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23744), { 0, 0, height },
                         { 32, 27, 0 }, { 0, 2, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24610, { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24610), { 0, 0, height },
+                        { 32, 27, 0 }, { 0, 2, height + 27 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23725, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23725), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24591, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24591), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23729, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23729), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24595, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24595), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23741, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23741), { 0, 0, height },
                         { 32, 25, 0 }, { 0, 3, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24607, { 0, 0, height }, { 32, 25, 0 },
-                        { 0, 3, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24607), { 0, 0, height },
+                        { 32, 25, 0 }, { 0, 3, height + 27 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3100,50 +3100,50 @@ static void wooden_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23733, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23733), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24599, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24599), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23745, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23745), { 0, 0, height },
                         { 32, 25, 0 }, { 0, 3, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24611, { 0, 0, height }, { 32, 25, 0 },
-                        { 0, 3, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24611), { 0, 0, height },
+                        { 32, 25, 0 }, { 0, 3, height + 27 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23737, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23737), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24603, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24603), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23736, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23736), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24602, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24602), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23748, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23748), { 0, 0, height },
                         { 32, 25, 0 }, { 0, 3, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24614, { 0, 0, height }, { 32, 25, 0 },
-                        { 0, 3, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24614), { 0, 0, height },
+                        { 32, 25, 0 }, { 0, 3, height + 27 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23740, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23740), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24606, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24606), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3159,50 +3159,50 @@ static void wooden_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23734, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23734), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24600, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24600), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23746, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23746), { 0, 0, height },
                         { 32, 26, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24612, { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24612), { 0, 0, height },
+                        { 32, 26, 0 }, { 0, 6, height + 27 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23738, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23738), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24604, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24604), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23735, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23735), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24601, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24601), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23747, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23747), { 0, 0, height },
                         { 32, 26, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24613, { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24613), { 0, 0, height },
+                        { 32, 26, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23739, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23739), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24605, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24605), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3218,50 +3218,50 @@ static void wooden_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23735, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23735), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24601, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24601), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23747, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23747), { 0, 0, height },
                         { 32, 26, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24613, { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24613), { 0, 0, height },
+                        { 32, 26, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23739, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23739), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24605, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24605), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23734, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23734), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24600, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24600), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23746, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23746), { 0, 0, height },
                         { 32, 26, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24612, { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24612), { 0, 0, height },
+                        { 32, 26, 0 }, { 0, 6, height + 27 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23738, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23738), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24604, { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24604), { 0, 0, height },
+                        { 32, 26, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3277,50 +3277,50 @@ static void wooden_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23736, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23736), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24602, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24602), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23748, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23748), { 0, 0, height },
                         { 32, 25, 0 }, { 0, 3, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24614, { 0, 0, height }, { 32, 25, 0 },
-                        { 0, 3, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24614), { 0, 0, height },
+                        { 32, 25, 0 }, { 0, 3, height + 27 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23740, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23740), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24606, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24606), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23733, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23733), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24599, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24599), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23745, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23745), { 0, 0, height },
                         { 32, 25, 0 }, { 0, 3, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24611, { 0, 0, height }, { 32, 25, 0 },
-                        { 0, 3, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24611), { 0, 0, height },
+                        { 32, 25, 0 }, { 0, 3, height + 27 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23737, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23737), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24603, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24603), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3352,19 +3352,23 @@ static void wooden_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23453, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23453), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23461, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23461), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23460, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23460), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23468, { 0, 6, height }, { 32, 20, 7 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23468), { 0, 6, height },
+                        { 32, 20, 7 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3384,25 +3388,29 @@ static void wooden_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23454, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23454), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_BOXED, 4, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23462, { 0, 14, height }, { 32, 2, 63 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23462), { 0, 14, height },
+                        { 32, 2, 63 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_BOXED, 4, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23459, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23459), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_BOXED, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23467, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23467), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_BOXED, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3419,19 +3427,23 @@ static void wooden_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23455, { 16, 0, height }, { 5, 16, 119 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23455), { 16, 0, height },
+                        { 5, 16, 119 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23463, { 12, 0, height }, { 3, 16, 119 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23463), { 12, 0, height },
+                        { 3, 16, 119 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23458, { 10, 16, height }, { 4, 16, 119 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23458), { 10, 16, height },
+                        { 4, 16, 119 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23466, { 16, 16, height }, { 4, 16, 119 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23466), { 16, 16, height },
+                        { 4, 16, 119 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3443,19 +3455,23 @@ static void wooden_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23456, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23456), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23464, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23464), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23457, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23457), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23465, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23465), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3476,19 +3492,23 @@ static void wooden_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23457, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23457), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23465, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23465), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23456, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23456), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23464, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23464), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3503,19 +3523,23 @@ static void wooden_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23458, { 10, 16, height }, { 4, 16, 119 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23458), { 10, 16, height },
+                        { 4, 16, 119 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23466, { 16, 16, height }, { 4, 16, 119 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23466), { 16, 16, height },
+                        { 4, 16, 119 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23455, { 16, 0, height }, { 5, 16, 119 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23455), { 16, 0, height },
+                        { 5, 16, 119 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23463, { 12, 0, height }, { 3, 16, 119 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23463), { 12, 0, height },
+                        { 3, 16, 119 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3527,25 +3551,29 @@ static void wooden_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23459, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23459), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_BOXED, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23467, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23467), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_BOXED, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23454, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23454), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_BOXED, 4, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23462, { 0, 14, height }, { 32, 2, 63 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23462), { 0, 14, height },
+                        { 32, 2, 63 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_BOXED, 4, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3562,19 +3590,23 @@ static void wooden_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23460, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23460), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23468, { 0, 6, height }, { 32, 20, 7 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23468), { 0, 6, height },
+                        { 32, 20, 7 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23453, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23453), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23461, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23461), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3610,19 +3642,23 @@ static void wooden_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23484, { 0, 6, height }, { 32, 20, 7 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23484), { 0, 6, height },
+                        { 32, 20, 7 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23476, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23476), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23477, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23477), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23469, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23469), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3637,25 +3673,29 @@ static void wooden_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23483, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23483), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_BOXED, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23475, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23475), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_BOXED, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23478, { 0, 14, height }, { 32, 2, 63 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23478), { 0, 14, height },
+                        { 32, 2, 63 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_BOXED, 4, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23470, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23470), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_BOXED, 4, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3667,19 +3707,23 @@ static void wooden_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23482, { 16, 16, height }, { 4, 16, 119 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23482), { 16, 16, height },
+                        { 4, 16, 119 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23474, { 10, 16, height }, { 4, 16, 119 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23474), { 10, 16, height },
+                        { 4, 16, 119 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23479, { 12, 0, height }, { 3, 16, 119 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23479), { 12, 0, height },
+                        { 3, 16, 119 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23471, { 16, 0, height }, { 5, 16, 119 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23471), { 16, 0, height },
+                        { 5, 16, 119 });
                     break;
             }
             paint_util_set_general_support_height(session, height + 168, 0x20);
@@ -3689,19 +3733,23 @@ static void wooden_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23481, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23481), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23473, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23473), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23480, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23480), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23472, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23472), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_general_support_height(session, height + 48, 0x20);
@@ -3717,19 +3765,23 @@ static void wooden_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23480, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23480), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23472, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23472), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23481, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23481), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23473, { 0, 16, height + 32 }, { 32, 16, 3 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23473), { 0, 16, height + 32 },
+                        { 32, 16, 3 });
                     break;
             }
             paint_util_set_general_support_height(session, height + 48, 0x20);
@@ -3739,19 +3791,23 @@ static void wooden_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23479, { 12, 0, height }, { 3, 16, 119 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23479), { 12, 0, height },
+                        { 3, 16, 119 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23471, { 16, 0, height }, { 5, 16, 119 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23471), { 16, 0, height },
+                        { 5, 16, 119 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23482, { 16, 16, height }, { 4, 16, 119 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23482), { 16, 16, height },
+                        { 4, 16, 119 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23474, { 10, 16, height }, { 4, 16, 119 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23474), { 10, 16, height },
+                        { 4, 16, 119 });
                     break;
             }
             paint_util_set_general_support_height(session, height + 168, 0x20);
@@ -3761,25 +3817,29 @@ static void wooden_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23478, { 0, 14, height }, { 32, 2, 63 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23478), { 0, 14, height },
+                        { 32, 2, 63 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_BOXED, 4, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23470, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23470), { 0, 0, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_BOXED, 4, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23483, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23483), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_BOXED, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23475, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23475), { 0, 6, height },
+                        { 32, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_BOXED, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3791,19 +3851,23 @@ static void wooden_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23477, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23477), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23469, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23469), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23484, { 0, 6, height }, { 32, 20, 7 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23484), { 0, 6, height },
+                        { 32, 20, 7 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 23476, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23476), { 0, 6, height },
+                        { 32, 20, 3 });
                     break;
             }
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3836,50 +3900,50 @@ static void wooden_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23828, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23828), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24694, { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24694), { 0, 6, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23831, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23831), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24697, { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24697), { 0, 6, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23840, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23840), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24706, { 0, 6, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24706), { 0, 6, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23834, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23834), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24700, { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24700), { 0, 6, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23825, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23825), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24691, { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24691), { 0, 6, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23837, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23837), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24703, { 0, 6, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24703), { 0, 6, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3898,47 +3962,47 @@ static void wooden_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23827, { 16, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23827), { 16, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24693, { 16, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24693), { 16, 0, height },
+                        { 16, 16, 2 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23830, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23830), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24696, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24696), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23839, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23839), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24705, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24705), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23833, { 0, 16, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23833), { 0, 16, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24699, { 0, 16, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24699), { 0, 16, height },
+                        { 16, 16, 2 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23824, { 16, 16, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23824), { 16, 16, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24690, { 16, 16, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24690), { 16, 16, height },
+                        { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23836, { 16, 16, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23836), { 16, 16, height },
                         { 16, 16, 0 }, { 16, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24702, { 16, 16, height }, { 16, 16, 0 },
-                        { 16, 16, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24702), { 16, 16, height },
+                        { 16, 16, 0 }, { 16, 16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3950,50 +4014,50 @@ static void wooden_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23826, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23826), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24692, { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24692), { 6, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23829, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23829), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24695, { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24695), { 6, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23838, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23838), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24704, { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24704), { 6, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23832, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23832), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24698, { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24698), { 6, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23823, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23823), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24689, { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24689), { 6, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23835, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23835), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24701, { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24701), { 6, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4036,55 +4100,55 @@ static void wooden_rc_track_left_quarter_turn_3_bank(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_5,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_5),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24712, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24712), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_8,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_8),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24715, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24715), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_17,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_17),
                         { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24724, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24724), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_11,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_11),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24718, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24718), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_2,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_2),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24709, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24709), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_14,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_14),
                         { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24721, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24721), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4104,52 +4168,52 @@ static void wooden_rc_track_left_quarter_turn_3_bank(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_4,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_4),
                         { 0, 0, height }, { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24711, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24711), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_7,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_7),
                         { 0, 0, height }, { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24714, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24714), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_16,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_16),
                         { 0, 0, height }, { 16, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24723, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24723), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_10,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_10),
                         { 0, 0, height }, { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24717, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24717), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_1,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_1),
                         { 0, 0, height }, { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24708, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24708), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_13,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_13),
                         { 0, 0, height }, { 16, 16, 0 }, { 16, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24720, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24720), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4162,55 +4226,55 @@ static void wooden_rc_track_left_quarter_turn_3_bank(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_3,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_3),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24710, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24710), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_6,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_6),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24713, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24713), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_15,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_15),
                         { 0, 0, height }, { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24722, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24722), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_9,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_9),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24716, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24716), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_0,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_0),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24707, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24707), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_12,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_12),
                         { 0, 0, height }, { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24719, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24719), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4253,50 +4317,50 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23906, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23906), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24772, { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24772), { 0, 6, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23908, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23908), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24774, { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24774), { 0, 6, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23919, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23919), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24785, { 0, 6, height }, { 32, 20, 0 },
-                        { 0, 6, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24785), { 0, 6, height },
+                        { 32, 20, 0 }, { 0, 6, height + 67 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23910, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23910), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24776, { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24776), { 0, 6, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23904, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23904), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24770, { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24770), { 0, 6, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23917, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23917), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24783, { 0, 6, height }, { 32, 20, 0 },
-                        { 0, 6, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24783), { 0, 6, height },
+                        { 32, 20, 0 }, { 0, 6, height + 67 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4320,56 +4384,56 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23905, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23905), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24771, { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24771), { 6, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23907, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23907), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24773, { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24773), { 6, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23918, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23918), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24784, { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24784), { 6, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23909, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23909), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24775, { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24775), { 6, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23920, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23920), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24786, { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24786), { 6, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23903, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23903), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24769, { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24769), { 6, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23916, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23916), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24782, { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24782), { 6, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4401,50 +4465,50 @@ static void wooden_rc_track_right_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23895, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23895), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24761, { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24761), { 0, 6, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23911, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23911), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24777, { 0, 6, height }, { 32, 20, 0 },
-                        { 0, 6, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24777), { 0, 6, height },
+                        { 32, 20, 0 }, { 0, 6, height + 67 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23897, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23897), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24763, { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24763), { 0, 6, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23899, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23899), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24765, { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24765), { 0, 6, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23914, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23914), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24780, { 0, 6, height }, { 32, 20, 0 },
-                        { 0, 6, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24780), { 0, 6, height },
+                        { 32, 20, 0 }, { 0, 6, height + 67 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23901, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23901), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24767, { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24767), { 0, 6, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4468,56 +4532,56 @@ static void wooden_rc_track_right_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23896, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23896), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24762, { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24762), { 6, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23912, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23912), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24778, { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24778), { 6, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23898, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23898), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24764, { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24764), { 6, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23913, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23913), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24779, { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24779), { 6, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23900, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23900), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24766, { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24766), { 6, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23915, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23915), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24781, { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24781), { 6, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23902, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23902), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24768, { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24768), { 6, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4572,55 +4636,55 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_41,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_41),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24748, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24748), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_44,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_44),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24751, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24751), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_53,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_53),
                         { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24760, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24760), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_47,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_47),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24754, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24754), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_38,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_38),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24745, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24745), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_50,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_50),
                         { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24757, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24757), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4659,52 +4723,52 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_40,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_40),
                         { 0, 0, height }, { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24747, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24747), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_43,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_43),
                         { 0, 0, height }, { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24750, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24750), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_52,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_52),
                         { 0, 0, height }, { 16, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24759, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24759), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_46,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_46),
                         { 0, 0, height }, { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24753, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24753), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_37,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_37),
                         { 0, 0, height }, { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24744, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24744), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_49,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_49),
                         { 0, 0, height }, { 16, 16, 0 }, { 16, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24756, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24756), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4717,55 +4781,55 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_39,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_39),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24746, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24746), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_42,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_42),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24749, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24749), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_51,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_51),
                         { 0, 0, height }, { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24758, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24758), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_45,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_45),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24752, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24752), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_36,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_36),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height + 8 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24743, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height + 8 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24743), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height + 8 });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_48,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_48),
                         { 0, 0, height }, { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24755, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24755), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4791,55 +4855,55 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_38,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_38),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24745, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24745), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_50,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_50),
                         { 0, 0, height }, { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24757, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24757), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_41,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_41),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24748, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24748), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_44,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_44),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24751, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24751), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_53,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_53),
                         { 0, 0, height }, { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24760, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24760), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_47,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_47),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24754, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24754), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4883,52 +4947,52 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_37,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_37),
                         { 0, 0, height }, { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24744, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24744), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_49,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_49),
                         { 0, 0, height }, { 16, 16, 0 }, { 16, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24756, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24756), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 16, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_40,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_40),
                         { 0, 0, height }, { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24747, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24747), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_43,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_43),
                         { 0, 0, height }, { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24750, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24750), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_52,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_52),
                         { 0, 0, height }, { 16, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24759, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24759), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_46,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_46),
                         { 0, 0, height }, { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24753, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24753), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4941,55 +5005,55 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_36,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_36),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 8 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24743, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height + 8 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24743), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height + 8 });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_48,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_48),
                         { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24755, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24755), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_39,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_39),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24746, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24746), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_42,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_42),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24749, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24749), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_51,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_51),
                         { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24758, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24758), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_45,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_45),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24752, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24752), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -5021,55 +5085,55 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_18,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_18),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24725, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24725), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_30,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_30),
                         { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24737, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24737), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_21,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_21),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24728, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24728), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_24,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_24),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24731, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24731), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_33,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_33),
                         { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24740, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24740), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_27,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_27),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24734, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24734), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -5108,52 +5172,52 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_19,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_19),
                         { 0, 0, height }, { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24726, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24726), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_31,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_31),
                         { 0, 0, height }, { 16, 16, 0 }, { 16, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24738, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24738), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 16, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_22,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_22),
                         { 0, 0, height }, { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24729, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24729), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_25,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_25),
                         { 0, 0, height }, { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24732, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24732), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_34,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_34),
                         { 0, 0, height }, { 16, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24741, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24741), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_28,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_28),
                         { 0, 0, height }, { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24735, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24735), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5166,55 +5230,55 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_20,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_20),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height + 8 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24727, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height + 8 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24727), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height + 8 });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_32,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_32),
                         { 0, 0, height }, { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24739, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24739), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_23,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_23),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24730, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24730), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_26,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_26),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24733, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24733), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_35,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_35),
                         { 0, 0, height }, { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24742, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24742), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_29,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_29),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24736, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24736), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -5240,55 +5304,55 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_21,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_21),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24728, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24728), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_24,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_24),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24731, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24731), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_33,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_33),
                         { 0, 0, height }, { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24740, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24740), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_27,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_27),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24734, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24734), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_18,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_18),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24725, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24725), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_30,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_30),
                         { 0, 0, height }, { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24737, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24737), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -5332,51 +5396,51 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_22,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_22),
                         { 0, 0, height }, { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24729, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24729), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_25,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_25),
                         { 0, 0, height }, { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24732, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24732), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_34,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_34),
                         { 0, 0, height }, { 16, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24741, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24741), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_28,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_28),
                         { 0, 0, height }, { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24735, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24735), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23860, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23860), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24726, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24726), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_31,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_31),
                         { 0, 0, height }, { 16, 16, 0 }, { 16, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24738, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24738), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 16, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5389,55 +5453,55 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_23,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_23),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24730, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24730), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_26,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_26),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24733, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24733), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_35,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_35),
                         { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24742, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24742), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_29,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_29),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24736, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24736), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_20,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_20),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 8 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24727, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height + 8 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24727), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height + 8 });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session) | SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_32,
+                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_32),
                         { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24739, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24739), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -5500,50 +5564,50 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23704, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23704), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24570, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24570), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23709, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23709), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24575, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24575), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23724, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23724), { 0, 0, height },
                         { 32, 27, 0 }, { 0, 2, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24590, { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24590), { 0, 0, height },
+                        { 32, 27, 0 }, { 0, 2, height + 27 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23714, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23714), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24580, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24580), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23699, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23699), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24565, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24565), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23719, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23719), { 0, 0, height },
                         { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24585, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24585), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -5568,50 +5632,50 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23703, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23703), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24569, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24569), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23708, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23708), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24574, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24574), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23723, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23723), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24589, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24589), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23713, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23713), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24579, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24579), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23698, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23698), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24564, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24564), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23718, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23718), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24584, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24584), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height + 27 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -5627,50 +5691,50 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23702, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23702), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24568, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24568), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23707, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23707), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24573, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24573), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23722, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23722), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 29 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24588, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 29 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24588), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 16, height + 29 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23712, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23712), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24578, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24578), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23697, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23697), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24563, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24563), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23717, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23717), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24583, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24583), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -5690,50 +5754,50 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23701, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23701), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24567, { 0, 0, height }, { 16, 32, 2 },
-                        { 16, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24567), { 0, 0, height },
+                        { 16, 32, 2 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23706, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23706), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24572, { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24572), { 0, 0, height },
+                        { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23721, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23721), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 33 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24587, { 0, 0, height }, { 16, 32, 0 },
-                        { 0, 0, height + 33 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24587), { 0, 0, height },
+                        { 16, 32, 0 }, { 0, 0, height + 33 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23711, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23711), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24577, { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24577), { 0, 0, height },
+                        { 16, 32, 2 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23696, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23696), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24562, { 0, 0, height }, { 16, 32, 2 },
-                        { 16, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24562), { 0, 0, height },
+                        { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23716, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23716), { 0, 0, height },
                         { 16, 32, 0 }, { 16, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24582, { 0, 0, height }, { 16, 32, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24582), { 0, 0, height },
+                        { 16, 32, 0 }, { 16, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -5749,50 +5813,50 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23700, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23700), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24566, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24566), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23705, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23705), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24571, { 0, 0, height }, { 27, 32, 2 },
-                        { 2, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24571), { 0, 0, height },
+                        { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23720, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23720), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 33 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24586, { 0, 0, height }, { 27, 32, 0 },
-                        { 2, 0, height + 33 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24586), { 0, 0, height },
+                        { 27, 32, 0 }, { 2, 0, height + 33 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23710, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23710), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24576, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24576), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23695, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23695), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height + 8 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24561, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height + 8 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24561), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height + 8 });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23715, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23715), { 0, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24581, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24581), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -5817,50 +5881,50 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23699, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23699), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24565, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24565), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23719, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23719), { 0, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24585, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24585), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23704, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23704), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24570, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24570), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23709, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23709), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24575, { 0, 0, height }, { 27, 32, 2 },
-                        { 2, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24575), { 0, 0, height },
+                        { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23724, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23724), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24590, { 0, 0, height }, { 27, 32, 0 },
-                        { 2, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24590), { 0, 0, height },
+                        { 27, 32, 0 }, { 2, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23714, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23714), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24580, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24580), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -5890,50 +5954,50 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23698, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23698), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24564, { 0, 0, height }, { 16, 32, 2 },
-                        { 16, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24564), { 0, 0, height },
+                        { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23718, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23718), { 0, 0, height },
                         { 16, 32, 0 }, { 16, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24584, { 0, 0, height }, { 16, 32, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24584), { 0, 0, height },
+                        { 16, 32, 0 }, { 16, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23703, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23703), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24569, { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24569), { 0, 0, height },
+                        { 16, 32, 2 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23708, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23708), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24574, { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24574), { 0, 0, height },
+                        { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23723, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23723), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24589, { 0, 0, height }, { 16, 32, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24589), { 0, 0, height },
+                        { 16, 32, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23713, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23713), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24579, { 0, 0, height }, { 16, 32, 2 },
-                        { 16, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24579), { 0, 0, height },
+                        { 16, 32, 2 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -5949,50 +6013,50 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23697, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23697), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24563, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24563), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23717, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23717), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24583, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24583), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23702, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23702), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24568, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24568), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23707, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23707), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24573, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24573), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23722, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23722), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 29 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24588, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 29 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24588), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 16, height + 29 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23712, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23712), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24578, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24578), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -6012,50 +6076,50 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23696, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23696), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24562, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24562), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23716, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23716), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24582, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24582), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height + 27 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23701, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23701), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24567, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24567), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23706, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23706), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24572, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24572), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23721, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23721), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 33 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24587, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 33 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24587), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height + 33 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23711, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23711), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24577, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24577), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -6071,50 +6135,50 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23695, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23695), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height + 8 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24561, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height + 8 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24561), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height + 8 });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23715, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23715), { 0, 0, height },
                         { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24581, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24581), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23700, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23700), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24566, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24566), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23705, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23705), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24571, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24571), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23720, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23720), { 0, 0, height },
                         { 32, 27, 0 }, { 0, 2, height + 33 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24586, { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 33 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24586), { 0, 0, height },
+                        { 32, 27, 0 }, { 0, 2, height + 33 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23710, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23710), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24576, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24576), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -6145,50 +6209,50 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23665, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23665), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24531, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24531), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23685, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23685), { 0, 0, height },
                         { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24551, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24551), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23670, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23670), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24536, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24536), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23675, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23675), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24541, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24541), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23690, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23690), { 0, 0, height },
                         { 32, 27, 0 }, { 0, 2, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24556, { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24556), { 0, 0, height },
+                        { 32, 27, 0 }, { 0, 2, height + 27 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23680, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23680), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24546, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24546), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -6213,50 +6277,50 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23666, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23666), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24532, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24532), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23686, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23686), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24552, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24552), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height + 27 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23671, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23671), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24537, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24537), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23676, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23676), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24542, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24542), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23691, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23691), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24557, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24557), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23681, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23681), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24547, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24547), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -6272,50 +6336,50 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23667, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23667), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24533, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24533), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23687, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23687), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24553, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24553), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23672, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23672), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24538, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24538), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23677, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23677), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24543, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24543), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23692, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23692), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 29 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24558, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 29 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24558), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 16, height + 29 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23682, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23682), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24548, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24548), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -6335,50 +6399,50 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23668, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23668), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24534, { 0, 0, height }, { 16, 32, 2 },
-                        { 16, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24534), { 0, 0, height },
+                        { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23688, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23688), { 0, 0, height },
                         { 16, 32, 0 }, { 16, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24554, { 0, 0, height }, { 16, 32, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24554), { 0, 0, height },
+                        { 16, 32, 0 }, { 16, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23673, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23673), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24539, { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24539), { 0, 0, height },
+                        { 16, 32, 2 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23678, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23678), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24544, { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24544), { 0, 0, height },
+                        { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23693, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23693), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 33 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24559, { 0, 0, height }, { 16, 32, 0 },
-                        { 0, 0, height + 33 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24559), { 0, 0, height },
+                        { 16, 32, 0 }, { 0, 0, height + 33 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23683, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23683), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24549, { 0, 0, height }, { 16, 32, 2 },
-                        { 16, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24549), { 0, 0, height },
+                        { 16, 32, 2 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -6394,50 +6458,50 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23669, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23669), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height + 8 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24535, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height + 8 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24535), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height + 8 });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23689, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23689), { 0, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24555, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24555), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23674, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23674), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24540, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24540), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23679, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23679), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24545, { 0, 0, height }, { 27, 32, 2 },
-                        { 2, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24545), { 0, 0, height },
+                        { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23694, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23694), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 33 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24560, { 0, 0, height }, { 27, 32, 0 },
-                        { 2, 0, height + 33 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24560), { 0, 0, height },
+                        { 27, 32, 0 }, { 2, 0, height + 33 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23684, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23684), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24550, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24550), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -6462,50 +6526,50 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23670, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23670), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24536, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24536), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23675, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23675), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24541, { 0, 0, height }, { 27, 32, 2 },
-                        { 2, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24541), { 0, 0, height },
+                        { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23690, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23690), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24556, { 0, 0, height }, { 27, 32, 0 },
-                        { 2, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24556), { 0, 0, height },
+                        { 27, 32, 0 }, { 2, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23680, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23680), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24546, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24546), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23665, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23665), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24531, { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24531), { 0, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23685, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23685), { 0, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24551, { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24551), { 0, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -6535,50 +6599,50 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23671, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23671), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24537, { 0, 0, height }, { 16, 32, 2 },
-                        { 16, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24537), { 0, 0, height },
+                        { 16, 32, 2 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23676, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23676), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24542, { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24542), { 0, 0, height },
+                        { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23691, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23691), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24557, { 0, 0, height }, { 16, 32, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24557), { 0, 0, height },
+                        { 16, 32, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23681, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23681), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24547, { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24547), { 0, 0, height },
+                        { 16, 32, 2 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23666, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23666), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24532, { 0, 0, height }, { 16, 32, 2 },
-                        { 16, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24532), { 0, 0, height },
+                        { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23686, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23686), { 0, 0, height },
                         { 16, 32, 0 }, { 16, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24552, { 0, 0, height }, { 16, 32, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24552), { 0, 0, height },
+                        { 16, 32, 0 }, { 16, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -6594,50 +6658,50 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23672, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23672), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24538, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24538), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23677, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23677), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24543, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24543), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23692, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23692), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 29 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24558, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 29 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24558), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 16, height + 29 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23682, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23682), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24548, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24548), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23667, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23667), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24533, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24533), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23687, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23687), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24553, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24553), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -6657,50 +6721,50 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23673, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23673), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24539, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24539), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23678, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23678), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24544, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24544), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23693, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23693), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 33 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24559, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 33 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24559), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height + 33 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23683, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23683), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24549, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24549), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23668, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23668), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24534, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24534), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23688, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23688), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24554, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24554), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height + 27 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -6716,50 +6780,50 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23674, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23674), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24540, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24540), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23679, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23679), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24545, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24545), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23694, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23694), { 0, 0, height },
                         { 32, 27, 0 }, { 0, 2, height + 33 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24560, { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 33 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24560), { 0, 0, height },
+                        { 32, 27, 0 }, { 0, 2, height + 33 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23684, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23684), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24550, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24550), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23669, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23669), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height + 8 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24535, { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height + 8 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24535), { 0, 0, height },
+                        { 32, 20, 2 }, { 0, 6, height + 8 });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23689, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23689), { 0, 0, height },
                         { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24555, { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24555), { 0, 0, height },
+                        { 32, 20, 0 }, { 0, 6, height + 27 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -6819,58 +6883,58 @@ static void wooden_rc_track_left_quarter_turn_1_60_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24209, { 0, 0, height }, { 28, 28, 3 },
-                { 2, 2, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24209), { 0, 0, height },
+                { 28, 28, 3 }, { 2, 2, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25075, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25075), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24217, { 0, 0, height }, { 28, 28, 1 },
-                { 2, 2, height + 99 });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24217), { 0, 0, height },
+                { 28, 28, 1 }, { 2, 2, height + 99 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25083, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25083), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24210, { 0, 0, height }, { 28, 28, 3 },
-                { 2, 2, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24210), { 0, 0, height },
+                { 28, 28, 3 }, { 2, 2, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25076, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25076), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24218, { 0, 0, height }, { 28, 28, 1 },
-                { 2, 2, height + 99 });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24218), { 0, 0, height },
+                { 28, 28, 1 }, { 2, 2, height + 99 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25084, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25084), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24211, { 0, 0, height }, { 28, 28, 3 },
-                { 2, 2, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24211), { 0, 0, height },
+                { 28, 28, 3 }, { 2, 2, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25077, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25077), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24219, { 0, 0, height }, { 28, 28, 1 },
-                { 2, 2, height + 99 });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24219), { 0, 0, height },
+                { 28, 28, 1 }, { 2, 2, height + 99 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25085, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25085), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24212, { 0, 0, height }, { 28, 28, 3 },
-                { 2, 2, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24212), { 0, 0, height },
+                { 28, 28, 3 }, { 2, 2, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25078, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25078), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24220, { 0, 0, height }, { 28, 28, 1 },
-                { 2, 2, height + 99 });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24220), { 0, 0, height },
+                { 28, 28, 1 }, { 2, 2, height + 99 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25086, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25086), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
     }
@@ -6889,58 +6953,58 @@ static void wooden_rc_track_right_quarter_turn_1_60_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24213, { 0, 0, height }, { 28, 28, 3 },
-                { 2, 2, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24213), { 0, 0, height },
+                { 28, 28, 3 }, { 2, 2, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25079, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25079), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24221, { 0, 0, height }, { 28, 28, 1 },
-                { 2, 2, height + 99 });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24221), { 0, 0, height },
+                { 28, 28, 1 }, { 2, 2, height + 99 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25087, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25087), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24214, { 0, 0, height }, { 28, 28, 3 },
-                { 2, 2, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24214), { 0, 0, height },
+                { 28, 28, 3 }, { 2, 2, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25080, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25080), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24222, { 0, 0, height }, { 28, 28, 1 },
-                { 2, 2, height + 99 });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24222), { 0, 0, height },
+                { 28, 28, 1 }, { 2, 2, height + 99 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25088, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25088), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24215, { 0, 0, height }, { 28, 28, 3 },
-                { 2, 2, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24215), { 0, 0, height },
+                { 28, 28, 3 }, { 2, 2, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25081, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25081), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24223, { 0, 0, height }, { 28, 28, 1 },
-                { 2, 2, height + 99 });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24223), { 0, 0, height },
+                { 28, 28, 1 }, { 2, 2, height + 99 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25089, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25089), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24216, { 0, 0, height }, { 28, 28, 3 },
-                { 2, 2, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24216), { 0, 0, height },
+                { 28, 28, 3 }, { 2, 2, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25082, { 0, 0, height }, { 28, 28, 3 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25082), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24224, { 0, 0, height }, { 28, 28, 1 },
-                { 2, 2, height + 99 });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24224), { 0, 0, height },
+                { 28, 28, 1 }, { 2, 2, height + 99 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25090, { 0, 0, height }, { 28, 28, 1 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25090), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
     }
@@ -7000,49 +7064,49 @@ static void wooden_rc_track_25_deg_up_left_banked(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24249, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24249), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25115, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25115), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             wooden_a_supports_paint_setup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24250, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24250), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25116, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25116), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24257, { 0, 0, height }, { 32, 1, 9 },
-                { 0, 26, height + 5 });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24257), { 0, 0, height },
+                { 32, 1, 9 }, { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25123, { 0, 0, height }, { 32, 1, 9 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25123), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
             wooden_a_supports_paint_setup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24251, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24251), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25117, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25117), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24258, { 0, 0, height }, { 32, 1, 9 },
-                { 0, 26, height + 5 });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24258), { 0, 0, height },
+                { 32, 1, 9 }, { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25124, { 0, 0, height }, { 32, 1, 9 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25124), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
             wooden_a_supports_paint_setup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24252, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24252), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25118, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25118), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             wooden_a_supports_paint_setup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -7069,49 +7133,49 @@ static void wooden_rc_track_25_deg_up_right_banked(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24253, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24253), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25119, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25119), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             wooden_a_supports_paint_setup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24254, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24254), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25120, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25120), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24259, { 0, 0, height }, { 32, 1, 9 },
-                { 0, 26, height + 5 });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24259), { 0, 0, height },
+                { 32, 1, 9 }, { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25125, { 0, 0, height }, { 32, 1, 9 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25125), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
             wooden_a_supports_paint_setup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24255, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24255), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25121, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25121), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24260, { 0, 0, height }, { 32, 1, 9 },
-                { 0, 26, height + 5 });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24260), { 0, 0, height },
+                { 32, 1, 9 }, { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25126, { 0, 0, height }, { 32, 1, 9 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25126), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
             wooden_a_supports_paint_setup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24256, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24256), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25122, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25122), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             wooden_a_supports_paint_setup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -7138,34 +7202,34 @@ static void wooden_rc_track_on_ride_photo(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23753, { 0, 2, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23753), { 0, 2, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 24619, { 0, 2, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(24619), { 0, 2, height }, { 32, 25, 2 },
                 { 0, 3, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23754, { 0, 2, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23754), { 0, 2, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 24620, { 0, 2, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(24620), { 0, 2, height }, { 32, 25, 2 },
                 { 0, 3, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23753, { 0, 2, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23753), { 0, 2, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 24619, { 0, 2, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(24619), { 0, 2, height }, { 32, 25, 2 },
                 { 0, 3, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23754, { 0, 2, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23754), { 0, 2, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 24620, { 0, 2, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(24620), { 0, 2, height }, { 32, 25, 2 },
                 { 0, 3, height });
             break;
     }
@@ -7201,7 +7265,8 @@ static void wooden_rc_track_water_splash(
     const TrackElement& trackElement)
 {
     const bool transparent = gConfigGeneral.transparent_water || (session.ViewFlags & VIEWPORT_FLAG_UNDERGROUND_INSIDE);
-    const uint32_t waterOverlay = transparent ? SPR_WATER_OVERLAY : SPR_RCT1_WATER_OVERLAY;
+    const auto waterMask = ImageId(SPR_WATER_MASK).WithRemap(FilterPaletteID::PaletteWater).WithBlended(true);
+    const auto waterOverlay = ImageId(transparent ? SPR_WATER_OVERLAY : SPR_RCT1_WATER_OVERLAY);
 
     switch (trackSequence)
     {
@@ -7210,107 +7275,99 @@ static void wooden_rc_track_water_splash(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23989, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23989), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24855, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, 0x61000000 | SPR_WATER_MASK, { 0, 0, height + 16 }, { 32, 25, 2 },
-                        { 0, 3, height + 16 });
-                    PaintAddImageAsChildRotated(
-                        session, direction, 0x00000000 | waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 },
-                        { 0, 3, height + 16 });
-                    PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_SUPPORTS] | 23997, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_SUPPORTS] | 24863, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23993, { 0, 0, height },
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24855), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24859, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                    PaintAddImageAsChildRotated(
+                        session, direction, waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                    PaintAddImageAsChildRotated(
+                        session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(23997), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24863), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23993), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24859), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23990, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23990), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24856, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, 0x61000000 | SPR_WATER_MASK, { 0, 0, height + 16 }, { 32, 25, 2 },
-                        { 0, 3, height + 16 });
-                    PaintAddImageAsChildRotated(
-                        session, direction, 0x00000000 | waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 },
-                        { 0, 3, height + 16 });
-                    PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_SUPPORTS] | 23998, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_SUPPORTS] | 24864, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23994, { 0, 0, height },
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24856), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24860, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                    PaintAddImageAsChildRotated(
+                        session, direction, waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                    PaintAddImageAsChildRotated(
+                        session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(23998), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24864), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23994), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24860), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23987, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23987), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24853, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, 0x61000000 | SPR_WATER_MASK, { 0, 0, height + 16 }, { 32, 25, 2 },
-                        { 0, 3, height + 16 });
-                    PaintAddImageAsChildRotated(
-                        session, direction, 0x00000000 | waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 },
-                        { 0, 3, height + 16 });
-                    PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_SUPPORTS] | 23995, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_SUPPORTS] | 24861, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23991, { 0, 0, height },
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24853), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24857, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                    PaintAddImageAsChildRotated(
+                        session, direction, waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                    PaintAddImageAsChildRotated(
+                        session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(23995), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24861), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23991), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24857), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23988, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23988), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24854, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, 0x61000000 | SPR_WATER_MASK, { 0, 0, height + 16 }, { 32, 25, 2 },
-                        { 0, 3, height + 16 });
-                    PaintAddImageAsChildRotated(
-                        session, direction, 0x00000000 | waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 },
-                        { 0, 3, height + 16 });
-                    PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_SUPPORTS] | 23996, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_SUPPORTS] | 24862, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23992, { 0, 0, height },
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24854), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24858, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                    PaintAddImageAsChildRotated(
+                        session, direction, waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                    PaintAddImageAsChildRotated(
+                        session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(23996), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24862), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23992), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24858), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
                     break;
             }
             wooden_a_supports_paint_setup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -7323,107 +7380,99 @@ static void wooden_rc_track_water_splash(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23977, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23977), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24843, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, 0x61000000 | SPR_WATER_MASK, { 0, 0, height + 16 }, { 32, 25, 2 },
-                        { 0, 3, height + 16 });
-                    PaintAddImageAsChildRotated(
-                        session, direction, 0x00000000 | waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 },
-                        { 0, 3, height + 16 });
-                    PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_SUPPORTS] | 23985, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_SUPPORTS] | 24851, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23981, { 0, 0, height },
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24843), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24847, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                    PaintAddImageAsChildRotated(
+                        session, direction, waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                    PaintAddImageAsChildRotated(
+                        session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(23985), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24851), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23981), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24847), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23978, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23978), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24844, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, 0x61000000 | SPR_WATER_MASK, { 0, 0, height + 16 }, { 32, 25, 2 },
-                        { 0, 3, height + 16 });
-                    PaintAddImageAsChildRotated(
-                        session, direction, 0x00000000 | waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 },
-                        { 0, 3, height + 16 });
-                    PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_SUPPORTS] | 23986, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_SUPPORTS] | 24852, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23982, { 0, 0, height },
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24844), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24848, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                    PaintAddImageAsChildRotated(
+                        session, direction, waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                    PaintAddImageAsChildRotated(
+                        session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(23986), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24852), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23982), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24848), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23975, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23975), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24841, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, 0x61000000 | SPR_WATER_MASK, { 0, 0, height + 16 }, { 32, 25, 2 },
-                        { 0, 3, height + 16 });
-                    PaintAddImageAsChildRotated(
-                        session, direction, 0x00000000 | waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 },
-                        { 0, 3, height + 16 });
-                    PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_SUPPORTS] | 23983, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_SUPPORTS] | 24849, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23979, { 0, 0, height },
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24841), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24845, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                    PaintAddImageAsChildRotated(
+                        session, direction, waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                    PaintAddImageAsChildRotated(
+                        session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(23983), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24849), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23979), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24845), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23976, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23976), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24842, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, 0x61000000 | SPR_WATER_MASK, { 0, 0, height + 16 }, { 32, 25, 2 },
-                        { 0, 3, height + 16 });
-                    PaintAddImageAsChildRotated(
-                        session, direction, 0x00000000 | waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 },
-                        { 0, 3, height + 16 });
-                    PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_SUPPORTS] | 23984, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_SUPPORTS] | 24850, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23980, { 0, 0, height },
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24842), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24846, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                    PaintAddImageAsChildRotated(
+                        session, direction, waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                    PaintAddImageAsChildRotated(
+                        session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(23984), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24850), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23980), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24846), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
                     break;
             }
             wooden_a_supports_paint_setup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -7436,56 +7485,52 @@ static void wooden_rc_track_water_splash(
                 case 0:
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23999, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23999), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24865, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, 0x61000000 | SPR_WATER_MASK, { 0, 0, height + 16 }, { 32, 25, 2 },
-                        { 0, 3, height + 16 });
-                    PaintAddImageAsChildRotated(
-                        session, direction, 0x00000000 | waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 },
-                        { 0, 3, height + 16 });
-                    PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_SUPPORTS] | 24003, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_SUPPORTS] | 24869, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24001, { 0, 0, height },
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24865), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24867, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                    PaintAddImageAsChildRotated(
+                        session, direction, waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                    PaintAddImageAsChildRotated(
+                        session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24003), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24869), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24001), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24867), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
                     break;
                 case 1:
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24000, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24000), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24866, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, 0x61000000 | SPR_WATER_MASK, { 0, 0, height + 16 }, { 32, 25, 2 },
-                        { 0, 3, height + 16 });
-                    PaintAddImageAsChildRotated(
-                        session, direction, 0x00000000 | waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 },
-                        { 0, 3, height + 16 });
-                    PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_SUPPORTS] | 24004, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_SUPPORTS] | 24870, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24002, { 0, 0, height },
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24866), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24868, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                    PaintAddImageAsChildRotated(
+                        session, direction, waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                    PaintAddImageAsChildRotated(
+                        session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24004), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24870), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24002), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24868), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
                     break;
             }
             wooden_a_supports_paint_setup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -7497,107 +7542,99 @@ static void wooden_rc_track_water_splash(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23975, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23975), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24841, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, 0x61000000 | SPR_WATER_MASK, { 0, 0, height + 16 }, { 32, 25, 2 },
-                        { 0, 3, height + 16 });
-                    PaintAddImageAsChildRotated(
-                        session, direction, 0x00000000 | waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 },
-                        { 0, 3, height + 16 });
-                    PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_SUPPORTS] | 23983, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_SUPPORTS] | 24849, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23979, { 0, 0, height },
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24841), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24845, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                    PaintAddImageAsChildRotated(
+                        session, direction, waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                    PaintAddImageAsChildRotated(
+                        session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(23983), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24849), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23979), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24845), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23976, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23976), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24842, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, 0x61000000 | SPR_WATER_MASK, { 0, 0, height + 16 }, { 32, 25, 2 },
-                        { 0, 3, height + 16 });
-                    PaintAddImageAsChildRotated(
-                        session, direction, 0x00000000 | waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 },
-                        { 0, 3, height + 16 });
-                    PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_SUPPORTS] | 23984, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_SUPPORTS] | 24850, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23980, { 0, 0, height },
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24842), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24846, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                    PaintAddImageAsChildRotated(
+                        session, direction, waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                    PaintAddImageAsChildRotated(
+                        session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(23984), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24850), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23980), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24846), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23977, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23977), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24843, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, 0x61000000 | SPR_WATER_MASK, { 0, 0, height + 16 }, { 32, 25, 2 },
-                        { 0, 3, height + 16 });
-                    PaintAddImageAsChildRotated(
-                        session, direction, 0x00000000 | waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 },
-                        { 0, 3, height + 16 });
-                    PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_SUPPORTS] | 23985, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_SUPPORTS] | 24851, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23981, { 0, 0, height },
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24843), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24847, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                    PaintAddImageAsChildRotated(
+                        session, direction, waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                    PaintAddImageAsChildRotated(
+                        session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(23985), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24851), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23981), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24847), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23978, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23978), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24844, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, 0x61000000 | SPR_WATER_MASK, { 0, 0, height + 16 }, { 32, 25, 2 },
-                        { 0, 3, height + 16 });
-                    PaintAddImageAsChildRotated(
-                        session, direction, 0x00000000 | waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 },
-                        { 0, 3, height + 16 });
-                    PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_SUPPORTS] | 23986, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_SUPPORTS] | 24852, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23982, { 0, 0, height },
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24844), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24848, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                    PaintAddImageAsChildRotated(
+                        session, direction, waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                    PaintAddImageAsChildRotated(
+                        session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(23986), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24852), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23982), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24848), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
                     break;
             }
             wooden_a_supports_paint_setup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -7609,107 +7646,99 @@ static void wooden_rc_track_water_splash(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23987, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23987), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24853, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, 0x61000000 | SPR_WATER_MASK, { 0, 0, height + 16 }, { 32, 25, 2 },
-                        { 0, 3, height + 16 });
-                    PaintAddImageAsChildRotated(
-                        session, direction, 0x00000000 | waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 },
-                        { 0, 3, height + 16 });
-                    PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_SUPPORTS] | 23995, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_SUPPORTS] | 24861, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23991, { 0, 0, height },
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24853), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24857, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                    PaintAddImageAsChildRotated(
+                        session, direction, waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                    PaintAddImageAsChildRotated(
+                        session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(23995), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24861), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23991), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24857), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23988, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23988), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24854, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, 0x61000000 | SPR_WATER_MASK, { 0, 0, height + 16 }, { 32, 25, 2 },
-                        { 0, 3, height + 16 });
-                    PaintAddImageAsChildRotated(
-                        session, direction, 0x00000000 | waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 },
-                        { 0, 3, height + 16 });
-                    PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_SUPPORTS] | 23996, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_SUPPORTS] | 24862, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23992, { 0, 0, height },
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24854), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24858, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                    PaintAddImageAsChildRotated(
+                        session, direction, waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                    PaintAddImageAsChildRotated(
+                        session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(23996), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24862), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23992), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24858), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23989, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23989), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24855, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, 0x61000000 | SPR_WATER_MASK, { 0, 0, height + 16 }, { 32, 25, 2 },
-                        { 0, 3, height + 16 });
-                    PaintAddImageAsChildRotated(
-                        session, direction, 0x00000000 | waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 },
-                        { 0, 3, height + 16 });
-                    PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_SUPPORTS] | 23997, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_SUPPORTS] | 24863, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23993, { 0, 0, height },
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24855), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24859, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                    PaintAddImageAsChildRotated(
+                        session, direction, waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                    PaintAddImageAsChildRotated(
+                        session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(23997), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24863), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23993), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24859), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23990, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23990), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24856, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, 0x61000000 | SPR_WATER_MASK, { 0, 0, height + 16 }, { 32, 25, 2 },
-                        { 0, 3, height + 16 });
-                    PaintAddImageAsChildRotated(
-                        session, direction, 0x00000000 | waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 },
-                        { 0, 3, height + 16 });
-                    PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_SUPPORTS] | 23998, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, session.TrackColours[SCHEME_SUPPORTS] | 24864, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23994, { 0, 0, height },
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24856), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24860, { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                    PaintAddImageAsChildRotated(
+                        session, direction, waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                    PaintAddImageAsChildRotated(
+                        session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(23998), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24864), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23994), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24860), { 0, 0, height },
+                        { 32, 25, 2 }, { 0, 3, height });
                     break;
             }
             wooden_a_supports_paint_setup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -7733,50 +7762,50 @@ static void wooden_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24137, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24137), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25003, { 0, 0, height }, { 32, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25003), { 0, 0, height },
+                        { 32, 32, 2 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24141, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24141), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25007, { 0, 0, height }, { 32, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25007), { 0, 0, height },
+                        { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24153, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24153), { 0, 0, height },
                         { 32, 32, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25019, { 0, 0, height }, { 32, 32, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25019), { 0, 0, height },
+                        { 32, 32, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24145, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24145), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25011, { 0, 0, height }, { 32, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25011), { 0, 0, height },
+                        { 32, 32, 2 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24149, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24149), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25015, { 0, 0, height }, { 32, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25015), { 0, 0, height },
+                        { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24157, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24157), { 0, 0, height },
                         { 32, 32, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25023, { 0, 0, height }, { 32, 32, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25023), { 0, 0, height },
+                        { 32, 32, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -7792,50 +7821,50 @@ static void wooden_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24138, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24138), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25004, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25004), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24142, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24142), { 0, 0, height },
                         { 34, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25008, { 0, 0, height }, { 34, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25008), { 0, 0, height },
+                        { 34, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24154, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24154), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25020, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25020), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24146, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24146), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25012, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25012), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24150, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24150), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25016, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25016), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24158, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24158), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25024, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25024), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height + 27 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -7847,50 +7876,50 @@ static void wooden_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24139, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24139), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25005, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25005), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24143, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24143), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25009, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25009), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24155, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24155), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25021, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25021), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 16, height + 27 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24147, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24147), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25013, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25013), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24151, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24151), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25017, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25017), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24159, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24159), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25025, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25025), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -7921,47 +7950,47 @@ static void wooden_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24140, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24140), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25006, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25006), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24144, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24144), { 0, 0, height },
                         { 16, 18, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25010, { 0, 0, height }, { 16, 18, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25010), { 0, 0, height },
+                        { 16, 18, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24156, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24156), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25022, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25022), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24148, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24148), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25014, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25014), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24152, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24152), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25018, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25018), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24160, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24160), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25026, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25026), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 0, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -7983,50 +8012,50 @@ static void wooden_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24113, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24113), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24979, { 0, 0, height }, { 32, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24979), { 0, 0, height },
+                        { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24129, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24129), { 0, 0, height },
                         { 32, 32, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24995, { 0, 0, height }, { 32, 32, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24995), { 0, 0, height },
+                        { 32, 32, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24117, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24117), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24983, { 0, 0, height }, { 32, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24983), { 0, 0, height },
+                        { 32, 32, 2 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24121, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24121), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24987, { 0, 0, height }, { 32, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24987), { 0, 0, height },
+                        { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24133, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24133), { 0, 0, height },
                         { 32, 32, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24999, { 0, 0, height }, { 32, 32, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24999), { 0, 0, height },
+                        { 32, 32, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24125, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24125), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24991, { 0, 0, height }, { 32, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24991), { 0, 0, height },
+                        { 32, 32, 2 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -8042,50 +8071,50 @@ static void wooden_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24114, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24114), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24980, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24980), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24130, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24130), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24996, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24996), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height + 27 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24118, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24118), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24984, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24984), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24122, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24122), { 0, 0, height },
                         { 34, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24988, { 0, 0, height }, { 34, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24988), { 0, 0, height },
+                        { 34, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24134, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24134), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25000, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25000), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24126, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24126), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24992, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24992), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -8097,50 +8126,50 @@ static void wooden_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24115, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24115), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24981, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24981), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24131, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24131), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24997, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24997), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24119, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24119), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24985, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24985), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24123, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24123), { 0, 0, height },
                         { 28, 28, 2 }, { 4, 4, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24989, { 0, 0, height }, { 28, 28, 2 },
-                        { 4, 4, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24989), { 0, 0, height },
+                        { 28, 28, 2 }, { 4, 4, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24135, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24135), { 0, 0, height },
                         { 28, 28, 0 }, { 4, 4, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25001, { 0, 0, height }, { 28, 28, 0 },
-                        { 4, 4, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25001), { 0, 0, height },
+                        { 28, 28, 0 }, { 4, 4, height + 27 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24127, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24127), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24993, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24993), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -8171,47 +8200,47 @@ static void wooden_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24116, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24116), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24982, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24982), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24132, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24132), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24998, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24998), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 0, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24120, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24120), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24986, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24986), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24124, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24124), { 0, 0, height },
                         { 16, 18, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24990, { 0, 0, height }, { 16, 18, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24990), { 0, 0, height },
+                        { 16, 18, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24136, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24136), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25002, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25002), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 16, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24128, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24128), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24994, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24994), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -8253,50 +8282,50 @@ static void wooden_rc_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24185, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24185), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25051, { 0, 0, height }, { 32, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25051), { 0, 0, height },
+                        { 32, 32, 2 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24189, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24189), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25055, { 0, 0, height }, { 32, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25055), { 0, 0, height },
+                        { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24201, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24201), { 0, 0, height },
                         { 32, 32, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25067, { 0, 0, height }, { 32, 32, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25067), { 0, 0, height },
+                        { 32, 32, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24193, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24193), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25059, { 0, 0, height }, { 32, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25059), { 0, 0, height },
+                        { 32, 32, 2 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24197, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24197), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25063, { 0, 0, height }, { 32, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25063), { 0, 0, height },
+                        { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24205, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24205), { 0, 0, height },
                         { 32, 32, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25071, { 0, 0, height }, { 32, 32, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25071), { 0, 0, height },
+                        { 32, 32, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -8312,50 +8341,50 @@ static void wooden_rc_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24186, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24186), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25052, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25052), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24190, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24190), { 0, 0, height },
                         { 34, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25056, { 0, 0, height }, { 34, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25056), { 0, 0, height },
+                        { 34, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24202, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24202), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25068, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25068), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24194, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24194), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25060, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25060), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24198, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24198), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25064, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25064), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24206, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24206), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25072, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25072), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height + 27 });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -8367,50 +8396,50 @@ static void wooden_rc_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24187, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24187), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25053, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25053), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24191, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24191), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25057, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25057), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24203, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24203), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25069, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25069), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 16, height + 27 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24195, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24195), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25061, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25061), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24199, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24199), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25065, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25065), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24207, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24207), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25073, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25073), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -8441,47 +8470,47 @@ static void wooden_rc_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24188, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24188), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25054, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25054), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24192, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24192), { 0, 0, height },
                         { 16, 18, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25058, { 0, 0, height }, { 16, 18, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25058), { 0, 0, height },
+                        { 16, 18, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24204, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24204), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25070, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25070), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24196, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24196), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25062, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25062), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24200, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24200), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25066, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25066), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24208, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24208), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25074, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25074), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 0, height + 27 });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -8503,50 +8532,50 @@ static void wooden_rc_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24161, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24161), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25027, { 0, 0, height }, { 32, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25027), { 0, 0, height },
+                        { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24177, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24177), { 0, 0, height },
                         { 32, 32, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25043, { 0, 0, height }, { 32, 32, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25043), { 0, 0, height },
+                        { 32, 32, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24165, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24165), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25031, { 0, 0, height }, { 32, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25031), { 0, 0, height },
+                        { 32, 32, 2 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24169, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24169), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25035, { 0, 0, height }, { 32, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25035), { 0, 0, height },
+                        { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24181, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24181), { 0, 0, height },
                         { 32, 32, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25047, { 0, 0, height }, { 32, 32, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25047), { 0, 0, height },
+                        { 32, 32, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24173, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24173), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25039, { 0, 0, height }, { 32, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25039), { 0, 0, height },
+                        { 32, 32, 2 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -8562,50 +8591,50 @@ static void wooden_rc_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24162, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24162), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25028, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25028), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24178, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24178), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25044, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25044), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height + 27 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24166, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24166), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25032, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25032), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24170, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24170), { 0, 0, height },
                         { 34, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25036, { 0, 0, height }, { 34, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25036), { 0, 0, height },
+                        { 34, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24182, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24182), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25048, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25048), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24174, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24174), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25040, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25040), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -8617,50 +8646,50 @@ static void wooden_rc_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24163, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24163), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25029, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25029), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24179, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24179), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25045, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25045), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 0, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24167, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24167), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25033, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25033), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24171, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24171), { 0, 0, height },
                         { 28, 28, 2 }, { 4, 4, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25037, { 0, 0, height }, { 28, 28, 2 },
-                        { 4, 4, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25037), { 0, 0, height },
+                        { 28, 28, 2 }, { 4, 4, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24183, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24183), { 0, 0, height },
                         { 28, 28, 0 }, { 4, 4, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25049, { 0, 0, height }, { 28, 28, 0 },
-                        { 4, 4, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25049), { 0, 0, height },
+                        { 28, 28, 0 }, { 4, 4, height + 27 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24175, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24175), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25041, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25041), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -8691,47 +8720,47 @@ static void wooden_rc_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24164, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24164), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25030, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25030), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24180, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24180), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25046, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25046), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 0, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24168, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24168), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25034, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25034), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24172, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24172), { 0, 0, height },
                         { 16, 18, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25038, { 0, 0, height }, { 16, 18, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25038), { 0, 0, height },
+                        { 16, 18, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24184, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24184), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25050, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25050), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 16, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24176, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24176), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25042, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25042), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -8777,10 +8806,10 @@ static void wooden_rc_track_diag_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24050, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24050),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24916, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24916), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -8791,10 +8820,10 @@ static void wooden_rc_track_diag_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24008, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24008),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24874, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24874), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -8809,16 +8838,16 @@ static void wooden_rc_track_diag_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24047, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24047),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24913, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24913), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24051, { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 27 });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24051),
+                            { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24917, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24917), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 27 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -8839,16 +8868,16 @@ static void wooden_rc_track_diag_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24005, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24005),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24871, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24871), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24009, { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 27 });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24009),
+                            { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24875, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24875), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 27 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -8879,16 +8908,16 @@ static void wooden_rc_track_diag_flat(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24049, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24049),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24915, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24915), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24052, { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 27 });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24052),
+                            { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24918, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24918), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 27 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -8909,16 +8938,16 @@ static void wooden_rc_track_diag_flat(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24007, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24007),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24873, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24873), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24010, { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 27 });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24010),
+                            { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24876, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24876), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 27 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -8937,10 +8966,10 @@ static void wooden_rc_track_diag_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24048, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24048),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24914, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24914), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -8951,10 +8980,10 @@ static void wooden_rc_track_diag_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24006, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24006),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24872, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24872), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -8980,10 +9009,10 @@ static void wooden_rc_track_diag_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24068, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24068),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24934, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24934), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -8994,10 +9023,10 @@ static void wooden_rc_track_diag_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24026, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24026),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24892, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24892), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -9012,16 +9041,16 @@ static void wooden_rc_track_diag_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24065, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24065),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24931, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24931), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24069, { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 43 });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24069),
+                            { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 43 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24935, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24935), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 43 });
                         wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9042,16 +9071,16 @@ static void wooden_rc_track_diag_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24023, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24023),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24889, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24889), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24027, { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 43 });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24027),
+                            { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 43 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24893, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24893), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 43 });
                         wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9082,16 +9111,16 @@ static void wooden_rc_track_diag_25_deg_up(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24067, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24067),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24933, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24933), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24070, { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 43 });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24070),
+                            { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 43 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24936, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24936), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 43 });
                         wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9112,16 +9141,16 @@ static void wooden_rc_track_diag_25_deg_up(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24025, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24025),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24891, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24891), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24028, { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 43 });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24028),
+                            { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 43 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24894, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24894), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 43 });
                         wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9140,10 +9169,10 @@ static void wooden_rc_track_diag_25_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24066, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24066),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24932, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24932), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -9154,10 +9183,10 @@ static void wooden_rc_track_diag_25_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24024, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24024),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24890, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24890), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -9181,11 +9210,11 @@ static void wooden_rc_track_diag_60_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24044, { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24044),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24910, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24910), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -9196,17 +9225,17 @@ static void wooden_rc_track_diag_60_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24041, { -16, -16, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24041),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24907), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24907, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24045, { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 91 });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24045),
+                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 91 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24911, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 91 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24911), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 91 });
                     wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -9233,17 +9262,17 @@ static void wooden_rc_track_diag_60_deg_up(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24043, { -16, -16, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24043),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24909), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24909, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24046, { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 91 });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24046),
+                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 91 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24912, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 91 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24912), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 91 });
                     wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -9258,11 +9287,11 @@ static void wooden_rc_track_diag_60_deg_up(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24042, { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24042),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24908, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24908), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -9286,10 +9315,10 @@ static void wooden_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24056, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24056),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24922, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24922), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -9300,10 +9329,10 @@ static void wooden_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24014, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24014),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24880, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24880), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -9318,16 +9347,16 @@ static void wooden_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24053, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24053),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24919, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24919), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24057, { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 35 });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24057),
+                            { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24923, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24923), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 35 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9348,16 +9377,16 @@ static void wooden_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24011, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24011),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24877, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24877), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24015, { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 35 });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24015),
+                            { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24881, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24881), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 35 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9388,16 +9417,16 @@ static void wooden_rc_track_diag_flat_to_25_deg_up(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24055, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24055),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24921, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24921), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24058, { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 35 });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24058),
+                            { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24924, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24924), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 35 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9418,16 +9447,16 @@ static void wooden_rc_track_diag_flat_to_25_deg_up(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24013, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24013),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24879, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24879), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24016, { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 35 });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24016),
+                            { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24882, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24882), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 35 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9446,10 +9475,10 @@ static void wooden_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24054, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24054),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24920, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24920), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -9460,10 +9489,10 @@ static void wooden_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24012, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24012),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24878, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24878), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -9487,11 +9516,11 @@ static void wooden_rc_track_diag_25_deg_up_to_60_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24032, { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24032),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24898, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24898), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -9502,17 +9531,17 @@ static void wooden_rc_track_diag_25_deg_up_to_60_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24029, { -16, -16, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24029),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24895), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24895, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24033, { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 59 });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24033),
+                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 59 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24899, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 59 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24899), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 59 });
                     wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -9539,17 +9568,17 @@ static void wooden_rc_track_diag_25_deg_up_to_60_deg_up(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24031, { -16, -16, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24031),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24897), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24897, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24034, { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 59 });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24034),
+                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 59 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24900, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 59 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24900), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 59 });
                     wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -9564,11 +9593,11 @@ static void wooden_rc_track_diag_25_deg_up_to_60_deg_up(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24030, { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24030),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24896, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24896), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -9590,11 +9619,11 @@ static void wooden_rc_track_diag_60_deg_up_to_25_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24038, { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24038),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24904, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24904), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -9605,17 +9634,17 @@ static void wooden_rc_track_diag_60_deg_up_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24035, { -16, -16, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24035),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24901), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24901, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24039, { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 59 });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24039),
+                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 59 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24905, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 59 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24905), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 59 });
                     wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -9642,17 +9671,17 @@ static void wooden_rc_track_diag_60_deg_up_to_25_deg_up(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24037, { -16, -16, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24037),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24903), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24903, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24040, { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 59 });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24040),
+                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 59 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24906, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 59 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24906), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 59 });
                     wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -9667,11 +9696,11 @@ static void wooden_rc_track_diag_60_deg_up_to_25_deg_up(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24036, { -16, -16, height },
-                        { 16, 16, 2 }, { 0, 0, height });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24036),
+                        { -16, -16, height }, { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24902, { -16, -16, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24902), { -16, -16, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -9695,10 +9724,10 @@ static void wooden_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24062, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24062),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24928, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24928), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -9709,10 +9738,10 @@ static void wooden_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24020, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24020),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24886, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24886), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -9727,16 +9756,16 @@ static void wooden_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24059, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24059),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24925, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24925), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24063, { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 35 });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24063),
+                            { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24929, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24929), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 35 });
                         wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9757,16 +9786,16 @@ static void wooden_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24017, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24017),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24883, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24883), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24021, { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 35 });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24021),
+                            { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24887, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24887), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 35 });
                         wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9797,16 +9826,16 @@ static void wooden_rc_track_diag_25_deg_up_to_flat(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24061, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24061),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24927, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24927), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24064, { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 35 });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24064),
+                            { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24930, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24930), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 35 });
                         wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9827,16 +9856,16 @@ static void wooden_rc_track_diag_25_deg_up_to_flat(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24019, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24019),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24885, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24885), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24022, { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 35 });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24022),
+                            { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24888, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24888), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 35 });
                         wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9855,10 +9884,10 @@ static void wooden_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24060, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24060),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24926, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24926), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -9869,10 +9898,10 @@ static void wooden_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24018, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24018),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24884, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24884), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -9898,10 +9927,10 @@ static void wooden_rc_track_diag_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24066, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24066),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24932, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24932), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -9912,10 +9941,10 @@ static void wooden_rc_track_diag_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24024, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24024),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24890, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24890), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -9930,16 +9959,16 @@ static void wooden_rc_track_diag_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24067, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24067),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24933, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24933), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24070, { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 43 });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24070),
+                            { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 43 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24936, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24936), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 43 });
                         wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9960,16 +9989,16 @@ static void wooden_rc_track_diag_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24025, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24025),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24891, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24891), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24028, { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 43 });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24028),
+                            { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 43 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24894, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24894), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 43 });
                         wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -10000,16 +10029,16 @@ static void wooden_rc_track_diag_25_deg_down(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24065, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24065),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24931, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24931), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24069, { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 43 });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24069),
+                            { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 43 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24935, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24935), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 43 });
                         wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -10030,16 +10059,16 @@ static void wooden_rc_track_diag_25_deg_down(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24023, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24023),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24889, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24889), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24027, { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 43 });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24027),
+                            { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 43 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24893, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24893), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 43 });
                         wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -10058,10 +10087,10 @@ static void wooden_rc_track_diag_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24068, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24068),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24934, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24934), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -10072,10 +10101,10 @@ static void wooden_rc_track_diag_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24026, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24026),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24892, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24892), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -10099,11 +10128,11 @@ static void wooden_rc_track_diag_60_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24042, { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24042),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24908, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24908), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -10114,17 +10143,17 @@ static void wooden_rc_track_diag_60_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24043, { -16, -16, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24043),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24909), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24909, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24046, { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 91 });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24046),
+                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 91 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24912, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 91 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24912), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 91 });
                     wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -10151,17 +10180,17 @@ static void wooden_rc_track_diag_60_deg_down(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24041, { -16, -16, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24041),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24907), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24907, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24045, { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 91 });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24045),
+                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 91 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24911, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 91 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24911), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 91 });
                     wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -10176,11 +10205,11 @@ static void wooden_rc_track_diag_60_deg_down(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24044, { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24044),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24910, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24910), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -10204,10 +10233,10 @@ static void wooden_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24060, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24060),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24926, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24926), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -10218,10 +10247,10 @@ static void wooden_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24018, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24018),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24884, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24884), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -10234,16 +10263,16 @@ static void wooden_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24061, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24061),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24927, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24927), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24064, { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 35 });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24064),
+                            { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24930, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24930), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 35 });
                         wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -10264,16 +10293,16 @@ static void wooden_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24019, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24019),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24885, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24885), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24022, { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 35 });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24022),
+                            { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24888, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24888), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 35 });
                         wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -10302,16 +10331,16 @@ static void wooden_rc_track_diag_flat_to_25_deg_down(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24059, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24059),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24925, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24925), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24063, { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 35 });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24063),
+                            { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24929, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24929), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 35 });
                         wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -10332,16 +10361,16 @@ static void wooden_rc_track_diag_flat_to_25_deg_down(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24017, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24017),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24883, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24883), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24021, { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 35 });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24021),
+                            { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24887, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24887), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 35 });
                         wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -10358,10 +10387,10 @@ static void wooden_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24062, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24062),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24928, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24928), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -10372,10 +10401,10 @@ static void wooden_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24020, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24020),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24886, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24886), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -10400,11 +10429,11 @@ static void wooden_rc_track_diag_25_deg_down_to_60_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24036, { -16, -16, height },
-                        { 16, 16, 2 }, { 0, 0, height });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24036),
+                        { -16, -16, height }, { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24902, { -16, -16, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24902), { -16, -16, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -10415,17 +10444,17 @@ static void wooden_rc_track_diag_25_deg_down_to_60_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24037, { -16, -16, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24037),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24903), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24903, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24040, { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 59 });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24040),
+                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 59 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24906, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 59 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24906), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 59 });
                     wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -10452,17 +10481,17 @@ static void wooden_rc_track_diag_25_deg_down_to_60_deg_down(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24035, { -16, -16, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24035),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24901), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24901, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24039, { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 59 });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24039),
+                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 59 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24905, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 59 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24905), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 59 });
                     wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -10477,11 +10506,11 @@ static void wooden_rc_track_diag_25_deg_down_to_60_deg_down(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24038, { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24038),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24904, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24904), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -10503,11 +10532,11 @@ static void wooden_rc_track_diag_60_deg_down_to_25_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24030, { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24030),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24896, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24896), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -10518,17 +10547,17 @@ static void wooden_rc_track_diag_60_deg_down_to_25_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24031, { -16, -16, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24031),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24897), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24897, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24034, { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 59 });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24034),
+                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 59 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24900, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 59 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24900), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 59 });
                     wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -10555,17 +10584,17 @@ static void wooden_rc_track_diag_60_deg_down_to_25_deg_down(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24029, { -16, -16, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24029),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24895), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24895, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24033, { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 59 });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24033),
+                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 59 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24899, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 59 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24899), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 59 });
                     wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -10580,11 +10609,11 @@ static void wooden_rc_track_diag_60_deg_down_to_25_deg_down(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24032, { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24032),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24898, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24898), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -10608,10 +10637,10 @@ static void wooden_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24054, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24054),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24920, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24920), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -10622,10 +10651,10 @@ static void wooden_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24012, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24012),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24878, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24878), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -10640,16 +10669,16 @@ static void wooden_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24055, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24055),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24921, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24921), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24058, { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 35 });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24058),
+                            { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24924, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24924), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 35 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -10670,16 +10699,16 @@ static void wooden_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24013, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24013),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24879, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24879), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24016, { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 35 });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24016),
+                            { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24882, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24882), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 35 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -10710,16 +10739,16 @@ static void wooden_rc_track_diag_25_deg_down_to_flat(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24053, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24053),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24919, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24919), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24057, { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 35 });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24057),
+                            { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24923, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24923), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 35 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -10740,16 +10769,16 @@ static void wooden_rc_track_diag_25_deg_down_to_flat(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24011, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24011),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24877, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24877), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24015, { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 35 });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24015),
+                            { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24881, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24881), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 35 });
                         wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -10768,10 +10797,10 @@ static void wooden_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24056, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24056),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24922, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24922), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -10782,10 +10811,10 @@ static void wooden_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24014, { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24014),
+                            { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session) | 24880, { -16, -16, height },
+                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24880), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -10809,11 +10838,11 @@ static void wooden_rc_track_diag_flat_to_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24080, { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24080),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24946, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24946), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -10824,17 +10853,17 @@ static void wooden_rc_track_diag_flat_to_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24077, { -16, -16, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24077),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24943), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24943, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24081, { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 27 });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24081),
+                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24947, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24947), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -10861,17 +10890,17 @@ static void wooden_rc_track_diag_flat_to_left_bank(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24079, { -16, -16, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24079),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24945), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24945, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24082, { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 27 });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24082),
+                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24948, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24948), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -10886,11 +10915,11 @@ static void wooden_rc_track_diag_flat_to_left_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24078, { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24078),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24944, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24944), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -10912,11 +10941,11 @@ static void wooden_rc_track_diag_flat_to_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24086, { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24086),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24952, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24952), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -10927,17 +10956,17 @@ static void wooden_rc_track_diag_flat_to_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24083, { -16, -16, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24083),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24949), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24949, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24087, { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 27 });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24087),
+                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24953, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24953), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -10964,17 +10993,17 @@ static void wooden_rc_track_diag_flat_to_right_bank(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24085, { -16, -16, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24085),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24951), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24951, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24088, { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 27 });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24088),
+                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24954, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24954), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -10989,11 +11018,11 @@ static void wooden_rc_track_diag_flat_to_right_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24084, { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24084),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24950, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24950), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -11015,11 +11044,11 @@ static void wooden_rc_track_diag_left_bank_to_flat(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24084, { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24084),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24950, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24950), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -11030,17 +11059,17 @@ static void wooden_rc_track_diag_left_bank_to_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24085, { -16, -16, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24085),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24951), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24951, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24088, { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 27 });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24088),
+                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24954, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24954), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -11067,17 +11096,17 @@ static void wooden_rc_track_diag_left_bank_to_flat(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24083, { -16, -16, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24083),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24949), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24949, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24087, { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 27 });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24087),
+                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24953, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24953), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -11092,11 +11121,11 @@ static void wooden_rc_track_diag_left_bank_to_flat(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24086, { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24086),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24952, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24952), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -11118,11 +11147,11 @@ static void wooden_rc_track_diag_right_bank_to_flat(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24078, { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24078),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24944, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24944), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -11133,17 +11162,17 @@ static void wooden_rc_track_diag_right_bank_to_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24079, { -16, -16, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24079),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24945), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24945, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24082, { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 27 });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24082),
+                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24948, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24948), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -11170,17 +11199,17 @@ static void wooden_rc_track_diag_right_bank_to_flat(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24077, { -16, -16, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24077),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24943), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24943, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24081, { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 27 });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24081),
+                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24947, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24947), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -11195,11 +11224,11 @@ static void wooden_rc_track_diag_right_bank_to_flat(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24080, { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24080),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24946, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24946), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -11221,11 +11250,11 @@ static void wooden_rc_track_diag_left_bank_to_25_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24104, { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24104),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24970, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24970), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -11236,17 +11265,17 @@ static void wooden_rc_track_diag_left_bank_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24101, { -16, -16, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24101),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24967), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24967, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24105, { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 35 });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24105),
+                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24971, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24971), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -11273,17 +11302,17 @@ static void wooden_rc_track_diag_left_bank_to_25_deg_up(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24103, { -16, -16, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24103),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24969), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24969, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24106, { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 35 });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24106),
+                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24972, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24972), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -11298,11 +11327,11 @@ static void wooden_rc_track_diag_left_bank_to_25_deg_up(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24102, { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24102),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24968, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24968), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -11324,11 +11353,11 @@ static void wooden_rc_track_diag_right_bank_to_25_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24110, { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24110),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24976, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24976), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -11339,17 +11368,17 @@ static void wooden_rc_track_diag_right_bank_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24107, { -16, -16, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24107),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24973), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24973, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24111, { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 35 });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24111),
+                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24977, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24977), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -11376,17 +11405,17 @@ static void wooden_rc_track_diag_right_bank_to_25_deg_up(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24109, { -16, -16, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24109),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24975), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24975, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24112, { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 35 });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24112),
+                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24978, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24978), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -11401,11 +11430,11 @@ static void wooden_rc_track_diag_right_bank_to_25_deg_up(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24108, { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24108),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24974, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24974), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -11427,11 +11456,11 @@ static void wooden_rc_track_diag_25_deg_up_to_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24092, { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24092),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24958, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24958), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -11442,17 +11471,17 @@ static void wooden_rc_track_diag_25_deg_up_to_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24089, { -16, -16, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24089),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24955), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24955, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24093, { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 35 });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24093),
+                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24959, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24959), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -11479,17 +11508,17 @@ static void wooden_rc_track_diag_25_deg_up_to_left_bank(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24091, { -16, -16, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24091),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24957), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24957, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24094, { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 35 });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24094),
+                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24960, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24960), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -11504,11 +11533,11 @@ static void wooden_rc_track_diag_25_deg_up_to_left_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24090, { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24090),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24956, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24956), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -11530,11 +11559,11 @@ static void wooden_rc_track_diag_25_deg_up_to_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24098, { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24098),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24964, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24964), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -11545,17 +11574,17 @@ static void wooden_rc_track_diag_25_deg_up_to_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24095, { -16, -16, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24095),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24961), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24961, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24099, { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 35 });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24099),
+                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24965, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24965), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -11582,17 +11611,17 @@ static void wooden_rc_track_diag_25_deg_up_to_right_bank(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24097, { -16, -16, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24097),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24963), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24963, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24100, { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 35 });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24100),
+                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24966, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24966), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -11607,11 +11636,11 @@ static void wooden_rc_track_diag_25_deg_up_to_right_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24096, { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24096),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24962, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24962), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -11633,11 +11662,11 @@ static void wooden_rc_track_diag_left_bank_to_25_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24096, { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24096),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24962, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24962), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
             break;
@@ -11646,17 +11675,17 @@ static void wooden_rc_track_diag_left_bank_to_25_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24097, { -16, -16, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24097),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24963), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24963, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24100, { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 35 });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24100),
+                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24966, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24966), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -11681,17 +11710,17 @@ static void wooden_rc_track_diag_left_bank_to_25_deg_down(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24095, { -16, -16, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24095),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24961), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24961, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24099, { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 35 });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24099),
+                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24965, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24965), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -11704,11 +11733,11 @@ static void wooden_rc_track_diag_left_bank_to_25_deg_down(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24098, { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24098),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24964, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24964), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
             break;
@@ -11731,11 +11760,11 @@ static void wooden_rc_track_diag_right_bank_to_25_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24090, { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24090),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24956, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24956), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
             break;
@@ -11744,17 +11773,17 @@ static void wooden_rc_track_diag_right_bank_to_25_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24091, { -16, -16, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24091),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24957), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24957, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24094, { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 35 });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24094),
+                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24960, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24960), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -11779,17 +11808,17 @@ static void wooden_rc_track_diag_right_bank_to_25_deg_down(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24089, { -16, -16, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24089),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24955), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24955, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24093, { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 35 });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24093),
+                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24959, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24959), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     wooden_b_supports_paint_setup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -11802,11 +11831,11 @@ static void wooden_rc_track_diag_right_bank_to_25_deg_down(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24092, { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24092),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24958, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24958), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
             break;
@@ -11829,11 +11858,11 @@ static void wooden_rc_track_diag_25_deg_down_to_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24108, { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24108),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24974, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24974), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -11844,17 +11873,17 @@ static void wooden_rc_track_diag_25_deg_down_to_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24109, { -16, -16, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24109),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24975), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24975, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24112, { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 35 });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24112),
+                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24978, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24978), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -11881,17 +11910,17 @@ static void wooden_rc_track_diag_25_deg_down_to_left_bank(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24107, { -16, -16, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24107),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24973), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24973, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24111, { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 35 });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24111),
+                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24977, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24977), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -11906,11 +11935,11 @@ static void wooden_rc_track_diag_25_deg_down_to_left_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24110, { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24110),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24976, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24976), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -11932,11 +11961,11 @@ static void wooden_rc_track_diag_25_deg_down_to_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24102, { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24102),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24968, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24968), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -11947,17 +11976,17 @@ static void wooden_rc_track_diag_25_deg_down_to_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24103, { -16, -16, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24103),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24969), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24969, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24106, { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 35 });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24106),
+                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24972, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24972), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -11984,17 +12013,17 @@ static void wooden_rc_track_diag_25_deg_down_to_right_bank(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24101, { -16, -16, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24101),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24967), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24967, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24105, { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 35 });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24105),
+                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24971, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 35 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24971), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -12009,11 +12038,11 @@ static void wooden_rc_track_diag_25_deg_down_to_right_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24104, { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24104),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24970, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24970), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -12035,11 +12064,11 @@ static void wooden_rc_track_diag_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24074, { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24074),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24940, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24940), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -12050,17 +12079,17 @@ static void wooden_rc_track_diag_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24071, { -16, -16, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24071),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24937), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24937, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24075, { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 27 });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24075),
+                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24941, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24941), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -12087,17 +12116,17 @@ static void wooden_rc_track_diag_left_bank(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24073, { -16, -16, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24073),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24939), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24939, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24076, { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 27 });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24076),
+                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24942, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24942), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -12112,11 +12141,11 @@ static void wooden_rc_track_diag_left_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24072, { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24072),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24938, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24938), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -12138,11 +12167,11 @@ static void wooden_rc_track_diag_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24072, { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24072),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24938, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24938), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -12153,17 +12182,17 @@ static void wooden_rc_track_diag_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24073, { -16, -16, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24073),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24939), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24939, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24076, { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 27 });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24076),
+                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24942, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24942), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -12190,17 +12219,17 @@ static void wooden_rc_track_diag_right_bank(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24071, { -16, -16, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24071),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                    PaintAddImageAsChildRotated(
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24937), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
-                    PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24937, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24075, { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 27 });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24075),
+                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24941, { -16, -16, height }, { 32, 32, 0 },
-                        { -16, -16, height + 27 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24941), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -12215,11 +12244,11 @@ static void wooden_rc_track_diag_right_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24074, { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24074),
+                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24940, { -16, -16, height }, { 32, 32, 2 },
-                        { -16, -16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24940), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -12241,50 +12270,50 @@ static void wooden_rc_track_left_bank_to_left_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23958, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23958), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24824, { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24824), { 0, 6, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23960, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23960), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24826, { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24826), { 0, 6, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23971, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23971), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24837, { 0, 6, height }, { 32, 20, 0 },
-                        { 0, 6, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24837), { 0, 6, height },
+                        { 32, 20, 0 }, { 0, 6, height + 67 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23962, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23962), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24828, { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24828), { 0, 6, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23956, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23956), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24822, { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24822), { 0, 6, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23969, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23969), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24835, { 0, 6, height }, { 32, 20, 0 },
-                        { 0, 6, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24835), { 0, 6, height },
+                        { 32, 20, 0 }, { 0, 6, height + 67 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -12308,56 +12337,56 @@ static void wooden_rc_track_left_bank_to_left_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23957, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23957), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24823, { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24823), { 6, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23959, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23959), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24825, { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24825), { 6, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23970, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23970), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24836, { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24836), { 6, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23961, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23961), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24827, { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24827), { 6, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23972, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23972), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24838, { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24838), { 6, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23955, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23955), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24821, { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24821), { 6, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23968, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23968), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24834, { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24834), { 6, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -12389,50 +12418,50 @@ static void wooden_rc_track_right_bank_to_right_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23947, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23947), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24813, { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24813), { 0, 6, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23963, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23963), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24829, { 0, 6, height }, { 32, 20, 0 },
-                        { 0, 6, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24829), { 0, 6, height },
+                        { 32, 20, 0 }, { 0, 6, height + 67 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23949, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23949), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24815, { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24815), { 0, 6, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23951, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23951), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24817, { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24817), { 0, 6, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23966, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23966), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24832, { 0, 6, height }, { 32, 20, 0 },
-                        { 0, 6, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24832), { 0, 6, height },
+                        { 32, 20, 0 }, { 0, 6, height + 67 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23953, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23953), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24819, { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24819), { 0, 6, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -12456,56 +12485,56 @@ static void wooden_rc_track_right_bank_to_right_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23948, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23948), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24814, { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24814), { 6, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23964, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23964), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24830, { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24830), { 6, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23950, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23950), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24816, { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24816), { 6, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23965, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23965), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24831, { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24831), { 6, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23952, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23952), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24818, { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24818), { 6, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23967, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23967), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24833, { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24833), { 6, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23954, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23954), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24820, { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24820), { 6, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -12537,56 +12566,56 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_down_to_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23950, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23950), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24816, { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24816), { 0, 6, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23965, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23965), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24831, { 0, 6, height }, { 32, 20, 0 },
-                        { 0, 6, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24831), { 0, 6, height },
+                        { 32, 20, 0 }, { 0, 6, height + 67 });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23952, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23952), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24818, { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24818), { 0, 6, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23967, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23967), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24833, { 0, 6, height }, { 32, 20, 0 },
-                        { 0, 6, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24833), { 0, 6, height },
+                        { 32, 20, 0 }, { 0, 6, height + 67 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23954, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23954), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24820, { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24820), { 0, 6, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23948, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23948), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24814, { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24814), { 0, 6, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23964, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23964), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24830, { 0, 6, height }, { 32, 20, 0 },
-                        { 0, 6, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24830), { 0, 6, height },
+                        { 32, 20, 0 }, { 0, 6, height + 67 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -12610,50 +12639,50 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_down_to_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23949, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23949), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24815, { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24815), { 6, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23951, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23951), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24817, { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24817), { 6, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23966, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23966), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24832, { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24832), { 6, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23953, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23953), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24819, { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24819), { 6, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23947, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23947), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24813, { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24813), { 6, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23963, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23963), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24829, { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24829), { 6, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -12685,56 +12714,56 @@ static void wooden_rc_track_right_quarter_turn_3_25_deg_down_to_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23955, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23955), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24821, { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24821), { 0, 6, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23968, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23968), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24834, { 0, 6, height }, { 32, 20, 0 },
-                        { 0, 6, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24834), { 0, 6, height },
+                        { 32, 20, 0 }, { 0, 6, height + 67 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23957, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23957), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24823, { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24823), { 0, 6, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23959, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23959), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24825, { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24825), { 0, 6, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23970, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23970), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24836, { 0, 6, height }, { 32, 20, 0 },
-                        { 0, 6, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24836), { 0, 6, height },
+                        { 32, 20, 0 }, { 0, 6, height + 67 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23961, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23961), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24827, { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24827), { 0, 6, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23972, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23972), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24838, { 0, 6, height }, { 32, 20, 0 },
-                        { 0, 6, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24838), { 0, 6, height },
+                        { 32, 20, 0 }, { 0, 6, height + 67 });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -12758,50 +12787,50 @@ static void wooden_rc_track_right_quarter_turn_3_25_deg_down_to_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23956, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23956), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24822, { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24822), { 6, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23969, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23969), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24835, { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24835), { 6, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23958, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23958), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24824, { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24824), { 6, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23960, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23960), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24826, { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24826), { 6, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23971, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23971), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24837, { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24837), { 6, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23962, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23962), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24828, { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24828), { 6, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -12849,50 +12878,50 @@ static void wooden_rc_track_left_banked_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23932, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23932), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24798, { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24798), { 0, 6, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23934, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23934), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24800, { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24800), { 0, 6, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23945, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23945), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24811, { 0, 6, height }, { 32, 20, 0 },
-                        { 0, 6, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24811), { 0, 6, height },
+                        { 32, 20, 0 }, { 0, 6, height + 67 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23936, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23936), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24802, { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24802), { 0, 6, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23930, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23930), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24796, { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24796), { 0, 6, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23943, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23943), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24809, { 0, 6, height }, { 32, 20, 0 },
-                        { 0, 6, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24809), { 0, 6, height },
+                        { 32, 20, 0 }, { 0, 6, height + 67 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -12916,56 +12945,56 @@ static void wooden_rc_track_left_banked_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23931, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23931), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24797, { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24797), { 6, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23933, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23933), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24799, { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24799), { 6, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23944, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23944), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24810, { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24810), { 6, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23935, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23935), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24801, { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24801), { 6, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23946, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23946), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24812, { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24812), { 6, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23929, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23929), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24795, { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24795), { 6, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23942, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23942), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24808, { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24808), { 6, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -12997,50 +13026,50 @@ static void wooden_rc_track_right_banked_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23921, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23921), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24787, { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24787), { 0, 6, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23937, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23937), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24803, { 0, 6, height }, { 32, 20, 0 },
-                        { 0, 6, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24803), { 0, 6, height },
+                        { 32, 20, 0 }, { 0, 6, height + 67 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23923, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23923), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24789, { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24789), { 0, 6, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23925, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23925), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24791, { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24791), { 0, 6, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23940, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23940), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24806, { 0, 6, height }, { 32, 20, 0 },
-                        { 0, 6, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24806), { 0, 6, height },
+                        { 32, 20, 0 }, { 0, 6, height + 67 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23927, { 0, 6, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23927), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24793, { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24793), { 0, 6, height },
+                        { 32, 20, 2 }, { 0, 6, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -13064,56 +13093,56 @@ static void wooden_rc_track_right_banked_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23922, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23922), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24788, { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24788), { 6, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23938, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23938), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24804, { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24804), { 6, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23924, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23924), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24790, { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24790), { 6, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23939, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23939), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24805, { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24805), { 6, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23926, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23926), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24792, { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24792), { 6, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23941, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23941), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24807, { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24807), { 6, 0, height },
+                        { 20, 32, 0 }, { 6, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 23928, { 6, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23928), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 24794, { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24794), { 6, 0, height },
+                        { 20, 32, 2 }, { 6, 0, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -13167,44 +13196,44 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24321, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24321), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25187, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25187), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24326, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24326), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25192, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25192), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24352, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24352), { 0, 0, height },
                         { 32, 27, 0 }, { 0, 2, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25218, { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25218), { 0, 0, height },
+                        { 32, 27, 0 }, { 0, 2, height + 67 });
                     wooden_a_supports_paint_setup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24331, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24331), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25197, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25197), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24336, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24336), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25202, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25202), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -13225,50 +13254,50 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24322, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24322), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25188, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25188), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24327, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24327), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25193, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25193), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24353, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24353), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25219, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25219), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24332, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24332), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25198, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25198), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24337, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24337), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25203, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25203), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24359, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24359), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25225, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25225), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height + 67 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -13284,50 +13313,50 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24323, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24323), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25189, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25189), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24328, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24328), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25194, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25194), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24354, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24354), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 59 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25220, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 59 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25220), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 16, height + 59 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24333, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24333), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25199, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25199), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24338, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24338), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25204, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25204), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24360, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24360), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 59 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25226, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 59 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25226), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 0, height + 59 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -13349,56 +13378,56 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24324, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24324), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25190, { 0, 0, height }, { 16, 32, 2 },
-                        { 16, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25190), { 0, 0, height },
+                        { 16, 32, 2 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24329, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24329), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25195, { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25195), { 0, 0, height },
+                        { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24355, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24355), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25221, { 0, 0, height }, { 16, 32, 0 },
-                        { 0, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25221), { 0, 0, height },
+                        { 16, 32, 0 }, { 0, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24334, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24334), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25200, { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25200), { 0, 0, height },
+                        { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24357, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24357), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25223, { 0, 0, height }, { 16, 32, 0 },
-                        { 0, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25223), { 0, 0, height },
+                        { 16, 32, 0 }, { 0, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24339, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24339), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25205, { 0, 0, height }, { 16, 32, 2 },
-                        { 16, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25205), { 0, 0, height },
+                        { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24361, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24361), { 0, 0, height },
                         { 16, 32, 0 }, { 16, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25227, { 0, 0, height }, { 16, 32, 0 },
-                        { 16, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25227), { 0, 0, height },
+                        { 16, 32, 0 }, { 16, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -13414,56 +13443,56 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24325, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24325), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25191, { 0, 0, height }, { 27, 32, 2 },
-                        { 2, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25191), { 0, 0, height },
+                        { 27, 32, 2 }, { 2, 0, height });
                     wooden_a_supports_paint_setup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24330, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24330), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25196, { 0, 0, height }, { 27, 32, 2 },
-                        { 2, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25196), { 0, 0, height },
+                        { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24356, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24356), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25222, { 0, 0, height }, { 27, 32, 0 },
-                        { 2, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25222), { 0, 0, height },
+                        { 27, 32, 0 }, { 2, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24335, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24335), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25201, { 0, 0, height }, { 27, 32, 2 },
-                        { 2, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25201), { 0, 0, height },
+                        { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24358, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24358), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25224, { 0, 0, height }, { 27, 32, 0 },
-                        { 2, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25224), { 0, 0, height },
+                        { 27, 32, 0 }, { 2, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24340, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24340), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25206, { 0, 0, height }, { 27, 32, 2 },
-                        { 2, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25206), { 0, 0, height },
+                        { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24362, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24362), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25228, { 0, 0, height }, { 27, 32, 0 },
-                        { 2, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25228), { 0, 0, height },
+                        { 27, 32, 0 }, { 2, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -13495,44 +13524,44 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24301, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24301), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25167, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25167), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24306, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24306), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25172, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25172), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24311, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24311), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25177, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25177), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24347, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24347), { 0, 0, height },
                         { 32, 27, 0 }, { 0, 2, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25213, { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25213), { 0, 0, height },
+                        { 32, 27, 0 }, { 0, 2, height + 67 });
                     wooden_a_supports_paint_setup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24316, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24316), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25182, { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25182), { 0, 0, height },
+                        { 32, 27, 2 }, { 0, 2, height });
                     wooden_a_supports_paint_setup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -13553,50 +13582,50 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24302, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24302), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25168, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25168), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24341, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24341), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25207, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25207), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 16, height + 67 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24307, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24307), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25173, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25173), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24312, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24312), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25178, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25178), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24348, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24348), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25214, { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25214), { 0, 0, height },
+                        { 32, 16, 0 }, { 0, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24317, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24317), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25183, { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25183), { 0, 0, height },
+                        { 32, 16, 2 }, { 0, 0, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -13612,50 +13641,50 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24303, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24303), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25169, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25169), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24342, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24342), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 59 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25208, { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 59 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25208), { 0, 0, height },
+                        { 16, 16, 0 }, { 0, 0, height + 59 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24308, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24308), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25174, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25174), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24313, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24313), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25179, { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25179), { 0, 0, height },
+                        { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24349, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24349), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 59 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25215, { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 59 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25215), { 0, 0, height },
+                        { 16, 16, 0 }, { 16, 16, height + 59 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24318, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24318), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25184, { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25184), { 0, 0, height },
+                        { 16, 16, 2 }, { 0, 16, height });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -13677,56 +13706,56 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24304, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24304), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25170, { 0, 0, height }, { 16, 32, 2 },
-                        { 16, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25170), { 0, 0, height },
+                        { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24343, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24343), { 0, 0, height },
                         { 16, 32, 0 }, { 16, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25209, { 0, 0, height }, { 16, 32, 0 },
-                        { 16, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25209), { 0, 0, height },
+                        { 16, 32, 0 }, { 16, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24309, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24309), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25175, { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25175), { 0, 0, height },
+                        { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24345, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24345), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25211, { 0, 0, height }, { 16, 32, 0 },
-                        { 0, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25211), { 0, 0, height },
+                        { 16, 32, 0 }, { 0, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24314, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24314), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25180, { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25180), { 0, 0, height },
+                        { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24350, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24350), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25216, { 0, 0, height }, { 16, 32, 0 },
-                        { 0, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25216), { 0, 0, height },
+                        { 16, 32, 0 }, { 0, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24319, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24319), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25185, { 0, 0, height }, { 16, 32, 2 },
-                        { 16, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25185), { 0, 0, height },
+                        { 16, 32, 2 }, { 16, 0, height });
                     wooden_a_supports_paint_setup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -13742,56 +13771,56 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24305, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24305), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25171, { 0, 0, height }, { 27, 32, 2 },
-                        { 2, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25171), { 0, 0, height },
+                        { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24344, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24344), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25210, { 0, 0, height }, { 27, 32, 0 },
-                        { 2, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25210), { 0, 0, height },
+                        { 27, 32, 0 }, { 2, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24310, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24310), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25176, { 0, 0, height }, { 27, 32, 2 },
-                        { 2, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25176), { 0, 0, height },
+                        { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24346, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24346), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25212, { 0, 0, height }, { 27, 32, 0 },
-                        { 2, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25212), { 0, 0, height },
+                        { 27, 32, 0 }, { 2, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24315, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24315), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25181, { 0, 0, height }, { 27, 32, 2 },
-                        { 2, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25181), { 0, 0, height },
+                        { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24351, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24351), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25217, { 0, 0, height }, { 27, 32, 0 },
-                        { 2, 0, height + 67 });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25217), { 0, 0, height },
+                        { 27, 32, 0 }, { 2, 0, height + 67 });
                     wooden_a_supports_paint_setup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24320, { 0, 0, height },
+                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24320), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session) | 25186, { 0, 0, height }, { 27, 32, 2 },
-                        { 2, 0, height });
+                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25186), { 0, 0, height },
+                        { 27, 32, 2 }, { 2, 0, height });
                     wooden_a_supports_paint_setup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -13842,37 +13871,37 @@ static void wooden_rc_track_25_deg_up_to_left_banked_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24261, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24261), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25127, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25127), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             wooden_a_supports_paint_setup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24262, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24262), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25128, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25128), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             wooden_a_supports_paint_setup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24263, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24263), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25129, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25129), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             wooden_a_supports_paint_setup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24264, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24264), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25130, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25130), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             wooden_a_supports_paint_setup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -13899,37 +13928,37 @@ static void wooden_rc_track_25_deg_up_to_right_banked_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24265, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24265), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25131, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25131), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             wooden_a_supports_paint_setup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24266, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24266), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25132, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25132), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             wooden_a_supports_paint_setup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24267, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24267), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25133, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25133), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             wooden_a_supports_paint_setup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24268, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24268), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25134, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25134), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             wooden_a_supports_paint_setup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -13956,37 +13985,37 @@ static void wooden_rc_track_left_banked_25_deg_up_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24269, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24269), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25135, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25135), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             wooden_a_supports_paint_setup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24270, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24270), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25136, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25136), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             wooden_a_supports_paint_setup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24271, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24271), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25137, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25137), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             wooden_a_supports_paint_setup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24272, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24272), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25138, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25138), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             wooden_a_supports_paint_setup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -14013,37 +14042,37 @@ static void wooden_rc_track_right_banked_25_deg_up_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24273, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24273), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25139, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25139), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             wooden_a_supports_paint_setup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24274, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24274), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25140, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25140), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             wooden_a_supports_paint_setup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24275, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24275), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25141, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25141), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             wooden_a_supports_paint_setup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24276, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24276), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25142, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25142), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             wooden_a_supports_paint_setup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -14110,49 +14139,49 @@ static void wooden_rc_track_left_banked_flat_to_left_banked_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24277, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24277), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25143, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25143), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             wooden_a_supports_paint_setup(session, 0, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24278, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24278), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25144, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25144), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24293, { 0, 0, height }, { 32, 1, 9 },
-                { 0, 26, height + 5 });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24293), { 0, 0, height },
+                { 32, 1, 9 }, { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25159, { 0, 0, height }, { 32, 1, 9 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25159), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
             wooden_a_supports_paint_setup(session, 1, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24279, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24279), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25145, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25145), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24294, { 0, 0, height }, { 32, 1, 9 },
-                { 0, 26, height + 5 });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24294), { 0, 0, height },
+                { 32, 1, 9 }, { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25160, { 0, 0, height }, { 32, 1, 9 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25160), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
             wooden_a_supports_paint_setup(session, 0, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24280, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24280), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25146, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25146), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             wooden_a_supports_paint_setup(session, 1, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -14179,49 +14208,49 @@ static void wooden_rc_track_right_banked_flat_to_right_banked_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24281, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24281), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25147, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25147), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             wooden_a_supports_paint_setup(session, 0, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24282, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24282), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25148, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25148), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24295, { 0, 0, height }, { 32, 1, 9 },
-                { 0, 26, height + 5 });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24295), { 0, 0, height },
+                { 32, 1, 9 }, { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25161, { 0, 0, height }, { 32, 1, 9 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25161), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
             wooden_a_supports_paint_setup(session, 1, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24283, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24283), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25149, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25149), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24296, { 0, 0, height }, { 32, 1, 9 },
-                { 0, 26, height + 5 });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24296), { 0, 0, height },
+                { 32, 1, 9 }, { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25162, { 0, 0, height }, { 32, 1, 9 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25162), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
             wooden_a_supports_paint_setup(session, 0, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24284, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24284), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25150, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25150), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             wooden_a_supports_paint_setup(session, 1, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -14248,49 +14277,49 @@ static void wooden_rc_track_left_banked_25_deg_up_to_left_banked_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24285, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24285), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25151, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25151), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             wooden_a_supports_paint_setup(session, 0, 5, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24286, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24286), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25152, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25152), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24297, { 0, 0, height }, { 32, 1, 9 },
-                { 0, 26, height + 5 });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24297), { 0, 0, height },
+                { 32, 1, 9 }, { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25163, { 0, 0, height }, { 32, 1, 9 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25163), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
             wooden_a_supports_paint_setup(session, 1, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24287, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24287), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25153, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25153), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24298, { 0, 0, height }, { 32, 1, 9 },
-                { 0, 26, height + 5 });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24298), { 0, 0, height },
+                { 32, 1, 9 }, { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25164, { 0, 0, height }, { 32, 1, 9 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25164), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
             wooden_a_supports_paint_setup(session, 0, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24288, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24288), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25154, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25154), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             wooden_a_supports_paint_setup(session, 1, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -14317,49 +14346,49 @@ static void wooden_rc_track_right_banked_25_deg_up_to_right_banked_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24289, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24289), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25155, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25155), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             wooden_a_supports_paint_setup(session, 0, 5, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24290, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24290), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25156, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25156), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24299, { 0, 0, height }, { 32, 1, 9 },
-                { 0, 26, height + 5 });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24299), { 0, 0, height },
+                { 32, 1, 9 }, { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25165, { 0, 0, height }, { 32, 1, 9 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25165), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
             wooden_a_supports_paint_setup(session, 1, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24291, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24291), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25157, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25157), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24300, { 0, 0, height }, { 32, 1, 9 },
-                { 0, 26, height + 5 });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24300), { 0, 0, height },
+                { 32, 1, 9 }, { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25166, { 0, 0, height }, { 32, 1, 9 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25166), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
             wooden_a_supports_paint_setup(session, 0, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24292, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24292), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25158, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25158), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             wooden_a_supports_paint_setup(session, 1, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -14426,49 +14455,49 @@ static void wooden_rc_track_flat_to_left_banked_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24225, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24225), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25091, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25091), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             wooden_a_supports_paint_setup(session, 0, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24226, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24226), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25092, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25092), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24241, { 0, 0, height }, { 32, 1, 9 },
-                { 0, 26, height + 5 });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24241), { 0, 0, height },
+                { 32, 1, 9 }, { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25107, { 0, 0, height }, { 32, 1, 9 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25107), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
             wooden_a_supports_paint_setup(session, 1, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24227, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24227), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25093, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25093), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24242, { 0, 0, height }, { 32, 1, 9 },
-                { 0, 26, height + 5 });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24242), { 0, 0, height },
+                { 32, 1, 9 }, { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25108, { 0, 0, height }, { 32, 1, 9 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25108), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
             wooden_a_supports_paint_setup(session, 0, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24228, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24228), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25094, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25094), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             wooden_a_supports_paint_setup(session, 1, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -14495,49 +14524,49 @@ static void wooden_rc_track_flat_to_right_banked_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24229, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24229), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25095, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25095), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             wooden_a_supports_paint_setup(session, 0, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24230, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24230), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25096, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25096), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24243, { 0, 0, height }, { 32, 1, 9 },
-                { 0, 26, height + 5 });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24243), { 0, 0, height },
+                { 32, 1, 9 }, { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25109, { 0, 0, height }, { 32, 1, 9 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25109), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
             wooden_a_supports_paint_setup(session, 1, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24231, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24231), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25097, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25097), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24244, { 0, 0, height }, { 32, 1, 9 },
-                { 0, 26, height + 5 });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24244), { 0, 0, height },
+                { 32, 1, 9 }, { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25110, { 0, 0, height }, { 32, 1, 9 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25110), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
             wooden_a_supports_paint_setup(session, 0, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24232, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24232), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25098, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25098), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             wooden_a_supports_paint_setup(session, 1, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -14564,49 +14593,49 @@ static void wooden_rc_track_left_banked_25_deg_up_to_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24233, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24233), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25099, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25099), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             wooden_a_supports_paint_setup(session, 0, 5, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24234, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24234), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25100, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25100), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24245, { 0, 0, height }, { 32, 1, 9 },
-                { 0, 26, height + 5 });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24245), { 0, 0, height },
+                { 32, 1, 9 }, { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25111, { 0, 0, height }, { 32, 1, 9 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25111), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
             wooden_a_supports_paint_setup(session, 1, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24235, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24235), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25101, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25101), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24246, { 0, 0, height }, { 32, 1, 9 },
-                { 0, 26, height + 5 });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24246), { 0, 0, height },
+                { 32, 1, 9 }, { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25112, { 0, 0, height }, { 32, 1, 9 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25112), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
             wooden_a_supports_paint_setup(session, 0, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24236, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24236), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25102, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25102), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             wooden_a_supports_paint_setup(session, 1, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -14633,49 +14662,49 @@ static void wooden_rc_track_right_banked_25_deg_up_to_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24237, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24237), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25103, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25103), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             wooden_a_supports_paint_setup(session, 0, 5, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24238, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24238), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25104, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25104), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24247, { 0, 0, height }, { 32, 1, 9 },
-                { 0, 26, height + 5 });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24247), { 0, 0, height },
+                { 32, 1, 9 }, { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25113, { 0, 0, height }, { 32, 1, 9 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25113), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
             wooden_a_supports_paint_setup(session, 1, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24239, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24239), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25105, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25105), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24248, { 0, 0, height }, { 32, 1, 9 },
-                { 0, 26, height + 5 });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24248), { 0, 0, height },
+                { 32, 1, 9 }, { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25114, { 0, 0, height }, { 32, 1, 9 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25114), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
             wooden_a_supports_paint_setup(session, 0, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session) | 24240, { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24240), { 0, 0, height },
+                { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session) | 25106, { 0, 0, height }, { 32, 25, 2 },
+                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25106), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             wooden_a_supports_paint_setup(session, 1, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;

--- a/src/openrct2/ride/coaster/WoodenWildMouse.cpp
+++ b/src/openrct2/ride/coaster/WoodenWildMouse.cpp
@@ -132,7 +132,7 @@ static void wooden_wild_mouse_track_flat(
         SPR_WOODEN_WILD_MOUSE_FLAT_NW_SE,
     };
 
-    uint32_t imageId = imageIds[direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 6, height }, { 32, 20, 1 });
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
@@ -157,11 +157,11 @@ static void wooden_wild_mouse_track_station(
     };
 
     PaintAddImageAsParentRotated(
-        session, direction, imageIds[direction][1] | session.TrackColours[SCHEME_MISC], { 0, 0, height - 2 }, { 32, 28, 1 },
-        { 0, 2, height });
+        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][1]), { 0, 0, height - 2 },
+        { 32, 28, 1 }, { 0, 2, height });
     PaintAddImageAsChildRotated(
-        session, direction, imageIds[direction][0] | session.TrackColours[SCHEME_TRACK], { 0, 6, height }, { 32, 20, 1 },
-        { 0, 0, height });
+        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]), { 0, 6, height },
+        { 32, 20, 1 }, { 0, 0, height });
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
     track_paint_util_draw_station(session, ride, direction, height, trackElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -190,7 +190,7 @@ static void wooden_wild_mouse_track_25_deg_up(
     };
 
     uint8_t isChained = trackElement.HasChain() ? 1 : 0;
-    uint32_t imageId = imageIds[isChained][direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[isChained][direction]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 2, height }, { 32, 25, 1 }, { 0, 3, height });
 
     wooden_a_supports_paint_setup(session, direction & 1, 9 + direction, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -229,7 +229,7 @@ static void wooden_wild_mouse_track_60_deg_up(
     };
 
     uint8_t isChained = trackElement.HasChain() ? 1 : 0;
-    uint32_t imageId = imageIds[isChained][direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[isChained][direction]);
     if (direction == 0 || direction == 3)
     {
         PaintAddImageAsParentRotated(session, direction, imageId, { 0, 2, height }, { 32, 25, 1 }, { 0, 3, height });
@@ -276,7 +276,7 @@ static void wooden_wild_mouse_track_flat_to_25_deg_up(
     };
 
     uint8_t isChained = trackElement.HasChain() ? 1 : 0;
-    uint32_t imageId = imageIds[isChained][direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[isChained][direction]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 2, height }, { 32, 25, 1 }, { 0, 3, height });
 
     wooden_a_supports_paint_setup(session, direction & 1, 1 + direction, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -315,18 +315,18 @@ static void wooden_wild_mouse_track_25_deg_up_to_60_deg_up(
     };
 
     uint8_t isChained = trackElement.HasChain() ? 1 : 0;
-    uint32_t imageId;
+    ImageId imageId;
     if (direction == 0 || direction == 3)
     {
-        imageId = imageIds[isChained][direction][0] | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[isChained][direction][0]);
         PaintAddImageAsParentRotated(session, direction, imageId, { 0, 2, height }, { 32, 25, 1 }, { 0, 3, height });
     }
     else
     {
-        imageId = imageIds[isChained][direction][0] | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[isChained][direction][0]);
         session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
             session, direction, imageId, { 0, 6, height }, { 2, 24, 43 }, { 28, 4, height + 2 });
-        imageId = imageIds[isChained][direction][1] | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[isChained][direction][1]);
         PaintAddImageAsParentRotated(session, direction, imageId, { 0, 6, height }, { 32, 2, 43 }, { 0, 4, height });
     }
 
@@ -365,18 +365,18 @@ static void wooden_wild_mouse_track_60_deg_to_25_deg_up(
     };
 
     uint8_t isChained = trackElement.HasChain() ? 1 : 0;
-    uint32_t imageId;
+    ImageId imageId;
     if (direction == 0 || direction == 3)
     {
-        imageId = imageIds[isChained][direction][0] | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[isChained][direction][0]);
         PaintAddImageAsParentRotated(session, direction, imageId, { 0, 2, height }, { 32, 25, 1 }, { 0, 3, height });
     }
     else
     {
-        imageId = imageIds[isChained][direction][0] | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[isChained][direction][0]);
         session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
             session, direction, imageId, { 0, 6, height }, { 2, 24, 43 }, { 28, 4, height + 2 });
-        imageId = imageIds[isChained][direction][1] | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[isChained][direction][1]);
         PaintAddImageAsParentRotated(session, direction, imageId, { 0, 6, height }, { 32, 2, 43 }, { 0, 4, height });
     }
 
@@ -416,7 +416,7 @@ static void wooden_wild_mouse_track_25_deg_up_to_flat(
     };
 
     uint8_t isChained = trackElement.HasChain() ? 1 : 0;
-    uint32_t imageId = imageIds[isChained][direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[isChained][direction]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 2, height }, { 32, 25, 1 }, { 0, 3, height });
 
     wooden_a_supports_paint_setup(session, direction & 1, 5 + direction, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -559,7 +559,7 @@ static void wooden_wild_mouse_track_left_quarter_turn_1(
     };
     static uint8_t supportType[] = { 5, 2, 3, 4 };
 
-    uint32_t imageId = imageIds[direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction]);
     switch (direction)
     {
         case 0:
@@ -610,17 +610,17 @@ static void wooden_wild_mouse_track_flat_to_60_deg_up(
     };
 
     uint8_t isChained = trackElement.HasChain() ? 1 : 0;
-    uint32_t imageId;
+    ImageId imageId;
     if (direction == 0 || direction == 3)
     {
-        imageId = imageIds[isChained][direction][0] | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[isChained][direction][0]);
         PaintAddImageAsParentRotated(session, direction, imageId, { 0, 2, height }, { 32, 25, 1 }, { 0, 3, height });
     }
     else
     {
-        imageId = imageIds[isChained][direction][0] | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[isChained][direction][0]);
         PaintAddImageAsParentRotated(session, direction, imageId, { 0, 6, height }, { 2, 24, 43 }, { 28, 4, height + 2 });
-        imageId = imageIds[isChained][direction][1] | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[isChained][direction][1]);
         PaintAddImageAsParentRotated(session, direction, imageId, { 0, 6, height }, { 32, 2, 43 }, { 0, 4, height });
     }
 
@@ -660,17 +660,17 @@ static void wooden_wild_mouse_track_60_deg_up_to_flat(
     };
 
     uint8_t isChained = trackElement.HasChain() ? 1 : 0;
-    uint32_t imageId;
+    ImageId imageId;
     if (direction == 0 || direction == 3)
     {
-        imageId = imageIds[isChained][direction][0] | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[isChained][direction][0]);
         PaintAddImageAsParentRotated(session, direction, imageId, { 0, 2, height }, { 32, 25, 1 }, { 0, 3, height });
     }
     else
     {
-        imageId = imageIds[isChained][direction][0] | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[isChained][direction][0]);
         PaintAddImageAsParentRotated(session, direction, imageId, { 0, 6, height }, { 2, 24, 43 }, { 28, 4, height + 2 });
-        imageId = imageIds[isChained][direction][1] | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[isChained][direction][1]);
         PaintAddImageAsParentRotated(session, direction, imageId, { 0, 6, height }, { 32, 2, 43 }, { 0, 4, height });
     }
 

--- a/src/openrct2/ride/gentle/CarRide.cpp
+++ b/src/openrct2/ride/gentle/CarRide.cpp
@@ -160,7 +160,7 @@ static void paint_car_ride_track_flat(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId = car_ride_track_pieces_flat[direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(car_ride_track_pieces_flat[direction]);
 
     if (direction == 0 || direction == 2)
     {
@@ -191,7 +191,7 @@ static void paint_car_ride_track_25_deg_up(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId = car_ride_track_pieces_25_deg_up[direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(car_ride_track_pieces_25_deg_up[direction]);
 
     if (direction == 0 || direction == 2)
     {
@@ -229,7 +229,7 @@ static void paint_car_ride_track_flat_to_25_deg_up(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId = car_ride_track_pieces_flat_to_25_deg_up[direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(car_ride_track_pieces_flat_to_25_deg_up[direction]);
 
     if (direction == 0 || direction == 2)
     {
@@ -267,7 +267,7 @@ static void paint_car_ride_track_25_deg_up_to_flat(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId = car_ride_track_pieces_25_deg_up_to_flat[direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(car_ride_track_pieces_25_deg_up_to_flat[direction]);
 
     if (direction == 0 || direction == 2)
     {
@@ -329,20 +329,20 @@ static void paint_car_ride_station(
     paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId;
+    ImageId imageId;
 
     if (direction == 0 || direction == 2)
     {
-        imageId = SPR_STATION_BASE_B_SW_NE | session.TrackColours[SCHEME_MISC];
+        imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_STATION_BASE_B_SW_NE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height - 2 }, { 32, 28, 1 }, { 0, 2, height });
     }
     else if (direction == 1 || direction == 3)
     {
-        imageId = SPR_STATION_BASE_B_NW_SE | session.TrackColours[SCHEME_MISC];
+        imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_STATION_BASE_B_NW_SE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height - 2 }, { 28, 32, 1 }, { 2, 0, height });
     }
 
-    imageId = car_ride_track_pieces_flat[direction] | session.TrackColours[SCHEME_TRACK];
+    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(car_ride_track_pieces_flat[direction]);
     if (direction == 0 || direction == 2)
     {
         PaintAddImageAsChild(session, imageId, { 0, 6, height }, { 32, 20, 1 }, { 0, 0, height });
@@ -429,7 +429,7 @@ static void paint_car_ride_track_left_quarter_turn_1_tile(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId = car_ride_track_pieces_left_quarter_turn_1_tile[direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(car_ride_track_pieces_left_quarter_turn_1_tile[direction]);
 
     switch (direction)
     {
@@ -468,7 +468,7 @@ static void paint_car_ride_track_spinning_tunnel(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId = car_ride_track_pieces_flat[direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(car_ride_track_pieces_flat[direction]);
 
     if (direction == 0 || direction == 2)
     {
@@ -501,7 +501,7 @@ static void paint_car_ride_track_60_deg_up(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId = car_ride_track_pieces_60_deg_up[direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(car_ride_track_pieces_60_deg_up[direction]);
 
     switch (direction)
     {
@@ -550,7 +550,7 @@ static void paint_car_ride_track_25_deg_up_to_60_deg_up(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId = car_ride_track_pieces_25_deg_up_to_60_deg_up[direction][0] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(car_ride_track_pieces_25_deg_up_to_60_deg_up[direction][0]);
 
     if (direction == 0 || direction == 2)
     {
@@ -563,7 +563,7 @@ static void paint_car_ride_track_25_deg_up_to_60_deg_up(
 
     if (car_ride_track_pieces_25_deg_up_to_60_deg_up[direction][1] != 0)
     {
-        imageId = car_ride_track_pieces_25_deg_up_to_60_deg_up[direction][1] | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(car_ride_track_pieces_25_deg_up_to_60_deg_up[direction][1]);
 
         if (direction == 0 || direction == 2)
         {
@@ -606,7 +606,7 @@ static void paint_car_ride_track_60_deg_up_to_25_deg_up(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId = car_ride_track_pieces_60_deg_up_to_25_deg_up[direction][0] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(car_ride_track_pieces_60_deg_up_to_25_deg_up[direction][0]);
 
     if (direction == 0 || direction == 2)
     {
@@ -619,7 +619,7 @@ static void paint_car_ride_track_60_deg_up_to_25_deg_up(
 
     if (car_ride_track_pieces_60_deg_up_to_25_deg_up[direction][1] != 0)
     {
-        imageId = car_ride_track_pieces_60_deg_up_to_25_deg_up[direction][1] | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(car_ride_track_pieces_60_deg_up_to_25_deg_up[direction][1]);
 
         if (direction == 0 || direction == 2)
         {
@@ -686,7 +686,7 @@ static void paint_car_ride_track_log_bumps(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId = car_ride_track_pieces_log_bumps[direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(car_ride_track_pieces_log_bumps[direction]);
 
     if (direction == 0 || direction == 2)
     {

--- a/src/openrct2/ride/gentle/Circus.cpp
+++ b/src/openrct2/ride/gentle/Circus.cpp
@@ -32,9 +32,9 @@ static void PaintCircusTent(paint_session& session, const Ride& ride, uint8_t di
 
     auto imageTemplate = ImageId(0, ride.vehicle_colours[0].Body, ride.vehicle_colours[0].Trim);
     auto imageFlags = session.TrackColours[SCHEME_MISC];
-    if (imageFlags != IMAGE_TYPE_REMAP)
+    if (!imageFlags.HasPrimary())
     {
-        imageTemplate = ImageId::FromUInt32(imageFlags);
+        imageTemplate = imageFlags;
     }
     auto imageIndex = rideEntry->Cars[0].base_image_id + direction;
 

--- a/src/openrct2/ride/gentle/CrookedHouse.cpp
+++ b/src/openrct2/ride/gentle/CrookedHouse.cpp
@@ -71,7 +71,7 @@ static void PaintCrookedHouseStructure(
     }
 
     const auto& boundBox = CrookedHouseData[segment];
-    auto imageTemplate = ImageId::FromUInt32(session.TrackColours[SCHEME_MISC]);
+    auto imageTemplate = session.TrackColours[SCHEME_MISC];
     auto imageIndex = rideEntry->Cars[0].base_image_id + direction;
     PaintAddImageAsParent(
         session, imageTemplate.WithIndex(imageIndex), { x_offset, y_offset, height + 3 }, { boundBox.length, 127 },

--- a/src/openrct2/ride/gentle/Dodgems.cpp
+++ b/src/openrct2/ride/gentle/Dodgems.cpp
@@ -36,10 +36,10 @@ static constexpr const uint32_t dodgems_fence_sprites[] = {
 
 static void paint_dodgems_roof(paint_session& session, int32_t height, int32_t offset)
 {
-    uint32_t image_id = (SPR_DODGEMS_ROOF_FRAME + offset) | session.TrackColours[SCHEME_TRACK];
+    auto image_id = session.TrackColours[SCHEME_TRACK].WithIndex((SPR_DODGEMS_ROOF_FRAME + offset));
     PaintAddImageAsParent(session, image_id, { 0, 0, height }, { 32, 32, 2 });
 
-    image_id = (SPR_DODGEMS_ROOF_GLASS + offset) | (EnumValue(FilterPaletteID::PaletteDarken3) << 19) | IMAGE_TYPE_TRANSPARENT;
+    image_id = ImageId(SPR_DODGEMS_ROOF_GLASS + offset).WithTransparancy(FilterPaletteID::PaletteDarken3);
     PaintAttachToPreviousPS(session, image_id, 0, 0);
 }
 
@@ -57,7 +57,7 @@ static void paint_dodgems(
 
     if (stationObject != nullptr && !(stationObject->Flags & STATION_OBJECT_FLAGS::NO_PLATFORMS))
     {
-        uint32_t imageId = SPR_DODGEMS_FLOOR | session.TrackColours[SCHEME_SUPPORTS];
+        auto imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_DODGEMS_FLOOR);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 30, 30, 1 }, { 1, 1, height });
 
         track_paint_util_paint_fences(

--- a/src/openrct2/ride/gentle/FerrisWheel.cpp
+++ b/src/openrct2/ride/gentle/FerrisWheel.cpp
@@ -76,12 +76,12 @@ static void PaintFerrisWheelStructure(
     CoordsXYZ offset((direction & 1) ? 0 : axisOffset, (direction & 1) ? axisOffset : 0, height + 7);
     BoundBoxXYZ bb = { { boundBox.offset, height + 7 }, { boundBox.length, 127 } };
 
-    auto supportsImageTemplate = ImageId::FromUInt32(session.TrackColours[SCHEME_TRACK]);
+    auto supportsImageTemplate = session.TrackColours[SCHEME_TRACK];
     auto wheelImageTemplate = ImageId(0, ride.vehicle_colours[0].Body, ride.vehicle_colours[0].Trim);
     auto wheelImageFlags = session.TrackColours[SCHEME_MISC];
-    if (wheelImageFlags != IMAGE_TYPE_REMAP)
+    if (!wheelImageFlags.HasPrimary())
     {
-        wheelImageTemplate = ImageId::FromUInt32(wheelImageFlags);
+        wheelImageTemplate = wheelImageFlags;
     }
 
     auto imageOffset = vehicle != nullptr ? vehicle->Pitch % 8 : 0;
@@ -123,29 +123,29 @@ static void PaintFerrisWheel(
 
     track_paint_util_paint_floor(session, edges, session.TrackColours[SCHEME_TRACK], height, floorSpritesCork, stationObject);
 
-    uint32_t imageId;
+    ImageId imageId;
     uint8_t rotation = session.CurrentRotation;
-    uint32_t colourFlags = session.TrackColours[SCHEME_MISC];
+    auto colourFlags = session.TrackColours[SCHEME_MISC];
 
     if (edges & EDGE_NW && track_paint_util_has_fence(EDGE_NW, session.MapPosition, trackElement, ride, rotation))
     {
-        imageId = SPR_FENCE_ROPE_NW | colourFlags;
+        imageId = colourFlags.WithIndex(SPR_FENCE_ROPE_NW);
         PaintAddImageAsChild(session, imageId, { 0, 0, height }, { 32, 1, 7 }, { 0, 2, height + 2 });
     }
     if (edges & EDGE_NE && track_paint_util_has_fence(EDGE_NE, session.MapPosition, trackElement, ride, rotation))
     {
-        imageId = SPR_FENCE_ROPE_NE | colourFlags;
+        imageId = colourFlags.WithIndex(SPR_FENCE_ROPE_NE);
         PaintAddImageAsChild(session, imageId, { 0, 0, height }, { 1, 32, 7 }, { 2, 0, height + 2 });
     }
     if (edges & EDGE_SE && track_paint_util_has_fence(EDGE_SE, session.MapPosition, trackElement, ride, rotation))
     {
         // Bound box is slightly different from track_paint_util_paint_fences
-        imageId = SPR_FENCE_ROPE_SE | colourFlags;
+        imageId = colourFlags.WithIndex(SPR_FENCE_ROPE_SE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 28, 1, 7 }, { 0, 29, height + 3 });
     }
     if (edges & EDGE_SW && track_paint_util_has_fence(EDGE_SW, session.MapPosition, trackElement, ride, rotation))
     {
-        imageId = SPR_FENCE_ROPE_SW | colourFlags;
+        imageId = colourFlags.WithIndex(SPR_FENCE_ROPE_SW);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 32, 7 }, { 30, 0, height + 2 });
     }
 

--- a/src/openrct2/ride/gentle/FlyingSaucers.cpp
+++ b/src/openrct2/ride/gentle/FlyingSaucers.cpp
@@ -48,7 +48,7 @@ static void paint_flying_saucers(
 
     if (stationObject != nullptr && !(stationObject->Flags & STATION_OBJECT_FLAGS::NO_PLATFORMS))
     {
-        uint32_t imageId = SPR_FLYING_SAUCERS_FLOOR | session.TrackColours[SCHEME_TRACK];
+        auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_FLYING_SAUCERS_FLOOR);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 30, 30, 1 }, { 1, 1, height });
     }
 

--- a/src/openrct2/ride/gentle/GhostTrain.cpp
+++ b/src/openrct2/ride/gentle/GhostTrain.cpp
@@ -180,7 +180,7 @@ static void paint_ghost_train_track_flat(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId = ghost_train_track_pieces_flat[direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(ghost_train_track_pieces_flat[direction]);
 
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
 
@@ -202,10 +202,10 @@ static void paint_ghost_train_track_25_deg_up(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId = ghost_train_track_pieces_25_deg_up[direction][0] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(ghost_train_track_pieces_25_deg_up[direction][0]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
 
-    imageId = ghost_train_track_pieces_25_deg_up[direction][1] | session.TrackColours[SCHEME_TRACK];
+    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(ghost_train_track_pieces_25_deg_up[direction][1]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 1, 23 }, { 0, 27, height });
 
     if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -250,10 +250,10 @@ static void paint_ghost_train_track_flat_to_25_deg_up(
         doorImage = doorOpeningOutwardsToImage[trackElement.GetDoorBState()];
     }
 
-    uint32_t imageId = ghost_train_track_pieces_flat_to_25_deg_up[direction][0] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(ghost_train_track_pieces_flat_to_25_deg_up[direction][0]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
 
-    imageId = ghost_train_track_pieces_flat_to_25_deg_up[direction][1] | session.TrackColours[SCHEME_TRACK];
+    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(ghost_train_track_pieces_flat_to_25_deg_up[direction][1]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 1, 15 }, { 0, 27, height });
 
     if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -286,10 +286,10 @@ static void paint_ghost_train_track_25_deg_up_to_flat_shared(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId = ghost_train_track_pieces_25_deg_up_to_flat[direction][0] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(ghost_train_track_pieces_25_deg_up_to_flat[direction][0]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
 
-    imageId = ghost_train_track_pieces_25_deg_up_to_flat[direction][1] | session.TrackColours[SCHEME_TRACK];
+    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(ghost_train_track_pieces_25_deg_up_to_flat[direction][1]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 1, 15 }, { 0, 27, height });
 
     if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -371,7 +371,7 @@ static void paint_ghost_train_station(
     paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId;
+    ImageId imageId;
 
     static constexpr const std::array imageIds = {
         SPR_STATION_BASE_B_SW_NE,
@@ -380,10 +380,10 @@ static void paint_ghost_train_station(
         SPR_STATION_BASE_B_NW_SE,
     };
 
-    imageId = imageIds[direction] | session.TrackColours[SCHEME_MISC];
+    imageId = session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height - 2 }, { 32, 28, 3 }, { 0, 2, height });
 
-    imageId = ghost_train_track_pieces_flat[direction] | session.TrackColours[SCHEME_TRACK];
+    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(ghost_train_track_pieces_flat[direction]);
     PaintAddImageAsChildRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 3 }, { 0, 0, height });
 
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -495,7 +495,7 @@ static void paint_ghost_train_track_spinning_tunnel(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId = ghost_train_track_pieces_spinning_tunnel_track[direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(ghost_train_track_pieces_spinning_tunnel_track[direction]);
 
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 28, 20, 3 }, { 2, 6, height });
 
@@ -515,7 +515,7 @@ static void paint_ghost_train_track_brakes(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId = ghost_train_track_pieces_brakes[direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(ghost_train_track_pieces_brakes[direction]);
 
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
 

--- a/src/openrct2/ride/gentle/HauntedHouse.cpp
+++ b/src/openrct2/ride/gentle/HauntedHouse.cpp
@@ -41,7 +41,7 @@ static void PaintHauntedHouseStructure(
     }
 
     const auto& boundBox = HauntedHouseData[part];
-    auto imageTemplate = ImageId::FromUInt32(session.TrackColours[SCHEME_MISC]);
+    auto imageTemplate = session.TrackColours[SCHEME_MISC];
     auto baseImageIndex = rideEntry->Cars[0].base_image_id;
     auto imageIndex = baseImageIndex + direction;
     PaintAddImageAsParent(

--- a/src/openrct2/ride/gentle/Maze.cpp
+++ b/src/openrct2/ride/gentle/Maze.cpp
@@ -61,7 +61,7 @@ static void maze_paint_setup(
 
     uint32_t rotation = session.CurrentRotation;
     // draw ground
-    int32_t image_id = SPR_TERRAIN_DIRT | session.TrackColours[SCHEME_MISC];
+    auto image_id = session.TrackColours[SCHEME_MISC].WithIndex(SPR_TERRAIN_DIRT);
     PaintAddImageAsParent(session, image_id, { 0, 0, height }, { 32, 32, 0 });
 
     wooden_a_supports_paint_setup(session, (rotation & 1) ? 0 : 1, 0, height, session.TrackColours[SCHEME_3]);
@@ -85,9 +85,9 @@ static void maze_paint_setup(
             break;
     }
 
-    base_image_id |= session.TrackColours[SCHEME_MISC];
+    auto baseImage = session.TrackColours[SCHEME_MISC].WithIndex(base_image_id);
 
-    image_id = base_image_id + SPR_MAZE_OFFSET_WALL_CENTRE;
+    image_id = baseImage.WithIndexOffset(SPR_MAZE_OFFSET_WALL_CENTRE);
     if (maze_entry & MAZE_ENTRY_FLAG_3)
         PaintAddImageAsParent(session, image_id, { 2, 2, height }, { 10, 10, 9 }, { 3, 3, height + 2 });
 
@@ -100,49 +100,49 @@ static void maze_paint_setup(
     if (maze_entry & MAZE_ENTRY_FLAG_15)
         PaintAddImageAsParent(session, image_id, { 18, 2, height }, { 10, 10, 9 }, { 19, 3, height + 2 });
 
-    image_id = base_image_id + SPR_MAZE_OFFSET_WALL_TOP_LEFT;
+    image_id = baseImage.WithIndexOffset(SPR_MAZE_OFFSET_WALL_TOP_LEFT);
     if (maze_entry & MAZE_ENTRY_FLAG_0)
         PaintAddImageAsParent(session, image_id, { 2, 0, height }, { 10, 1, 9 }, { 3, 1, height + 2 });
 
     if (maze_entry & MAZE_ENTRY_FLAG_13)
         PaintAddImageAsParent(session, image_id, { 18, 0, height }, { 10, 1, 9 }, { 19, 1, height + 2 });
 
-    image_id = base_image_id + SPR_MAZE_OFFSET_WALL_BOTTOM_RIGHT;
+    image_id = baseImage.WithIndexOffset(SPR_MAZE_OFFSET_WALL_BOTTOM_RIGHT);
     if (maze_entry & MAZE_ENTRY_FLAG_5)
         PaintAddImageAsParent(session, image_id, { 2, 30, height }, { 10, 1, 9 }, { 3, 30, height + 2 });
 
     if (maze_entry & MAZE_ENTRY_FLAG_8)
         PaintAddImageAsParent(session, image_id, { 18, 30, height }, { 10, 1, 9 }, { 19, 30, height + 2 });
 
-    image_id = base_image_id + SPR_MAZE_OFFSET_WALL_TOP_RIGHT;
+    image_id = baseImage.WithIndexOffset(SPR_MAZE_OFFSET_WALL_TOP_RIGHT);
     if (maze_entry & MAZE_ENTRY_FLAG_1)
         PaintAddImageAsParent(session, image_id, { 0, 2, height }, { 1, 10, 9 }, { 1, 3, height + 2 });
 
     if (maze_entry & MAZE_ENTRY_FLAG_4)
         PaintAddImageAsParent(session, image_id, { 0, 18, height }, { 1, 10, 9 }, { 1, 19, height + 2 });
 
-    image_id = base_image_id + SPR_MAZE_OFFSET_WALL_BOTTOM_LEFT;
+    image_id = baseImage.WithIndexOffset(SPR_MAZE_OFFSET_WALL_BOTTOM_LEFT);
     if (maze_entry & MAZE_ENTRY_FLAG_12)
         PaintAddImageAsParent(session, image_id, { 30, 2, height }, { 1, 10, 9 }, { 30, 3, height + 2 });
 
     if (maze_entry & MAZE_ENTRY_FLAG_9)
         PaintAddImageAsParent(session, image_id, { 30, 18, height }, { 1, 10, 9 }, { 30, 19, height + 2 });
 
-    image_id = base_image_id + SPR_MAZE_OFFSET_WALL_INNER_NE_SW;
+    image_id = baseImage.WithIndexOffset(SPR_MAZE_OFFSET_WALL_INNER_NE_SW);
     if (maze_entry & MAZE_ENTRY_FLAG_2)
         PaintAddImageAsParent(session, image_id, { 2, 14, height }, { 10, 4, 9 }, { 3, 14, height + 2 });
 
     if (maze_entry & MAZE_ENTRY_FLAG_10)
         PaintAddImageAsParent(session, image_id, { 18, 14, height }, { 10, 4, 9 }, { 19, 14, height + 2 });
 
-    image_id = base_image_id + SPR_MAZE_OFFSET_WALL_INNER_NW_SE;
+    image_id = baseImage.WithIndexOffset(SPR_MAZE_OFFSET_WALL_INNER_NW_SE);
     if (maze_entry & MAZE_ENTRY_FLAG_14)
         PaintAddImageAsParent(session, image_id, { 14, 2, height }, { 4, 10, 9 }, { 14, 3, height + 2 });
 
     if (maze_entry & MAZE_ENTRY_FLAG_6)
         PaintAddImageAsParent(session, image_id, { 14, 18, height }, { 4, 10, 9 }, { 14, 19, height + 2 });
 
-    image_id = base_image_id + SPR_MAZE_OFFSET_COLUMN_CORNER;
+    image_id = baseImage.WithIndexOffset(SPR_MAZE_OFFSET_COLUMN_CORNER);
     if (maze_entry & (MAZE_ENTRY_FLAG_0 | MAZE_ENTRY_FLAG_1))
         PaintAddImageAsParent(session, image_id, { 0, 0, height }, { 1, 1, 9 }, { 1, 1, height + 2 });
 

--- a/src/openrct2/ride/gentle/MerryGoRound.cpp
+++ b/src/openrct2/ride/gentle/MerryGoRound.cpp
@@ -84,9 +84,9 @@ static void PaintCarousel(
 
     auto imageTemplate = ImageId(0, ride.vehicle_colours[0].Body, ride.vehicle_colours[0].Trim);
     auto imageFlags = session.TrackColours[SCHEME_MISC];
-    if (imageFlags != IMAGE_TYPE_REMAP)
+    if (!imageFlags.HasPrimary())
     {
-        imageTemplate = ImageId::FromUInt32(imageFlags);
+        imageTemplate = imageFlags;
     }
     auto imageOffset = rotationOffset & 0x1F;
     auto imageId = imageTemplate.WithIndex(rideEntry->Cars[0].base_image_id + imageOffset);

--- a/src/openrct2/ride/gentle/MiniGolf.cpp
+++ b/src/openrct2/ride/gentle/MiniGolf.cpp
@@ -444,7 +444,7 @@ const size_t mini_golf_peep_animation_lengths[] = {
 // clang-format on
 
 static paint_struct* mini_golf_paint_util_7c(
-    paint_session& session, uint8_t direction, uint32_t image_id, int8_t x_offset, int8_t y_offset, int16_t bound_box_length_x,
+    paint_session& session, uint8_t direction, ImageId image_id, int8_t x_offset, int8_t y_offset, int16_t bound_box_length_x,
     int16_t bound_box_length_y, int8_t bound_box_length_z, int16_t z_offset, int16_t bound_box_offset_x,
     int16_t bound_box_offset_y, int16_t bound_box_offset_z, uint32_t rotation)
 {
@@ -487,17 +487,17 @@ static void paint_mini_golf_track_flat(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId;
+    ImageId imageId;
 
     if (direction & 1)
     {
-        imageId = SPR_MINI_GOLF_FLAT_NW_SE | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_MINI_GOLF_FLAT_NW_SE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 20, 32, 1 }, { 6, 0, height });
         paint_util_push_tunnel_right(session, height, TUNNEL_PATH_AND_MINI_GOLF);
     }
     else
     {
-        imageId = SPR_MINI_GOLF_FLAT_SW_NE | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_MINI_GOLF_FLAT_SW_NE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 20, 1 }, { 0, 6, height });
         paint_util_push_tunnel_left(session, height, TUNNEL_PATH_AND_MINI_GOLF);
     }
@@ -510,18 +510,18 @@ static void paint_mini_golf_track_flat(
     {
         if (direction & 1)
         {
-            imageId = SPR_MINI_GOLF_FLAT_FENCE_BACK_NW_SE | session.TrackColours[SCHEME_MISC];
+            imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_MINI_GOLF_FLAT_FENCE_BACK_NW_SE);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 32, 7 }, { 10, 0, height + 2 });
 
-            imageId = SPR_MINI_GOLF_FLAT_FENCE_FRONT_NW_SE | session.TrackColours[SCHEME_MISC];
+            imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_MINI_GOLF_FLAT_FENCE_FRONT_NW_SE);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 32, 7 }, { 22, 0, height + 2 });
         }
         else
         {
-            imageId = SPR_MINI_GOLF_FLAT_FENCE_BACK_SW_NE | session.TrackColours[SCHEME_MISC];
+            imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_MINI_GOLF_FLAT_FENCE_BACK_SW_NE);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 1, 7 }, { 0, 10, height + 2 });
 
-            imageId = SPR_MINI_GOLF_FLAT_FENCE_FRONT_SW_NE | session.TrackColours[SCHEME_MISC];
+            imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_MINI_GOLF_FLAT_FENCE_FRONT_SW_NE);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 1, 7 }, { 0, 22, height + 2 });
         }
     }
@@ -534,19 +534,19 @@ static void paint_mini_golf_track_25_deg_up(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId;
+    ImageId imageId;
 
-    imageId = mini_golf_track_sprites_25_deg_up[direction][0] | session.TrackColours[SCHEME_TRACK];
+    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(mini_golf_track_sprites_25_deg_up[direction][0]);
     mini_golf_paint_util_7c(session, direction, imageId, 0, 0, 32, 20, 1, height, 0, 6, height, session.CurrentRotation);
 
     metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
     paint_util_set_segment_support_height(
         session, paint_util_rotate_segments(SEGMENT_D0 | SEGMENT_C4 | SEGMENT_CC, direction), 0xFFFF, 0);
 
-    imageId = mini_golf_track_sprites_25_deg_up[direction][1] | session.TrackColours[SCHEME_MISC];
+    imageId = session.TrackColours[SCHEME_MISC].WithIndex(mini_golf_track_sprites_25_deg_up[direction][1]);
     mini_golf_paint_util_7c(session, direction, imageId, 0, 0, 32, 1, 15, height, 0, 10, height + 2, session.CurrentRotation);
 
-    imageId = mini_golf_track_sprites_25_deg_up[direction][2] | session.TrackColours[SCHEME_MISC];
+    imageId = session.TrackColours[SCHEME_MISC].WithIndex(mini_golf_track_sprites_25_deg_up[direction][2]);
     mini_golf_paint_util_7c(session, direction, imageId, 0, 0, 32, 1, 15, height, 0, 22, height + 2, session.CurrentRotation);
 
     switch (direction)
@@ -573,19 +573,19 @@ static void paint_mini_golf_track_flat_to_25_deg_up(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId;
+    ImageId imageId;
 
-    imageId = mini_golf_track_sprites_flat_to_25_deg_up[direction][0] | session.TrackColours[SCHEME_TRACK];
+    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(mini_golf_track_sprites_flat_to_25_deg_up[direction][0]);
     mini_golf_paint_util_7c(session, direction, imageId, 0, 0, 32, 20, 1, height, 0, 6, height, session.CurrentRotation);
 
     metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
     paint_util_set_segment_support_height(
         session, paint_util_rotate_segments(SEGMENT_D0 | SEGMENT_C4 | SEGMENT_CC, direction), 0xFFFF, 0);
 
-    imageId = mini_golf_track_sprites_flat_to_25_deg_up[direction][1] | session.TrackColours[SCHEME_MISC];
+    imageId = session.TrackColours[SCHEME_MISC].WithIndex(mini_golf_track_sprites_flat_to_25_deg_up[direction][1]);
     mini_golf_paint_util_7c(session, direction, imageId, 0, 0, 32, 1, 11, height, 0, 10, height + 2, session.CurrentRotation);
 
-    imageId = mini_golf_track_sprites_flat_to_25_deg_up[direction][2] | session.TrackColours[SCHEME_MISC];
+    imageId = session.TrackColours[SCHEME_MISC].WithIndex(mini_golf_track_sprites_flat_to_25_deg_up[direction][2]);
     mini_golf_paint_util_7c(session, direction, imageId, 0, 0, 32, 1, 11, height, 0, 22, height + 2, session.CurrentRotation);
 
     switch (direction)
@@ -612,19 +612,19 @@ static void paint_mini_golf_track_25_deg_up_to_flat(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId;
+    ImageId imageId;
 
-    imageId = mini_golf_track_sprites_25_deg_up_to_flat[direction][0] | session.TrackColours[SCHEME_TRACK];
+    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(mini_golf_track_sprites_25_deg_up_to_flat[direction][0]);
     mini_golf_paint_util_7c(session, direction, imageId, 0, 0, 32, 20, 1, height, 0, 6, height, session.CurrentRotation);
 
     metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
     paint_util_set_segment_support_height(
         session, paint_util_rotate_segments(SEGMENT_D0 | SEGMENT_C4 | SEGMENT_CC, direction), 0xFFFF, 0);
 
-    imageId = mini_golf_track_sprites_25_deg_up_to_flat[direction][1] | session.TrackColours[SCHEME_MISC];
+    imageId = session.TrackColours[SCHEME_MISC].WithIndex(mini_golf_track_sprites_25_deg_up_to_flat[direction][1]);
     mini_golf_paint_util_7c(session, direction, imageId, 0, 0, 32, 1, 11, height, 0, 10, height + 2, session.CurrentRotation);
 
-    imageId = mini_golf_track_sprites_25_deg_up_to_flat[direction][2] | session.TrackColours[SCHEME_MISC];
+    imageId = session.TrackColours[SCHEME_MISC].WithIndex(mini_golf_track_sprites_25_deg_up_to_flat[direction][2]);
     mini_golf_paint_util_7c(session, direction, imageId, 0, 0, 32, 1, 11, height, 0, 22, height + 2, session.CurrentRotation);
 
     switch (direction)
@@ -676,10 +676,10 @@ static void paint_mini_golf_station(
     const TrackElement& trackElement)
 {
     const auto* stationObj = ride.GetStationObject();
-    uint32_t imageId;
+    ImageId imageId;
     bool hasFence;
 
-    imageId = SPR_MINI_GOLF_STATION_FLOOR | session.TrackColours[SCHEME_TRACK];
+    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_MINI_GOLF_STATION_FLOOR);
     mini_golf_paint_util_7c(session, direction, imageId, 0, 0, 32, 28, 1, height, 0, 0, height, session.CurrentRotation);
 
     if (direction & 1)
@@ -687,14 +687,14 @@ static void paint_mini_golf_station(
         hasFence = track_paint_util_has_fence(EDGE_NE, session.MapPosition, trackElement, ride, session.CurrentRotation);
         if (hasFence)
         {
-            imageId = SPR_MINI_GOLF_FLAT_FENCE_BACK_NW_SE | session.TrackColours[SCHEME_MISC];
+            imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_MINI_GOLF_FLAT_FENCE_BACK_NW_SE);
             PaintAddImageAsParent(session, imageId, { -10, 0, height }, { 1, 32, 7 }, { 0, 0, height + 2 });
         }
 
         bool hasSWFence = track_paint_util_has_fence(EDGE_SW, session.MapPosition, trackElement, ride, session.CurrentRotation);
         if (hasFence)
         {
-            imageId = SPR_MINI_GOLF_FLAT_FENCE_FRONT_NW_SE | session.TrackColours[SCHEME_MISC];
+            imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_MINI_GOLF_FLAT_FENCE_FRONT_NW_SE);
             PaintAddImageAsParent(session, imageId, { 10, 0, height }, { 1, 32, 7 }, { 31, 0, height + 2 });
         }
 
@@ -709,14 +709,14 @@ static void paint_mini_golf_station(
         hasFence = track_paint_util_has_fence(EDGE_NW, session.MapPosition, trackElement, ride, session.CurrentRotation);
         if (hasFence)
         {
-            imageId = SPR_MINI_GOLF_FLAT_FENCE_BACK_SW_NE | session.TrackColours[SCHEME_MISC];
+            imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_MINI_GOLF_FLAT_FENCE_BACK_SW_NE);
             PaintAddImageAsParent(session, imageId, { 0, -10, height }, { 32, 1, 7 }, { 0, 0, height + 2 });
         }
 
         bool hasSEFence = track_paint_util_has_fence(EDGE_SE, session.MapPosition, trackElement, ride, session.CurrentRotation);
         if (hasFence)
         {
-            imageId = SPR_MINI_GOLF_FLAT_FENCE_FRONT_SW_NE | session.TrackColours[SCHEME_MISC];
+            imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_MINI_GOLF_FLAT_FENCE_FRONT_SW_NE);
             PaintAddImageAsParent(session, imageId, { 0, 10, height }, { 32, 1, 7 }, { 0, 31, height + 2 });
         }
 
@@ -737,7 +737,7 @@ static void paint_mini_golf_track_left_quarter_turn_1_tile(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId;
+    ImageId imageId;
 
     track_paint_util_left_quarter_turn_1_tile_paint(
         session, 1, height, 0, direction, session.TrackColours[SCHEME_TRACK], mini_golf_track_sprites_quarter_turn_1_tile);
@@ -756,7 +756,7 @@ static void paint_mini_golf_track_left_quarter_turn_1_tile(
             if (!shouldDrawFence)
                 break;
 
-            imageId = SPR_MINI_GOLF_QUARTER_TURN_1_TILE_FENCE_BACK_SW_NW | session.TrackColours[SCHEME_MISC];
+            imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_MINI_GOLF_QUARTER_TURN_1_TILE_FENCE_BACK_SW_NW);
             PaintAddImageAsChild(session, imageId, { 0, 0, height }, { 26, 24, 1 }, { 6, 2, height });
 
             break;
@@ -765,7 +765,7 @@ static void paint_mini_golf_track_left_quarter_turn_1_tile(
             if (!shouldDrawFence)
                 break;
 
-            imageId = SPR_MINI_GOLF_QUARTER_TURN_1_TILE_FENCE_BACK_NW_NE | session.TrackColours[SCHEME_MISC];
+            imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_MINI_GOLF_QUARTER_TURN_1_TILE_FENCE_BACK_NW_NE);
             PaintAddImageAsChild(session, imageId, { 0, 0, height }, { 26, 26, 1 }, { 0, 0, height });
             break;
 
@@ -774,7 +774,7 @@ static void paint_mini_golf_track_left_quarter_turn_1_tile(
             if (!shouldDrawFence)
                 break;
 
-            imageId = SPR_MINI_GOLF_QUARTER_TURN_1_TILE_FENCE_BACK_NE_SE | session.TrackColours[SCHEME_MISC];
+            imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_MINI_GOLF_QUARTER_TURN_1_TILE_FENCE_BACK_NE_SE);
             PaintAddImageAsChild(session, imageId, { 0, 0, height }, { 24, 26, 1 }, { 2, 6, height });
             break;
 
@@ -784,7 +784,7 @@ static void paint_mini_golf_track_left_quarter_turn_1_tile(
             if (!shouldDrawFence)
                 break;
 
-            imageId = SPR_MINI_GOLF_QUARTER_TURN_1_TILE_FENCE_BACK_SE_SW | session.TrackColours[SCHEME_MISC];
+            imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_MINI_GOLF_QUARTER_TURN_1_TILE_FENCE_BACK_SE_SW);
             PaintAddImageAsChild(session, imageId, { 0, 0, height }, { 24, 24, 1 }, { 6, 6, height });
             break;
     }
@@ -799,11 +799,11 @@ static void paint_mini_golf_track_left_quarter_turn_1_tile(
         switch (direction)
         {
             case 0:
-                imageId = SPR_MINI_GOLF_QUARTER_TURN_1_TILE_FENCE_INSIDE_SW_NW | session.TrackColours[SCHEME_MISC];
+                imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_MINI_GOLF_QUARTER_TURN_1_TILE_FENCE_INSIDE_SW_NW);
                 PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 5, 5, 5 }, { 24, 0, height + 2 });
                 break;
             case 2:
-                imageId = SPR_MINI_GOLF_QUARTER_TURN_1_TILE_FENCE_INSIDE_NE_SE | session.TrackColours[SCHEME_MISC];
+                imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_MINI_GOLF_QUARTER_TURN_1_TILE_FENCE_INSIDE_NE_SE);
                 PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 5, 5, 5 }, { 0, 24, height + 2 });
                 break;
         }
@@ -823,7 +823,7 @@ static void paint_mini_golf_track_right_quarter_turn_1_tile(
 static void paint_mini_golf_hole_ab(
     paint_session& session, uint8_t trackSequence, uint8_t direction, int32_t height, const uint32_t sprites[4][2][2])
 {
-    uint32_t imageId;
+    ImageId imageId;
     CoordsXY boundBox, boundBoxOffset;
 
     bool drewSupports = wooden_a_supports_paint_setup(
@@ -852,23 +852,24 @@ static void paint_mini_golf_hole_ab(
         boundBoxOffset = { 0, 3 };
     }
 
-    imageId = sprites[direction][trackSequence][1] | session.TrackColours[SCHEME_TRACK];
+    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(sprites[direction][trackSequence][1]);
     PaintAddImageAsParent(
         session, imageId, { 0, 0, height }, { boundBox.x, boundBox.y, 0 }, { boundBoxOffset.x, boundBoxOffset.y, height + 24 });
 
     if (drewSupports)
     {
-        imageId = ((direction & 1) ? SPR_FLOOR_PLANKS_90_DEG : SPR_FLOOR_PLANKS) | session.TrackColours[SCHEME_SUPPORTS];
+        imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(
+            ((direction & 1) ? SPR_FLOOR_PLANKS_90_DEG : SPR_FLOOR_PLANKS));
         PaintAddImageAsParent(
             session, imageId, { 0, 0, height }, { boundBox.x, boundBox.y, 1 }, { boundBoxOffset.x, boundBoxOffset.y, height });
 
-        imageId = sprites[direction][trackSequence][0] | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(sprites[direction][trackSequence][0]);
         PaintAddImageAsChild(
             session, imageId, { 0, 0, height }, { boundBox.x, boundBox.y, 1 }, { boundBoxOffset.x, boundBoxOffset.y, height });
     }
     else
     {
-        imageId = sprites[direction][trackSequence][0] | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(sprites[direction][trackSequence][0]);
         PaintAddImageAsParent(
             session, imageId, { 0, 0, height }, { boundBox.x, boundBox.y, 1 }, { boundBoxOffset.x, boundBoxOffset.y, height });
     }
@@ -895,7 +896,7 @@ static void paint_mini_golf_hole_c(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId;
+    ImageId imageId;
     CoordsXY boundBox, boundBoxOffset;
 
     bool drewSupports = wooden_a_supports_paint_setup(
@@ -924,7 +925,7 @@ static void paint_mini_golf_hole_c(
         boundBoxOffset = { 0, 3 };
     }
 
-    imageId = mini_golf_track_sprites_hole_c[direction][trackSequence][1] | session.TrackColours[SCHEME_TRACK];
+    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(mini_golf_track_sprites_hole_c[direction][trackSequence][1]);
 
     switch ((direction << 4) | trackSequence)
     {
@@ -945,17 +946,18 @@ static void paint_mini_golf_hole_c(
 
     if (drewSupports)
     {
-        imageId = ((direction & 1) ? SPR_FLOOR_PLANKS_90_DEG : SPR_FLOOR_PLANKS) | session.TrackColours[SCHEME_SUPPORTS];
+        imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(
+            ((direction & 1) ? SPR_FLOOR_PLANKS_90_DEG : SPR_FLOOR_PLANKS));
         PaintAddImageAsParent(
             session, imageId, { 0, 0, height }, { boundBox.x, boundBox.y, 1 }, { boundBoxOffset.x, boundBoxOffset.y, height });
 
-        imageId = mini_golf_track_sprites_hole_c[direction][trackSequence][0] | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(mini_golf_track_sprites_hole_c[direction][trackSequence][0]);
         PaintAddImageAsChild(
             session, imageId, { 0, 0, height }, { boundBox.x, boundBox.y, 1 }, { boundBoxOffset.x, boundBoxOffset.y, height });
     }
     else
     {
-        imageId = mini_golf_track_sprites_hole_c[direction][trackSequence][0] | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(mini_golf_track_sprites_hole_c[direction][trackSequence][0]);
         PaintAddImageAsParent(
             session, imageId, { 0, 0, height }, { boundBox.x, boundBox.y, 1 }, { boundBoxOffset.x, boundBoxOffset.y, height });
     }
@@ -966,7 +968,7 @@ static void paint_mini_golf_hole_d(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId;
+    ImageId imageId;
     CoordsXY boundBox, boundBoxOffset;
 
     int32_t supportType = (direction & 1);
@@ -1001,7 +1003,7 @@ static void paint_mini_golf_hole_d(
         boundBoxOffset = { 0, 3 };
     }
 
-    imageId = mini_golf_track_sprites_hole_d[direction][trackSequence][1] | session.TrackColours[SCHEME_TRACK];
+    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(mini_golf_track_sprites_hole_d[direction][trackSequence][1]);
 
     switch ((direction << 4) | trackSequence)
     {
@@ -1038,17 +1040,18 @@ static void paint_mini_golf_hole_d(
 
     if (drewSupports)
     {
-        imageId = ((supportType & 1) ? SPR_FLOOR_PLANKS_90_DEG : SPR_FLOOR_PLANKS) | session.TrackColours[SCHEME_SUPPORTS];
+        imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(
+            ((supportType & 1) ? SPR_FLOOR_PLANKS_90_DEG : SPR_FLOOR_PLANKS));
         PaintAddImageAsParent(
             session, imageId, { 0, 0, height }, { boundBox.x, boundBox.y, 1 }, { boundBoxOffset.x, boundBoxOffset.y, height });
 
-        imageId = mini_golf_track_sprites_hole_d[direction][trackSequence][0] | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(mini_golf_track_sprites_hole_d[direction][trackSequence][0]);
         PaintAddImageAsChild(
             session, imageId, { 0, 0, height }, { boundBox.x, boundBox.y, 1 }, { boundBoxOffset.x, boundBoxOffset.y, height });
     }
     else
     {
-        imageId = mini_golf_track_sprites_hole_d[direction][trackSequence][0] | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(mini_golf_track_sprites_hole_d[direction][trackSequence][0]);
         PaintAddImageAsParent(
             session, imageId, { 0, 0, height }, { boundBox.x, boundBox.y, 1 }, { boundBoxOffset.x, boundBoxOffset.y, height });
     }
@@ -1059,7 +1062,7 @@ static void paint_mini_golf_hole_e(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId;
+    ImageId imageId;
     CoordsXY boundBox, boundBoxOffset;
 
     int32_t supportType = (direction & 1);
@@ -1094,7 +1097,7 @@ static void paint_mini_golf_hole_e(
         boundBoxOffset = { 0, 3 };
     }
 
-    imageId = mini_golf_track_sprites_hole_e[direction][trackSequence][1] | session.TrackColours[SCHEME_TRACK];
+    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(mini_golf_track_sprites_hole_e[direction][trackSequence][1]);
 
     switch ((direction << 4) | trackSequence)
     {
@@ -1131,17 +1134,18 @@ static void paint_mini_golf_hole_e(
 
     if (drewSupports)
     {
-        imageId = ((supportType & 1) ? SPR_FLOOR_PLANKS_90_DEG : SPR_FLOOR_PLANKS) | session.TrackColours[SCHEME_SUPPORTS];
+        imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(
+            ((supportType & 1) ? SPR_FLOOR_PLANKS_90_DEG : SPR_FLOOR_PLANKS));
         PaintAddImageAsParent(
             session, imageId, { 0, 0, height }, { boundBox.x, boundBox.y, 1 }, { boundBoxOffset.x, boundBoxOffset.y, height });
 
-        imageId = mini_golf_track_sprites_hole_e[direction][trackSequence][0] | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(mini_golf_track_sprites_hole_e[direction][trackSequence][0]);
         PaintAddImageAsChild(
             session, imageId, { 0, 0, height }, { boundBox.x, boundBox.y, 1 }, { boundBoxOffset.x, boundBoxOffset.y, height });
     }
     else
     {
-        imageId = mini_golf_track_sprites_hole_e[direction][trackSequence][0] | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(mini_golf_track_sprites_hole_e[direction][trackSequence][0]);
         PaintAddImageAsParent(
             session, imageId, { 0, 0, height }, { boundBox.x, boundBox.y, 1 }, { boundBoxOffset.x, boundBoxOffset.y, height });
     }

--- a/src/openrct2/ride/gentle/MiniHelicopters.cpp
+++ b/src/openrct2/ride/gentle/MiniHelicopters.cpp
@@ -21,14 +21,14 @@ static void paint_mini_helicopters_track_station(
     paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId;
+    ImageId imageId;
 
     if (direction == 0 || direction == 2)
     {
-        imageId = SPR_STATION_BASE_B_SW_NE | session.TrackColours[SCHEME_MISC];
+        imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_STATION_BASE_B_SW_NE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height - 2 }, { 32, 28, 1 }, { 0, 2, height });
 
-        imageId = SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_FLAT_NE_SW | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_FLAT_NE_SW);
         PaintAddImageAsChild(session, imageId, { 0, 0, height }, { 32, 20, 1 }, { 0, 0, height });
 
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -37,10 +37,10 @@ static void paint_mini_helicopters_track_station(
     }
     else if (direction == 1 || direction == 3)
     {
-        imageId = SPR_STATION_BASE_B_NW_SE | session.TrackColours[SCHEME_MISC];
+        imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_STATION_BASE_B_NW_SE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height - 2 }, { 28, 32, 1 }, { 2, 0, height });
 
-        imageId = SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_FLAT_SE_NW | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_FLAT_SE_NW);
         PaintAddImageAsChild(session, imageId, { 0, 0, height }, { 20, 32, 1 }, { 0, 0, height });
 
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -59,17 +59,17 @@ static void paint_mini_helicopters_track_flat(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId;
+    ImageId imageId;
 
     if (direction & 1)
     {
-        imageId = SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_FLAT_SE_NW | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_FLAT_SE_NW);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
         paint_util_push_tunnel_right(session, height, TUNNEL_0);
     }
     else
     {
-        imageId = SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_FLAT_NE_SW | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_FLAT_NE_SW);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
         paint_util_push_tunnel_left(session, height, TUNNEL_0);
     }
@@ -91,27 +91,31 @@ static void paint_mini_helicopters_track_flat_to_25_deg_up(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId;
+    ImageId imageId;
 
     switch (direction)
     {
         case 0:
-            imageId = SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_FLAT_TO_25_DEG_UP_SW_NE | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+                SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_FLAT_TO_25_DEG_UP_SW_NE);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
             paint_util_push_tunnel_left(session, height, TUNNEL_0);
             break;
         case 1:
-            imageId = SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_FLAT_TO_25_DEG_UP_NW_SE | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+                SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_FLAT_TO_25_DEG_UP_NW_SE);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
             paint_util_push_tunnel_right(session, height, TUNNEL_2);
             break;
         case 2:
-            imageId = SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_FLAT_TO_25_DEG_UP_NE_SW | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+                SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_FLAT_TO_25_DEG_UP_NE_SW);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
             paint_util_push_tunnel_left(session, height, TUNNEL_2);
             break;
         case 3:
-            imageId = SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_FLAT_TO_25_DEG_UP_SE_NW | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+                SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_FLAT_TO_25_DEG_UP_SE_NW);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
             paint_util_push_tunnel_right(session, height, TUNNEL_0);
             break;
@@ -132,27 +136,27 @@ static void paint_mini_helicopters_track_25_deg_up(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId;
+    ImageId imageId;
 
     switch (direction)
     {
         case 0:
-            imageId = SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_25_DEG_UP_SW_NE | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_25_DEG_UP_SW_NE);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
             paint_util_push_tunnel_left(session, height - 8, TUNNEL_1);
             break;
         case 1:
-            imageId = SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_25_DEG_UP_NW_SE | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_25_DEG_UP_NW_SE);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
             paint_util_push_tunnel_right(session, height + 8, TUNNEL_2);
             break;
         case 2:
-            imageId = SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_25_DEG_UP_NE_SW | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_25_DEG_UP_NE_SW);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
             paint_util_push_tunnel_left(session, height + 8, TUNNEL_2);
             break;
         case 3:
-            imageId = SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_25_DEG_UP_SE_NW | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_25_DEG_UP_SE_NW);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
             paint_util_push_tunnel_right(session, height - 8, TUNNEL_1);
             break;
@@ -173,27 +177,31 @@ static void paint_mini_helicopters_track_25_deg_up_to_flat(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId;
+    ImageId imageId;
 
     switch (direction)
     {
         case 0:
-            imageId = SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_25_DEG_UP_TO_FLAT_SW_NE | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+                SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_25_DEG_UP_TO_FLAT_SW_NE);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
             paint_util_push_tunnel_left(session, height - 8, TUNNEL_0);
             break;
         case 1:
-            imageId = SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_25_DEG_UP_TO_FLAT_NW_SE | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+                SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_25_DEG_UP_TO_FLAT_NW_SE);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
             paint_util_push_tunnel_right(session, height + 8, TUNNEL_12);
             break;
         case 2:
-            imageId = SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_25_DEG_UP_TO_FLAT_NE_SW | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+                SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_25_DEG_UP_TO_FLAT_NE_SW);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
             paint_util_push_tunnel_left(session, height + 8, TUNNEL_12);
             break;
         case 3:
-            imageId = SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_25_DEG_UP_TO_FLAT_SE_NW | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+                SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_25_DEG_UP_TO_FLAT_SE_NW);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 20, 32, 3 }, { 6, 0, height });
             paint_util_push_tunnel_right(session, height - 8, TUNNEL_0);
             break;

--- a/src/openrct2/ride/gentle/MonorailCycles.cpp
+++ b/src/openrct2/ride/gentle/MonorailCycles.cpp
@@ -160,7 +160,7 @@ static constexpr const uint32_t monorail_cycles_track_pieces_flat_quarter_turn_3
 };
 
 static paint_struct* paint_monorail_cycles_util_7c(
-    paint_session& session, bool flip, uint32_t image_id, int8_t x_offset, int8_t y_offset, int16_t bound_box_length_x,
+    paint_session& session, bool flip, ImageId image_id, int8_t x_offset, int8_t y_offset, int16_t bound_box_length_x,
     int16_t bound_box_length_y, int8_t bound_box_length_z, int16_t z_offset, int16_t bound_box_offset_x,
     int16_t bound_box_offset_y, int16_t bound_box_offset_z, uint32_t rotation)
 {
@@ -181,7 +181,7 @@ static void paint_monorail_cycles_track_flat(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId = monorail_cycles_track_pieces_flat[(direction & 1)] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(monorail_cycles_track_pieces_flat[(direction & 1)]);
     paint_monorail_cycles_util_7c(
         session, static_cast<bool>(direction & 1), imageId, 0, 0, 32, 20, 3, height, 0, 6, height, session.CurrentRotation);
 
@@ -208,14 +208,14 @@ static void paint_monorail_cycles_station(
     paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId;
+    ImageId imageId;
 
     if (direction == 0 || direction == 2)
     {
-        imageId = SPR_STATION_BASE_B_SW_NE | session.TrackColours[SCHEME_MISC];
+        imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_STATION_BASE_B_SW_NE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height - 2 }, { 32, 28, 1 }, { 0, 2, height });
 
-        imageId = SPR_MONORAIL_CYCLES_FLAT_SW_NE | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_MONORAIL_CYCLES_FLAT_SW_NE);
         PaintAddImageAsChild(session, imageId, { 0, 0, height }, { 32, 20, 1 }, { 0, 0, height });
 
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -224,10 +224,10 @@ static void paint_monorail_cycles_station(
     }
     else if (direction == 1 || direction == 3)
     {
-        imageId = SPR_STATION_BASE_B_NW_SE | session.TrackColours[SCHEME_MISC];
+        imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_STATION_BASE_B_NW_SE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height - 2 }, { 28, 32, 1 }, { 2, 0, height });
 
-        imageId = SPR_MONORAIL_CYCLES_FLAT_NW_SE | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_MONORAIL_CYCLES_FLAT_NW_SE);
         PaintAddImageAsChild(session, imageId, { 0, 0, height }, { 20, 32, 1 }, { 0, 0, height });
 
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -439,8 +439,8 @@ static void paint_monorail_cycles_track_s_bend_left(
         trackSequence = 3 - trackSequence;
     }
 
-    uint32_t imageId = monorail_cycles_track_pieces_s_bend_left[direction & 1][trackSequence]
-        | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+        monorail_cycles_track_pieces_s_bend_left[direction & 1][trackSequence]);
     switch (trackSequence)
     {
         case 0:
@@ -548,8 +548,8 @@ static void paint_monorail_cycles_track_s_bend_right(
         trackSequence = 3 - trackSequence;
     }
 
-    uint32_t imageId = monorail_cycles_track_pieces_s_bend_right[direction & 1][trackSequence]
-        | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+        monorail_cycles_track_pieces_s_bend_right[direction & 1][trackSequence]);
     switch (trackSequence)
     {
         case 0:

--- a/src/openrct2/ride/gentle/ObservationTower.cpp
+++ b/src/openrct2/ride/gentle/ObservationTower.cpp
@@ -101,13 +101,13 @@ static void paint_observation_tower_base(
 
     if (trackSequence == 0)
     {
-        uint32_t imageId = SPR_OBSERVATION_TOWER_SEGMENT_BASE | session.TrackColours[SCHEME_TRACK];
+        auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_OBSERVATION_TOWER_SEGMENT_BASE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 2, 2, 27 }, { 8, 8, height + 3 });
 
-        imageId = SPR_OBSERVATION_TOWER_SEGMENT | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_OBSERVATION_TOWER_SEGMENT);
         PaintAddImageAsParent(session, imageId, { 0, 0, height + 32 }, { 2, 2, 30 }, { 8, 8, height + 32 });
 
-        imageId = SPR_OBSERVATION_TOWER_SEGMENT | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_OBSERVATION_TOWER_SEGMENT);
         PaintAddImageAsParent(session, imageId, { 0, 0, height + 64 }, { 2, 2, 30 }, { 8, 8, height + 64 });
 
         paint_util_set_vertical_tunnel(session, height + 96);
@@ -161,13 +161,13 @@ static void paint_observation_tower_section(
         return;
     }
 
-    uint32_t imageId = SPR_OBSERVATION_TOWER_SEGMENT | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_OBSERVATION_TOWER_SEGMENT);
     PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 2, 2, 30 }, { 8, 8, height });
 
     const TileElement* nextTileElement = reinterpret_cast<const TileElement*>(&trackElement) + 1;
     if (trackElement.IsLastForTile() || trackElement.GetClearanceZ() != nextTileElement->GetBaseZ())
     {
-        imageId = SPR_OBSERVATION_TOWER_SEGMENT_TOP | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_OBSERVATION_TOWER_SEGMENT_TOP);
         PaintAddImageAsChild(session, imageId, { 0, 0, height }, { 2, 2, 30 }, { 8, 8, height });
     }
 

--- a/src/openrct2/ride/gentle/SpaceRings.cpp
+++ b/src/openrct2/ride/gentle/SpaceRings.cpp
@@ -53,19 +53,18 @@ static void paint_space_rings_structure(
             frameNum += static_cast<int8_t>(vehicle->Pitch) * 4;
         }
 
-        uint32_t imageColourFlags = session.TrackColours[SCHEME_MISC];
+        auto imageColourFlags = session.TrackColours[SCHEME_MISC];
         if ((ride.colour_scheme_type & 3) != RIDE_COLOUR_SCHEME_MODE_DIFFERENT_PER_TRAIN)
         {
             vehicleIndex = 0;
         }
 
-        if (imageColourFlags == IMAGE_TYPE_REMAP)
+        if (imageColourFlags.ToUInt32() == IMAGE_TYPE_REMAP)
         {
-            imageColourFlags = SPRITE_ID_PALETTE_COLOUR_2(
-                ride.vehicle_colours[vehicleIndex].Body, ride.vehicle_colours[vehicleIndex].Trim);
+            imageColourFlags = ImageId(0, ride.vehicle_colours[vehicleIndex].Body, ride.vehicle_colours[vehicleIndex].Trim);
         }
 
-        uint32_t imageId = (baseImageId + frameNum) | imageColourFlags;
+        auto imageId = imageColourFlags.WithIndex(baseImageId + frameNum);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 20, 20, 23 }, { -10, -10, height });
 
         if (vehicle != nullptr && vehicle->num_peeps > 0)
@@ -73,8 +72,8 @@ static void paint_space_rings_structure(
             auto* rider = GetEntity<Guest>(vehicle->peep[0]);
             if (rider != nullptr)
             {
-                imageColourFlags = SPRITE_ID_PALETTE_COLOUR_2(rider->TshirtColour, rider->TrousersColour);
-                imageId = ((baseImageId & 0x7FFFF) + 352 + frameNum) | imageColourFlags;
+                imageColourFlags = ImageId(0, rider->TshirtColour, rider->TrousersColour);
+                imageId = imageColourFlags.WithIndex((baseImageId & 0x7FFFF) + 352 + frameNum);
                 PaintAddImageAsChild(session, imageId, { 0, 0, height }, { 20, 20, 23 }, { -10, -10, height });
             }
         }
@@ -94,7 +93,7 @@ static void paint_space_rings(
     int32_t edges = edges_3x3[trackSequence];
     CoordsXY position = session.MapPosition;
 
-    uint32_t imageId;
+    ImageId imageId;
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session.TrackColours[SCHEME_MISC]);
 
@@ -106,12 +105,12 @@ static void paint_space_rings(
         case 7:
             if (track_paint_util_has_fence(EDGE_SW, position, trackElement, ride, session.CurrentRotation))
             {
-                imageId = SPR_SPACE_RINGS_FENCE_SW | session.TrackColours[SCHEME_MISC];
+                imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_SPACE_RINGS_FENCE_SW);
                 PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 28, 7 }, { 29, 0, height + 2 });
             }
             if (track_paint_util_has_fence(EDGE_SE, position, trackElement, ride, session.CurrentRotation))
             {
-                imageId = SPR_SPACE_RINGS_FENCE_SE | session.TrackColours[SCHEME_MISC];
+                imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_SPACE_RINGS_FENCE_SE);
                 PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 28, 1, 7 }, { 0, 29, height + 2 });
             }
             break;

--- a/src/openrct2/ride/gentle/SpiralSlide.cpp
+++ b/src/openrct2/ride/gentle/SpiralSlide.cpp
@@ -56,16 +56,16 @@ static void spiral_slide_paint_tile_right(
     if (rideEntry == nullptr)
         return;
 
-    uint32_t image_id = 0;
+    ImageId image_id;
 
     if (direction == 0)
-        image_id = (rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_RIGHT_R0) | session.TrackColours[SCHEME_TRACK];
-    if (direction == 1)
-        image_id = (rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_RIGHT_R1) | session.TrackColours[SCHEME_TRACK];
-    if (direction == 2)
-        image_id = (rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_RIGHT_R2) | session.TrackColours[SCHEME_TRACK];
-    if (direction == 3)
-        image_id = (rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_RIGHT_R3) | session.TrackColours[SCHEME_TRACK];
+        image_id = session.TrackColours[SCHEME_TRACK].WithIndex((rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_RIGHT_R0));
+    else if (direction == 1)
+        image_id = session.TrackColours[SCHEME_TRACK].WithIndex((rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_RIGHT_R1));
+    else if (direction == 2)
+        image_id = session.TrackColours[SCHEME_TRACK].WithIndex((rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_RIGHT_R2));
+    else
+        image_id = session.TrackColours[SCHEME_TRACK].WithIndex((rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_RIGHT_R3));
 
     PaintAddImageAsParent(session, image_id, { 16, 16, height }, { 16, 16, 108 }, { 16, 0, height + 3 });
 }
@@ -78,16 +78,16 @@ static void spiral_slide_paint_tile_left(
     if (rideEntry == nullptr)
         return;
 
-    uint32_t image_id = 0;
+    ImageId image_id;
 
     if (direction == 0)
-        image_id = (rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_LEFT_R0) | session.TrackColours[SCHEME_TRACK];
-    if (direction == 1)
-        image_id = (rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_LEFT_R1) | session.TrackColours[SCHEME_TRACK];
-    if (direction == 2)
-        image_id = (rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_LEFT_R2) | session.TrackColours[SCHEME_TRACK];
-    if (direction == 3)
-        image_id = (rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_LEFT_R3) | session.TrackColours[SCHEME_TRACK];
+        image_id = session.TrackColours[SCHEME_TRACK].WithIndex((rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_LEFT_R0));
+    else if (direction == 1)
+        image_id = session.TrackColours[SCHEME_TRACK].WithIndex((rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_LEFT_R1));
+    else if (direction == 2)
+        image_id = session.TrackColours[SCHEME_TRACK].WithIndex((rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_LEFT_R2));
+    else
+        image_id = session.TrackColours[SCHEME_TRACK].WithIndex((rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_LEFT_R3));
 
     PaintAddImageAsParent(session, image_id, { 16, 16, height }, { 16, 16, 108 }, { 0, 16, height + 3 });
 }
@@ -100,37 +100,37 @@ static void spiral_slide_paint_tile_front(
     if (rideEntry == nullptr)
         return;
 
-    uint32_t image_id = 0;
+    ImageId image_id;
 
     if (direction == 1)
     {
-        image_id = (rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_INSIDE_R1) | session.TrackColours[SCHEME_TRACK];
+        image_id = session.TrackColours[SCHEME_TRACK].WithIndex((rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_INSIDE_R1));
         PaintAddImageAsParent(session, image_id, { 16, 16, height }, { 2, 16, 108 }, { -12, 0, height + 3 });
     }
     else if (direction == 2)
     {
-        image_id = (rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_INSIDE_R2) | session.TrackColours[SCHEME_TRACK];
+        image_id = session.TrackColours[SCHEME_TRACK].WithIndex((rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_INSIDE_R2));
         PaintAddImageAsParent(session, image_id, { 16, 16, height }, { 16, 2, 108 }, { 0, -12, height + 3 });
     }
 
     if (direction == 0)
     {
-        image_id = (rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_CENTRE_R0) | session.TrackColours[SCHEME_TRACK];
+        image_id = session.TrackColours[SCHEME_TRACK].WithIndex((rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_CENTRE_R0));
         PaintAddImageAsParent(session, image_id, { 16, 16, height }, { 16, 8, 108 }, { 0, 8, height + 3 });
     }
     else if (direction == 1)
     {
-        image_id = (rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_CENTRE_R1) | session.TrackColours[SCHEME_TRACK];
+        image_id = session.TrackColours[SCHEME_TRACK].WithIndex((rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_CENTRE_R1));
         PaintAddImageAsParent(session, image_id, { 16, 16, height }, { 2, 16, 108 }, { 14, 0, height + 3 });
     }
     else if (direction == 2)
     {
-        image_id = (rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_CENTRE_R2) | session.TrackColours[SCHEME_TRACK];
+        image_id = session.TrackColours[SCHEME_TRACK].WithIndex((rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_CENTRE_R2));
         PaintAddImageAsParent(session, image_id, { 16, 16, height }, { 16, 2, 108 }, { 0, 14, height + 3 });
     }
     else if (direction == 3)
     {
-        image_id = (rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_CENTRE_R3) | session.TrackColours[SCHEME_TRACK];
+        image_id = session.TrackColours[SCHEME_TRACK].WithIndex((rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_CENTRE_R3));
         PaintAddImageAsParent(session, image_id, { 16, 16, height }, { 8, 16, 108 }, { 8, 0, height + 3 });
     }
 
@@ -183,7 +183,7 @@ static void spiral_slide_paint_tile_front(
                 boundingBox.x = 8;
             }
 
-            image_id = (offset + slide_progress) | (ride.slide_peep_t_shirt_colour << 19) | (1 << 29);
+            image_id = ImageId(offset + slide_progress, ride.slide_peep_t_shirt_colour, COLOUR_GREY);
 
             PaintAddImageAsChild(session, image_id, { 16, 16, height }, boundingBox, boundingBoxOffset);
         }
@@ -212,9 +212,8 @@ static void paint_spiral_slide(
 
     if (stationObject != nullptr && !(stationObject->Flags & STATION_OBJECT_FLAGS::NO_PLATFORMS))
     {
-        uint32_t imageId = ((direction & 1) ? rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_BASE_B
-                                            : rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_BASE_A)
-            | session.TrackColours[SCHEME_SUPPORTS];
+        auto imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(
+            rideEntry->Cars[0].base_image_id + ((direction & 1) ? SPIRAL_SLIDE_BASE_B : SPIRAL_SLIDE_BASE_A));
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 32, 1 }, { 0, 0, height });
     }
 

--- a/src/openrct2/ride/shops/Facility.cpp
+++ b/src/openrct2/ride/shops/Facility.cpp
@@ -37,12 +37,12 @@ static void PaintFacility(
     CoordsXYZ offset(0, 0, height);
     BoundBoxXYZ bb = { { direction == 3 ? 28 : 2, direction == 0 ? 28 : 2, height }, { lengthX, lengthY, 29 } };
 
-    auto imageTemplate = ImageId::FromUInt32(session.TrackColours[SCHEME_TRACK]);
+    auto imageTemplate = session.TrackColours[SCHEME_TRACK];
     auto imageIndex = firstCarEntry->base_image_id + ((direction + 2) & 3);
     auto imageId = imageTemplate.WithIndex(imageIndex);
     if (hasSupports)
     {
-        auto foundationImageTemplate = ImageId::FromUInt32(session.TrackColours[SCHEME_3]);
+        auto foundationImageTemplate = session.TrackColours[SCHEME_3];
         auto foundationImageIndex = (direction & 1) ? SPR_FLOOR_PLANKS_90_DEG : SPR_FLOOR_PLANKS;
         auto foundationImageId = foundationImageTemplate.WithIndex(foundationImageIndex);
         PaintAddImageAsParent(session, foundationImageId, offset, bb);

--- a/src/openrct2/ride/shops/Shop.cpp
+++ b/src/openrct2/ride/shops/Shop.cpp
@@ -35,25 +35,19 @@ static void PaintShop(
     CoordsXYZ offset(0, 0, height);
     BoundBoxXYZ bb = { { 2, 2, height }, { 28, 28, 45 } };
 
-    auto imageFlags = session.TrackColours[SCHEME_TRACK];
-    if (imageFlags & IMAGE_TYPE_REMAP_2_PLUS)
-    {
-        imageFlags &= ~IMAGE_TYPE_REMAP_2_PLUS;
-        imageFlags &= ~(31 << 24);
-    }
-    auto imageTemplate = ImageId::FromUInt32(imageFlags);
+    auto imageFlags = session.TrackColours[SCHEME_TRACK].WithoutSecondary();
     auto imageIndex = firstCarEntry->base_image_id + direction;
     if (hasSupports)
     {
-        auto foundationImageTemplate = ImageId::FromUInt32(session.TrackColours[SCHEME_3]);
+        auto foundationImageTemplate = session.TrackColours[SCHEME_3];
         auto foundationImageIndex = (direction & 1) ? SPR_FLOOR_PLANKS_90_DEG : SPR_FLOOR_PLANKS;
         auto foundationImageId = foundationImageTemplate.WithIndex(foundationImageIndex);
         PaintAddImageAsParent(session, foundationImageId, offset, bb);
-        PaintAddImageAsChild(session, imageTemplate.WithIndex(imageIndex), offset, bb);
+        PaintAddImageAsChild(session, imageFlags.WithIndex(imageIndex), offset, bb);
     }
     else
     {
-        PaintAddImageAsParent(session, imageTemplate.WithIndex(imageIndex), offset, bb);
+        PaintAddImageAsParent(session, imageFlags.WithIndex(imageIndex), offset, bb);
     }
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);

--- a/src/openrct2/ride/thrill/3dCinema.cpp
+++ b/src/openrct2/ride/thrill/3dCinema.cpp
@@ -32,9 +32,9 @@ static void Paint3dCinemaDome(
 
     auto imageTemplate = ImageId(0, ride.vehicle_colours[0].Body, ride.vehicle_colours[0].Trim);
     auto imageFlags = session.TrackColours[SCHEME_MISC];
-    if (imageFlags != IMAGE_TYPE_REMAP)
+    if (imageFlags.ToUInt32() != IMAGE_TYPE_REMAP)
     {
-        imageTemplate = ImageId::FromUInt32(imageFlags);
+        imageTemplate = imageFlags;
     }
 
     auto imageId = imageTemplate.WithIndex(rideEntry->Cars[0].base_image_id + direction);

--- a/src/openrct2/ride/thrill/Enterprise.cpp
+++ b/src/openrct2/ride/thrill/Enterprise.cpp
@@ -71,9 +71,9 @@ static void PaintEnterpriseStructure(
 
     auto imageTemplate = ImageId(0, ride.vehicle_colours[0].Body, ride.vehicle_colours[0].Trim);
     auto imageFlags = session.TrackColours[SCHEME_MISC];
-    if (imageFlags != IMAGE_TYPE_REMAP)
+    if (imageFlags.ToUInt32() != IMAGE_TYPE_REMAP)
     {
-        imageTemplate = ImageId::FromUInt32(imageFlags);
+        imageTemplate = imageFlags;
     }
     auto imageId = imageTemplate.WithIndex(rideEntry->Cars[0].base_image_id + imageOffset);
     PaintAddImageAsParent(session, imageId, offset, bb);

--- a/src/openrct2/ride/thrill/GoKarts.cpp
+++ b/src/openrct2/ride/thrill/GoKarts.cpp
@@ -129,23 +129,23 @@ static void paint_go_karts_track_flat(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId;
+    ImageId imageId;
     if (direction == 0 || direction == 2)
     {
-        imageId = SPR_GO_KARTS_FLAT_SW_NE | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_GO_KARTS_FLAT_SW_NE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 28, 1 }, { 0, 2, height });
 
-        imageId = SPR_GO_KARTS_FLAT_FRONT_SW_NE | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_GO_KARTS_FLAT_FRONT_SW_NE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 1, 3 }, { 0, 29, height + 2 });
 
         paint_util_push_tunnel_left(session, height, TUNNEL_SQUARE_FLAT);
     }
     else
     {
-        imageId = SPR_GO_KARTS_FLAT_NW_SE | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_GO_KARTS_FLAT_NW_SE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 28, 32, 1 }, { 2, 0, height });
 
-        imageId = SPR_GO_KARTS_FLAT_FRONT_NW_SE | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_GO_KARTS_FLAT_FRONT_NW_SE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 32, 3 }, { 29, 0, height + 2 });
 
         paint_util_push_tunnel_right(session, height, TUNNEL_SQUARE_FLAT);
@@ -162,10 +162,10 @@ static void paint_go_karts_track_25_deg_up(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId;
+    ImageId imageId;
     paint_struct* ps;
 
-    imageId = go_karts_track_pieces_25_deg_up[direction][0] | session.TrackColours[SCHEME_TRACK];
+    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(go_karts_track_pieces_25_deg_up[direction][0]);
     if (direction == 0 || direction == 2)
     {
         ps = PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 28, 1 }, { 0, 2, height });
@@ -175,7 +175,7 @@ static void paint_go_karts_track_25_deg_up(
         ps = PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 28, 32, 1 }, { 2, 0, height });
     }
 
-    imageId = go_karts_track_pieces_25_deg_up[direction][1] | session.TrackColours[SCHEME_TRACK];
+    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(go_karts_track_pieces_25_deg_up[direction][1]);
     if (direction == 0 || direction == 2)
     {
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 1, 11 }, { 0, 29, height + 2 });
@@ -216,10 +216,10 @@ static void paint_go_karts_track_flat_to_25_deg_up(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId;
+    ImageId imageId;
     paint_struct* ps;
 
-    imageId = go_karts_track_pieces_flat_to_25_deg_up[direction][0] | session.TrackColours[SCHEME_TRACK];
+    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(go_karts_track_pieces_flat_to_25_deg_up[direction][0]);
     if (direction == 0 || direction == 2)
     {
         ps = PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 28, 1 }, { 0, 2, height });
@@ -229,7 +229,7 @@ static void paint_go_karts_track_flat_to_25_deg_up(
         ps = PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 28, 32, 1 }, { 2, 0, height });
     }
 
-    imageId = go_karts_track_pieces_flat_to_25_deg_up[direction][1] | session.TrackColours[SCHEME_TRACK];
+    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(go_karts_track_pieces_flat_to_25_deg_up[direction][1]);
     if (direction == 0 || direction == 2)
     {
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 1, 11 }, { 0, 29, height + 2 });
@@ -270,10 +270,10 @@ static void paint_go_karts_track_25_deg_up_to_flat(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId;
+    ImageId imageId;
     paint_struct* ps;
 
-    imageId = go_karts_track_pieces_25_deg_up_to_flat[direction][0] | session.TrackColours[SCHEME_TRACK];
+    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(go_karts_track_pieces_25_deg_up_to_flat[direction][0]);
     if (direction == 0 || direction == 2)
     {
         ps = PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 28, 1 }, { 0, 2, height });
@@ -283,7 +283,7 @@ static void paint_go_karts_track_25_deg_up_to_flat(
         ps = PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 28, 32, 1 }, { 2, 0, height });
     }
 
-    imageId = go_karts_track_pieces_25_deg_up_to_flat[direction][1] | session.TrackColours[SCHEME_TRACK];
+    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(go_karts_track_pieces_25_deg_up_to_flat[direction][1]);
     if (direction == 0 || direction == 2)
     {
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 1, 11 }, { 0, 29, height + 2 });
@@ -351,7 +351,7 @@ static void paint_go_karts_station(
     const auto* stationObj = ride.GetStationObject();
 
     bool hasFence;
-    uint32_t imageId;
+    ImageId imageId;
     const uint32_t(*sprites)[2] = go_karts_track_pieces_starting_grid;
 
     if (trackElement.GetTrackType() == TrackElemType::EndStation)
@@ -359,7 +359,7 @@ static void paint_go_karts_station(
         sprites = go_karts_track_pieces_starting_grid_end;
     }
 
-    imageId = sprites[direction][0] | session.TrackColours[SCHEME_TRACK];
+    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(sprites[direction][0]);
     if (direction == 0 || direction == 2)
     {
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 28, 1 }, { 0, 2, height });
@@ -380,7 +380,7 @@ static void paint_go_karts_station(
         track_paint_util_draw_station_covers(session, EDGE_NE, hasFence, stationObj, height);
     }
 
-    imageId = sprites[direction][1] | session.TrackColours[SCHEME_TRACK];
+    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(sprites[direction][1]);
     if (direction == 0 || direction == 2)
     {
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 1, 3 }, { 0, 29, height + 2 });
@@ -412,35 +412,35 @@ static void paint_go_karts_station(
         switch (direction)
         {
             case 0:
-                imageId = (hasGreenLight ? SPR_GO_KARTS_START_POLE_GREEN_SW_NE : SPR_GO_KARTS_START_POLE_RED_SW_NE)
-                    | session.TrackColours[SCHEME_TRACK];
+                imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+                    (hasGreenLight ? SPR_GO_KARTS_START_POLE_GREEN_SW_NE : SPR_GO_KARTS_START_POLE_RED_SW_NE));
                 PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 3, 3, 13 }, { 1, 1, height + 4 });
 
-                imageId = (hasGreenLight ? SPR_GO_KARTS_START_LIGHTS_GREEN_SW_NE : SPR_GO_KARTS_START_LIGHTS_RED_SW_NE)
-                    | session.TrackColours[SCHEME_TRACK];
+                imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+                    (hasGreenLight ? SPR_GO_KARTS_START_LIGHTS_GREEN_SW_NE : SPR_GO_KARTS_START_LIGHTS_RED_SW_NE));
                 PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 3, 3, 13 }, { 1, 28, height + 4 });
                 break;
             case 1:
-                imageId = SPR_GO_KARTS_START_POLE_NW_SE | session.TrackColours[SCHEME_TRACK];
+                imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_GO_KARTS_START_POLE_NW_SE);
                 PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 3, 3, 13 }, { 1, 28, height + 4 });
 
-                imageId = SPR_GO_KARTS_START_LIGHTS_NW_SE | session.TrackColours[SCHEME_TRACK];
+                imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_GO_KARTS_START_LIGHTS_NW_SE);
                 PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 3, 3, 13 }, { 28, 28, height + 4 });
                 break;
             case 2:
-                imageId = SPR_GO_KARTS_START_POLE_NE_SW | session.TrackColours[SCHEME_TRACK];
+                imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_GO_KARTS_START_POLE_NE_SW);
                 PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 3, 3, 13 }, { 28, 1, height + 4 });
 
-                imageId = SPR_GO_KARTS_START_LIGHTS_NE_SW | session.TrackColours[SCHEME_TRACK];
+                imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_GO_KARTS_START_LIGHTS_NE_SW);
                 PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 3, 3, 13 }, { 28, 28, height + 4 });
                 break;
             case 3:
-                imageId = (hasGreenLight ? SPR_GO_KARTS_START_POLE_GREEN_SE_NW : SPR_GO_KARTS_START_POLE_RED_SE_NW)
-                    | session.TrackColours[SCHEME_TRACK];
+                imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+                    (hasGreenLight ? SPR_GO_KARTS_START_POLE_GREEN_SE_NW : SPR_GO_KARTS_START_POLE_RED_SE_NW));
                 PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 3, 3, 13 }, { 1, 1, height + 4 });
 
-                imageId = (hasGreenLight ? SPR_GO_KARTS_START_LIGHTS_GREEN_SE_NW : SPR_GO_KARTS_START_LIGHTS_RED_SE_NW)
-                    | session.TrackColours[SCHEME_TRACK];
+                imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+                    (hasGreenLight ? SPR_GO_KARTS_START_LIGHTS_GREEN_SE_NW : SPR_GO_KARTS_START_LIGHTS_RED_SE_NW));
                 PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 3, 3, 13 }, { 28, 1, height + 4 });
                 break;
         }
@@ -457,45 +457,45 @@ static void paint_go_karts_track_left_quarter_turn_1_tile(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId;
+    ImageId imageId;
 
     switch (direction)
     {
         case 0:
-            imageId = SPR_GO_KARTS_FLAT_QUARTER_TURN_1_TILE_NW_NE | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_GO_KARTS_FLAT_QUARTER_TURN_1_TILE_NW_NE);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 28, 1 }, { 0, 2, height });
 
-            imageId = SPR_GO_KARTS_FLAT_QUARTER_TURN_1_TILE_EDGE_A_NW_NE | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_GO_KARTS_FLAT_QUARTER_TURN_1_TILE_EDGE_A_NW_NE);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 1, 3 }, { 29, 2, height + 2 });
 
-            imageId = SPR_GO_KARTS_FLAT_QUARTER_TURN_1_TILE_EDGE_B_NW_NE | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_GO_KARTS_FLAT_QUARTER_TURN_1_TILE_EDGE_B_NW_NE);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 16, 1, 3 }, { 14, 29, height + 2 });
             break;
         case 1:
-            imageId = SPR_GO_KARTS_FLAT_QUARTER_TURN_1_TILE_NE_SE | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_GO_KARTS_FLAT_QUARTER_TURN_1_TILE_NE_SE);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 30, 30, 1 }, { 0, 0, height });
 
-            imageId = SPR_GO_KARTS_FLAT_QUARTER_TURN_1_TILE_EDGE_A_NE_SE | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_GO_KARTS_FLAT_QUARTER_TURN_1_TILE_EDGE_A_NE_SE);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 16, 1, 3 }, { 2, 29, height + 2 });
 
-            imageId = SPR_GO_KARTS_FLAT_QUARTER_TURN_1_TILE_EDGE_B_NE_SE | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_GO_KARTS_FLAT_QUARTER_TURN_1_TILE_EDGE_B_NE_SE);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 16, 3 }, { 29, 2, height + 2 });
             break;
         case 2:
-            imageId = SPR_GO_KARTS_FLAT_QUARTER_TURN_1_TILE_SE_SW | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_GO_KARTS_FLAT_QUARTER_TURN_1_TILE_SE_SW);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 28, 32, 1 }, { 2, 0, height });
 
-            imageId = SPR_GO_KARTS_FLAT_QUARTER_TURN_1_TILE_EDGE_A_SE_SW | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_GO_KARTS_FLAT_QUARTER_TURN_1_TILE_EDGE_A_SE_SW);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 1, 3 }, { 2, 2, height + 2 });
 
-            imageId = SPR_GO_KARTS_FLAT_QUARTER_TURN_1_TILE_EDGE_B_SE_SW | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_GO_KARTS_FLAT_QUARTER_TURN_1_TILE_EDGE_B_SE_SW);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 16, 3 }, { 29, 14, height + 2 });
             break;
         case 3:
-            imageId = SPR_GO_KARTS_FLAT_QUARTER_TURN_1_TILE_SW_NW | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_GO_KARTS_FLAT_QUARTER_TURN_1_TILE_SW_NW);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 32, 1 }, { 0, 0, height });
 
-            imageId = SPR_GO_KARTS_FLAT_QUARTER_TURN_1_TILE_EDGE_A_SW_NW | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_GO_KARTS_FLAT_QUARTER_TURN_1_TILE_EDGE_A_SW_NW);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 1, 3 }, { 29, 29, height + 2 });
 
             // The empty sprite isn't drawn

--- a/src/openrct2/ride/thrill/LaunchedFreefall.cpp
+++ b/src/openrct2/ride/thrill/LaunchedFreefall.cpp
@@ -105,15 +105,15 @@ static void paint_launched_freefall_base(
 
     if (trackSequence == 0)
     {
-        uint32_t imageId = SPR_LAUNCHED_FREEFALL_TOWER_BASE | session.TrackColours[SCHEME_TRACK];
+        auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_LAUNCHED_FREEFALL_TOWER_BASE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 2, 2, 27 }, { 8, 8, height + 3 });
 
         height += 32;
-        imageId = SPR_LAUNCHED_FREEFALL_TOWER_SEGMENT | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_LAUNCHED_FREEFALL_TOWER_SEGMENT);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 2, 2, 30 }, { 8, 8, height });
 
         height += 32;
-        imageId = SPR_LAUNCHED_FREEFALL_TOWER_SEGMENT | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_LAUNCHED_FREEFALL_TOWER_SEGMENT);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 2, 2, 30 }, { 8, 8, height });
 
         paint_util_set_vertical_tunnel(session, height + 32);
@@ -167,13 +167,13 @@ static void paint_launched_freefall_tower_section(
         return;
     }
 
-    uint32_t imageId = SPR_LAUNCHED_FREEFALL_TOWER_SEGMENT | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_LAUNCHED_FREEFALL_TOWER_SEGMENT);
     PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 2, 2, 30 }, { 8, 8, height });
 
     const TileElement* nextTileElement = reinterpret_cast<const TileElement*>(&trackElement) + 1;
     if (trackElement.IsLastForTile() || trackElement.GetClearanceZ() != nextTileElement->GetBaseZ())
     {
-        imageId = SPR_LAUNCHED_FREEFALL_TOWER_SEGMENT_TOP | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_LAUNCHED_FREEFALL_TOWER_SEGMENT_TOP);
         PaintAddImageAsChild(session, imageId, { 0, 0, height }, { 2, 2, 30 }, { 8, 8, height });
     }
 

--- a/src/openrct2/ride/thrill/MagicCarpet.cpp
+++ b/src/openrct2/ride/thrill/MagicCarpet.cpp
@@ -117,7 +117,7 @@ static void PaintMagicCarpetFrame(
     paint_session& session, Plane plane, Direction direction, const CoordsXYZ& offset, const BoundBoxXYZ& bb)
 {
     auto imageIndex = GetMagicCarpetFrameImage(plane, direction);
-    auto imageTemplate = ImageId::FromUInt32(session.TrackColours[SCHEME_TRACK]);
+    auto imageTemplate = session.TrackColours[SCHEME_TRACK];
     auto imageId = imageTemplate.WithIndex(imageIndex);
     if (plane == Plane::Back)
     {
@@ -133,7 +133,7 @@ static void PaintMagicCarpetPendulum(
     paint_session& session, Plane plane, int32_t swing, Direction direction, const CoordsXYZ& offset, const BoundBoxXYZ& bb)
 {
     auto imageIndex = GetMagicCarpetPendulumImage(plane, direction, swing);
-    auto imageTemplate = ImageId::FromUInt32(session.TrackColours[SCHEME_TRACK]);
+    auto imageTemplate = session.TrackColours[SCHEME_TRACK];
     auto imageId = imageTemplate.WithIndex(imageIndex);
     PaintAddImageAsChild(session, imageId, offset, bb);
 }
@@ -166,9 +166,9 @@ static void PaintMagicCarpetVehicle(
     // Vehicle
     auto imageTemplate = ImageId(0, ride.vehicle_colours[0].Body, ride.vehicle_colours[0].Trim);
     auto imageFlags = session.TrackColours[SCHEME_MISC];
-    if (imageFlags != IMAGE_TYPE_REMAP)
+    if (imageFlags.ToUInt32() != IMAGE_TYPE_REMAP)
     {
-        imageTemplate = ImageId::FromUInt32(imageFlags);
+        imageTemplate = imageFlags;
     }
     auto vehicleImageIndex = rideEntry->Cars[0].base_image_id + direction;
     PaintAddImageAsChild(session, imageTemplate.WithIndex(vehicleImageIndex), offset, bb);
@@ -238,7 +238,7 @@ static void PaintMagicCarpet(
 
             if (stationObject != nullptr && !(stationObject->Flags & STATION_OBJECT_FLAGS::NO_PLATFORMS))
             {
-                uint32_t imageId = SPR_STATION_BASE_D | session.TrackColours[SCHEME_SUPPORTS];
+                auto imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_BASE_D);
                 PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 32, 1 });
             }
             break;

--- a/src/openrct2/ride/thrill/MotionSimulator.cpp
+++ b/src/openrct2/ride/thrill/MotionSimulator.cpp
@@ -66,9 +66,9 @@ static void PaintMotionSimulatorVehicle(
 
     auto imageTemplate = ImageId(0, ride.vehicle_colours[0].Body, ride.vehicle_colours[0].Trim);
     auto imageFlags = session.TrackColours[SCHEME_MISC];
-    if (imageFlags != IMAGE_TYPE_REMAP)
+    if (imageFlags.ToUInt32() != IMAGE_TYPE_REMAP)
     {
-        imageTemplate = ImageId::FromUInt32(imageFlags);
+        imageTemplate = imageFlags;
     }
     auto simulatorImageId = imageTemplate.WithIndex(imageIndex);
     auto stairsImageId = imageTemplate.WithIndex(SPR_MOTION_SIMULATOR_STAIRS_R0 + direction);

--- a/src/openrct2/ride/thrill/RotoDrop.cpp
+++ b/src/openrct2/ride/thrill/RotoDrop.cpp
@@ -120,16 +120,16 @@ static void paint_roto_drop_base(
 
     if (trackSequence == 0)
     {
-        uint32_t imageId = (direction & 1 ? SPR_ROTO_DROP_TOWER_BASE_90_DEG : SPR_ROTO_DROP_TOWER_BASE)
-            | session.TrackColours[SCHEME_TRACK];
+        auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+            (direction & 1 ? SPR_ROTO_DROP_TOWER_BASE_90_DEG : SPR_ROTO_DROP_TOWER_BASE));
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 2, 2, 27 }, { 8, 8, height + 3 });
 
-        imageId = (direction & 1 ? SPR_ROTO_DROP_TOWER_BASE_SEGMENT_90_DEG : SPR_ROTO_DROP_TOWER_BASE_SEGMENT)
-            | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+            (direction & 1 ? SPR_ROTO_DROP_TOWER_BASE_SEGMENT_90_DEG : SPR_ROTO_DROP_TOWER_BASE_SEGMENT));
         PaintAddImageAsParent(session, imageId, { 0, 0, height + 32 }, { 2, 2, 30 }, { 8, 8, height + 32 });
 
-        imageId = (direction & 1 ? SPR_ROTO_DROP_TOWER_BASE_SEGMENT_90_DEG : SPR_ROTO_DROP_TOWER_BASE_SEGMENT)
-            | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+            (direction & 1 ? SPR_ROTO_DROP_TOWER_BASE_SEGMENT_90_DEG : SPR_ROTO_DROP_TOWER_BASE_SEGMENT));
         PaintAddImageAsParent(session, imageId, { 0, 0, height + 64 }, { 2, 2, 30 }, { 8, 8, height + 64 });
 
         paint_util_set_vertical_tunnel(session, height + 96);
@@ -183,13 +183,13 @@ static void paint_roto_drop_tower_section(
         return;
     }
 
-    uint32_t imageId = SPR_ROTO_DROP_TOWER_SEGMENT | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_ROTO_DROP_TOWER_SEGMENT);
     PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 2, 2, 30 }, { 8, 8, height });
 
     const TileElement* nextTileElement = reinterpret_cast<const TileElement*>(&trackElement) + 1;
     if (trackElement.IsLastForTile() || trackElement.GetClearanceZ() != nextTileElement->GetBaseZ())
     {
-        imageId = SPR_ROTO_DROP_TOWER_SEGMENT_TOP | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_ROTO_DROP_TOWER_SEGMENT_TOP);
         PaintAddImageAsChild(session, imageId, { 0, 0, height }, { 2, 2, 30 }, { 8, 8, height });
     }
 

--- a/src/openrct2/ride/thrill/SwingingInverterShip.cpp
+++ b/src/openrct2/ride/thrill/SwingingInverterShip.cpp
@@ -101,11 +101,11 @@ static void PaintSwingingInverterShipStructure(
 
     auto vehicleImageTemplate = ImageId(0, ride.vehicle_colours[0].Body, ride.vehicle_colours[0].Trim);
     auto imageFlags = session.TrackColours[SCHEME_MISC];
-    if (imageFlags != IMAGE_TYPE_REMAP)
+    if (imageFlags.ToUInt32() != IMAGE_TYPE_REMAP)
     {
-        vehicleImageTemplate = ImageId::FromUInt32(imageFlags);
+        vehicleImageTemplate = imageFlags;
     }
-    auto frameImageTemplate = ImageId::FromUInt32(session.TrackColours[SCHEME_TRACK]);
+    auto frameImageTemplate = session.TrackColours[SCHEME_TRACK];
     auto vehicleImageId = vehicleImageTemplate.WithIndex(vehicleImageIndex);
     auto frameImageId = frameImageTemplate.WithIndex(SwingingInverterShipFrameSprites[direction]);
 
@@ -129,7 +129,7 @@ static void PaintSwingingInverterShip(
     const TrackElement& trackElement)
 {
     uint8_t relativeTrackSequence = track_map_1x4[direction][trackSequence];
-    uint32_t imageId;
+    ImageId imageId;
 
     const StationObject* stationObject = ride.GetStationObject();
 
@@ -148,25 +148,25 @@ static void PaintSwingingInverterShip(
 
         if (stationObject != nullptr && !(stationObject->Flags & STATION_OBJECT_FLAGS::NO_PLATFORMS))
         {
-            imageId = SPR_STATION_BASE_D | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_BASE_D);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 32, 1 });
 
             switch (direction)
             {
                 case 0:
-                    imageId = SPR_STATION_PLATFORM_SW_NE | session.TrackColours[SCHEME_TRACK];
+                    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_STATION_PLATFORM_SW_NE);
                     PaintAddImageAsParent(session, imageId, { 0, 24, height + 9 }, { 32, 8, 1 });
                     break;
                 case 1:
-                    imageId = SPR_STATION_PLATFORM_NW_SE | session.TrackColours[SCHEME_TRACK];
+                    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_STATION_PLATFORM_NW_SE);
                     PaintAddImageAsParent(session, imageId, { 24, 0, height + 9 }, { 8, 32, 1 });
                     break;
                 case 2:
-                    imageId = SPR_STATION_PLATFORM_SW_NE | session.TrackColours[SCHEME_TRACK];
+                    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_STATION_PLATFORM_SW_NE);
                     PaintAddImageAsChild(session, imageId, { 0, 0, height + 9 }, { 32, 8, 1 }, { -2, 0, height });
                     break;
                 case 3:
-                    imageId = SPR_STATION_PLATFORM_NW_SE | session.TrackColours[SCHEME_TRACK];
+                    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_STATION_PLATFORM_NW_SE);
                     PaintAddImageAsChild(session, imageId, { 0, 0, height + 9 }, { 8, 32, 1 }, { 0, -2, height });
                     break;
             }

--- a/src/openrct2/ride/thrill/SwingingShip.cpp
+++ b/src/openrct2/ride/thrill/SwingingShip.cpp
@@ -121,12 +121,12 @@ static void PaintSwingingShipStructure(
         }
     }
 
-    auto supportsImageTemplate = ImageId::FromUInt32(session.TrackColours[SCHEME_TRACK]);
+    auto supportsImageTemplate = session.TrackColours[SCHEME_TRACK];
     auto vehicleImageTemplate = ImageId(0, ride.vehicle_colours[0].Body, ride.vehicle_colours[0].Trim);
     auto imageFlags = session.TrackColours[SCHEME_MISC];
-    if (imageFlags != IMAGE_TYPE_REMAP)
+    if (imageFlags.ToUInt32() != IMAGE_TYPE_REMAP)
     {
-        vehicleImageTemplate = ImageId::FromUInt32(imageFlags);
+        vehicleImageTemplate = imageFlags;
     }
 
     // Supports (back)
@@ -156,7 +156,7 @@ static void PaintSwingingShip(
 {
     uint8_t relativeTrackSequence = track_map_1x5[direction][trackSequence];
 
-    uint32_t imageId;
+    ImageId imageId;
     bool hasFence;
 
     const StationObject* stationObject = ride.GetStationObject();
@@ -172,7 +172,7 @@ static void PaintSwingingShip(
 
         if (stationObject != nullptr && !(stationObject->Flags & STATION_OBJECT_FLAGS::NO_PLATFORMS))
         {
-            imageId = SPR_STATION_BASE_A_NW_SE | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_BASE_A_NW_SE);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 32, 1 });
         }
     }
@@ -183,7 +183,7 @@ static void PaintSwingingShip(
 
         if (stationObject != nullptr && !(stationObject->Flags & STATION_OBJECT_FLAGS::NO_PLATFORMS))
         {
-            imageId = SPR_STATION_BASE_A_SW_NE | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_BASE_A_SW_NE);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 32, 1 });
         }
     }
@@ -200,18 +200,18 @@ static void PaintSwingingShip(
                     EDGE_NE, session.MapPosition, trackElement, ride, session.CurrentRotation);
                 if (relativeTrackSequence == 2)
                 {
-                    imageId = (hasFence ? SPR_STATION_PLATFORM_BEGIN_FENCED_NW_SE : SPR_STATION_PLATFORM_BEGIN_NW_SE)
-                        | session.TrackColours[SCHEME_TRACK];
+                    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+                        (hasFence ? SPR_STATION_PLATFORM_BEGIN_FENCED_NW_SE : SPR_STATION_PLATFORM_BEGIN_NW_SE));
                 }
                 else
                 {
-                    imageId = (hasFence ? SPR_STATION_PLATFORM_FENCED_NW_SE : SPR_STATION_PLATFORM_NW_SE)
-                        | session.TrackColours[SCHEME_TRACK];
+                    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+                        (hasFence ? SPR_STATION_PLATFORM_FENCED_NW_SE : SPR_STATION_PLATFORM_NW_SE));
                 }
                 PaintAddImageAsChild(session, imageId, { 0, 0, height + 9 }, { 8, 32, 1 }, { 0, -2, height + 9 });
 
-                imageId = (relativeTrackSequence == 2 ? SPR_STATION_PLATFORM_BEGIN_NW_SE : SPR_STATION_PLATFORM_NW_SE)
-                    | session.TrackColours[SCHEME_TRACK];
+                imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+                    (relativeTrackSequence == 2 ? SPR_STATION_PLATFORM_BEGIN_NW_SE : SPR_STATION_PLATFORM_NW_SE));
                 PaintAddImageAsParent(session, imageId, { 24, 0, height + 9 }, { 8, 32, 1 });
 
                 hasFence = track_paint_util_has_fence(
@@ -220,21 +220,21 @@ static void PaintSwingingShip(
                 {
                     if (hasFence)
                     {
-                        imageId = SPR_STATION_BEGIN_ANGLE_FENCE_NW_SE | session.TrackColours[SCHEME_TRACK];
+                        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_STATION_BEGIN_ANGLE_FENCE_NW_SE);
                         PaintAddImageAsParent(session, imageId, { 31, 0, height + 11 }, { 1, 32, 7 });
                     }
                     else
                     {
-                        imageId = SPR_STATION_FENCE_SMALL_SW_NE | session.TrackColours[SCHEME_TRACK];
+                        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_STATION_FENCE_SMALL_SW_NE);
                         PaintAddImageAsParent(session, imageId, { 23, 31, height + 11 }, { 8, 1, 7 });
                     }
 
-                    imageId = SPR_STATION_FENCE_SMALL_SW_NE | session.TrackColours[SCHEME_TRACK];
+                    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_STATION_FENCE_SMALL_SW_NE);
                     PaintAddImageAsParent(session, imageId, { 0, 31, height + 11 }, { 8, 1, 7 });
                 }
                 else if (hasFence)
                 {
-                    imageId = SPR_STATION_FENCE_NW_SE | session.TrackColours[SCHEME_TRACK];
+                    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_STATION_FENCE_NW_SE);
                     PaintAddImageAsParent(session, imageId, { 31, 0, height + 11 }, { 1, 32, 7 });
                 }
             }
@@ -247,18 +247,18 @@ static void PaintSwingingShip(
                     EDGE_NW, session.MapPosition, trackElement, ride, session.CurrentRotation);
                 if (relativeTrackSequence == 2)
                 {
-                    imageId = (hasFence ? SPR_STATION_PLATFORM_BEGIN_FENCED_SW_NE : SPR_STATION_PLATFORM_BEGIN_SW_NE)
-                        | session.TrackColours[SCHEME_TRACK];
+                    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+                        (hasFence ? SPR_STATION_PLATFORM_BEGIN_FENCED_SW_NE : SPR_STATION_PLATFORM_BEGIN_SW_NE));
                 }
                 else
                 {
-                    imageId = (hasFence ? SPR_STATION_PLATFORM_FENCED_SW_NE : SPR_STATION_PLATFORM_SW_NE)
-                        | session.TrackColours[SCHEME_TRACK];
+                    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+                        (hasFence ? SPR_STATION_PLATFORM_FENCED_SW_NE : SPR_STATION_PLATFORM_SW_NE));
                 }
                 PaintAddImageAsChild(session, imageId, { 0, 0, height + 9 }, { 32, 8, 1 }, { -2, 0, height + 9 });
 
-                imageId = (relativeTrackSequence == 2 ? SPR_STATION_PLATFORM_BEGIN_SW_NE : SPR_STATION_PLATFORM_SW_NE)
-                    | session.TrackColours[SCHEME_TRACK];
+                imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+                    (relativeTrackSequence == 2 ? SPR_STATION_PLATFORM_BEGIN_SW_NE : SPR_STATION_PLATFORM_SW_NE));
                 PaintAddImageAsParent(session, imageId, { 0, 24, height + 9 }, { 32, 8, 1 });
 
                 hasFence = track_paint_util_has_fence(
@@ -267,21 +267,21 @@ static void PaintSwingingShip(
                 {
                     if (hasFence)
                     {
-                        imageId = SPR_STATION_BEGIN_ANGLE_FENCE_SW_NE | session.TrackColours[SCHEME_TRACK];
+                        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_STATION_BEGIN_ANGLE_FENCE_SW_NE);
                         PaintAddImageAsParent(session, imageId, { 0, 31, height + 11 }, { 32, 1, 7 });
                     }
                     else
                     {
-                        imageId = SPR_STATION_FENCE_SMALL_NW_SE | session.TrackColours[SCHEME_TRACK];
+                        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_STATION_FENCE_SMALL_NW_SE);
                         PaintAddImageAsParent(session, imageId, { 31, 23, height + 11 }, { 1, 8, 7 });
                     }
 
-                    imageId = SPR_STATION_FENCE_SMALL_NW_SE | session.TrackColours[SCHEME_TRACK];
+                    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_STATION_FENCE_SMALL_NW_SE);
                     PaintAddImageAsParent(session, imageId, { 31, 0, height + 11 }, { 1, 8, 7 });
                 }
                 else if (hasFence)
                 {
-                    imageId = SPR_STATION_FENCE_SW_NE | session.TrackColours[SCHEME_TRACK];
+                    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_STATION_FENCE_SW_NE);
                     PaintAddImageAsParent(session, imageId, { 0, 31, height + 11 }, { 32, 1, 7 });
                 }
             }

--- a/src/openrct2/ride/thrill/TopSpin.cpp
+++ b/src/openrct2/ride/thrill/TopSpin.cpp
@@ -103,9 +103,9 @@ static void PaintTopSpinSeat(
 
     auto imageFlags = session.TrackColours[SCHEME_MISC];
     auto imageTemplate = ImageId(0, ride.vehicle_colours[0].Body, ride.vehicle_colours[0].Trim);
-    if (imageFlags != IMAGE_TYPE_REMAP)
+    if (imageFlags.ToUInt32() != IMAGE_TYPE_REMAP)
     {
-        imageTemplate = ImageId::FromUInt32(imageFlags);
+        imageTemplate = imageFlags;
     }
 
     PaintAddImageAsChild(session, imageTemplate.WithIndex(seatImageIndex), seatCoords, bb);
@@ -152,9 +152,9 @@ static void PaintTopSpinVehicle(
     auto imageFlags = session.TrackColours[SCHEME_MISC];
     auto supportImageTemplate = ImageId(0, ride.track_colour[0].main, ride.track_colour[0].supports);
     auto armImageTemplate = ImageId(0, ride.track_colour[0].main, ride.track_colour[0].additional);
-    if (imageFlags != IMAGE_TYPE_REMAP)
+    if (imageFlags.ToUInt32() != IMAGE_TYPE_REMAP)
     {
-        supportImageTemplate = ImageId::FromUInt32(imageFlags);
+        supportImageTemplate = imageFlags;
         armImageTemplate = supportImageTemplate;
     }
 

--- a/src/openrct2/ride/thrill/Twist.cpp
+++ b/src/openrct2/ride/thrill/Twist.cpp
@@ -51,9 +51,9 @@ static void paint_twist_structure(
 
     auto imageFlags = session.TrackColours[SCHEME_MISC];
     auto imageTemplate = ImageId(0, ride.vehicle_colours[0].Body, ride.vehicle_colours[0].Trim);
-    if (imageFlags != IMAGE_TYPE_REMAP)
+    if (imageFlags.ToUInt32() != IMAGE_TYPE_REMAP)
     {
-        imageTemplate = ImageId::FromUInt32(imageFlags);
+        imageTemplate = imageFlags;
     }
 
     auto baseImageId = rideEntry->Cars[0].base_image_id;
@@ -89,7 +89,7 @@ static void paint_twist(
 
     const uint8_t edges = edges_3x3[trackSequence];
 
-    uint32_t imageId;
+    ImageId imageId;
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session.TrackColours[SCHEME_MISC]);
 
@@ -101,12 +101,12 @@ static void paint_twist(
         case 7:
             if (track_paint_util_has_fence(EDGE_SW, session.MapPosition, trackElement, ride, session.CurrentRotation))
             {
-                imageId = SPR_FENCE_ROPE_SW | session.TrackColours[SCHEME_MISC];
+                imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_FENCE_ROPE_SW);
                 PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 28, 7 }, { 29, 0, height + 3 });
             }
             if (track_paint_util_has_fence(EDGE_SE, session.MapPosition, trackElement, ride, session.CurrentRotation))
             {
-                imageId = SPR_FENCE_ROPE_SE | session.TrackColours[SCHEME_MISC];
+                imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_FENCE_ROPE_SE);
                 PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 28, 1, 7 }, { 0, 29, height + 3 });
             }
             break;

--- a/src/openrct2/ride/transport/Chairlift.cpp
+++ b/src/openrct2/ride/transport/Chairlift.cpp
@@ -181,7 +181,7 @@ static void chairlift_paint_station_ne_sw(
 {
     const CoordsXY pos = session.MapPosition;
     auto trackType = trackElement.GetTrackType();
-    uint32_t imageId;
+    ImageId imageId;
 
     bool isStart = chairlift_paint_util_is_first_track(ride, trackElement, pos, trackType);
     bool isEnd = chairlift_paint_util_is_last_track(ride, trackElement, pos, trackType);
@@ -192,31 +192,31 @@ static void chairlift_paint_station_ne_sw(
 
     if (!isStart && !isEnd)
     {
-        imageId = ((direction == 0) ? SPR_20502 : SPR_20504) | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(((direction == 0) ? SPR_20502 : SPR_20504));
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 6, 2 }, { 0, 13, height + 28 });
     }
 
-    imageId = SPR_FLOOR_METAL | session.TrackColours[SCHEME_SUPPORTS];
+    imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_FLOOR_METAL);
     PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 32, 1 }, { 0, 0, height });
 
     bool hasFence = track_paint_util_has_fence(EDGE_NW, pos, trackElement, ride, session.CurrentRotation);
     if (hasFence)
     {
-        imageId = SPR_FENCE_METAL_NW | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_FENCE_METAL_NW);
         PaintAddImageAsChild(session, imageId, { 0, 0, height }, { 32, 1, 7 }, { 0, 2, height + 2 });
     }
     track_paint_util_draw_station_covers(session, EDGE_NW, hasFence, stationObj, height);
 
     if ((direction == 2 && isStart) || (direction == 0 && isEnd))
     {
-        imageId = SPR_FENCE_METAL_NE | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_FENCE_METAL_NE);
         PaintAddImageAsChild(session, imageId, { 0, 0, height }, { 1, 28, 7 }, { 2, 2, height + 4 });
     }
 
     hasFence = track_paint_util_has_fence(EDGE_SE, pos, trackElement, ride, session.CurrentRotation);
     if (hasFence)
     {
-        imageId = SPR_FENCE_METAL_SE | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_FENCE_METAL_SE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 1, 27 }, { 0, 30, height + 2 });
     }
     track_paint_util_draw_station_covers(session, EDGE_SE, hasFence, stationObj, height);
@@ -225,23 +225,25 @@ static void chairlift_paint_station_ne_sw(
     bool drawBackColumn = true;
     if ((direction == 0 && isStart) || (direction == 2 && isEnd))
     {
-        imageId = SPR_FENCE_METAL_SW | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_FENCE_METAL_SW);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 28, 27 }, { 30, 2, height + 4 });
 
-        imageId = chairlift_bullwheel_frames[ride.chairlift_bullwheel_rotation / 16384] | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+            chairlift_bullwheel_frames[ride.chairlift_bullwheel_rotation / 16384]);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 4, 4, 26 }, { 14, 14, height + 4 });
 
-        imageId = SPR_CHAIRLIFT_STATION_END_CAP_NE | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_CHAIRLIFT_STATION_END_CAP_NE);
         PaintAddImageAsChild(session, imageId, { 0, 0, height }, { 4, 4, 26 }, { 14, 14, height + 4 });
 
         drawFrontColumn = false;
     }
     else if ((direction == 2 && isStart) || (direction == 0 && isEnd))
     {
-        imageId = chairlift_bullwheel_frames[ride.chairlift_bullwheel_rotation / 16384] | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+            chairlift_bullwheel_frames[ride.chairlift_bullwheel_rotation / 16384]);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 4, 4, 26 }, { 14, 14, height + 4 });
 
-        imageId = SPR_CHAIRLIFT_STATION_END_CAP_SW | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_CHAIRLIFT_STATION_END_CAP_SW);
         PaintAddImageAsChild(session, imageId, { 0, 0, height }, { 4, 4, 26 }, { 14, 14, height + 4 });
 
         drawBackColumn = false;
@@ -249,13 +251,13 @@ static void chairlift_paint_station_ne_sw(
 
     if (drawBackColumn)
     {
-        imageId = SPR_CHAIRLIFT_STATION_COLUMN_NE_SW | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_CHAIRLIFT_STATION_COLUMN_NE_SW);
         PaintAddImageAsParent(session, imageId, { 0, 16, height + 2 }, { 1, 1, 7 }, { 1, 16, height + 2 });
     }
 
     if (drawFrontColumn)
     {
-        imageId = SPR_CHAIRLIFT_STATION_COLUMN_NE_SW | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_CHAIRLIFT_STATION_COLUMN_NE_SW);
         PaintAddImageAsParent(
             session, imageId, { 30, 16, height + 2 }, { 1, 1, 7 }, { 1, 16, height + 2 }); // bound offset x is wrong?
     }
@@ -271,7 +273,7 @@ static void chairlift_paint_station_se_nw(
 {
     const CoordsXY pos = session.MapPosition;
     auto trackType = trackElement.GetTrackType();
-    uint32_t imageId;
+    ImageId imageId;
 
     bool isStart = chairlift_paint_util_is_first_track(ride, trackElement, pos, trackType);
     bool isEnd = chairlift_paint_util_is_last_track(ride, trackElement, pos, trackType);
@@ -282,31 +284,31 @@ static void chairlift_paint_station_se_nw(
 
     if (!isStart && !isEnd)
     {
-        imageId = ((direction == 1) ? SPR_20503 : SPR_20505) | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(((direction == 1) ? SPR_20503 : SPR_20505));
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 6, 32, 2 }, { 13, 0, height + 28 });
     }
 
-    imageId = SPR_FLOOR_METAL | session.TrackColours[SCHEME_SUPPORTS];
+    imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_FLOOR_METAL);
     PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 32, 1 }, { 0, 0, height });
 
     bool hasFence = track_paint_util_has_fence(EDGE_NE, pos, trackElement, ride, session.CurrentRotation);
     if (hasFence)
     {
-        imageId = SPR_FENCE_METAL_NE | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_FENCE_METAL_NE);
         PaintAddImageAsChild(session, imageId, { 0, 0, height }, { 1, 32, 7 }, { 2, 0, height + 2 });
     }
     track_paint_util_draw_station_covers(session, EDGE_NE, hasFence, stationObj, height);
 
     if ((direction == 1 && isStart) || (direction == 3 && isEnd))
     {
-        imageId = SPR_FENCE_METAL_NW | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_FENCE_METAL_NW);
         PaintAddImageAsChild(session, imageId, { 0, 0, height }, { 28, 1, 7 }, { 2, 2, height + 4 });
     }
 
     hasFence = track_paint_util_has_fence(EDGE_SW, pos, trackElement, ride, session.CurrentRotation);
     if (hasFence)
     {
-        imageId = SPR_FENCE_METAL_SW | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_FENCE_METAL_SW);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 32, 27 }, { 30, 0, height + 2 });
     }
     track_paint_util_draw_station_covers(session, EDGE_SW, hasFence, stationObj, height);
@@ -315,23 +317,25 @@ static void chairlift_paint_station_se_nw(
     bool drawLeftColumn = true;
     if ((direction == 1 && isStart) || (direction == 3 && isEnd))
     {
-        imageId = chairlift_bullwheel_frames[ride.chairlift_bullwheel_rotation / 16384] | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+            chairlift_bullwheel_frames[ride.chairlift_bullwheel_rotation / 16384]);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 4, 4, 26 }, { 14, 14, height + 4 });
 
-        imageId = SPR_CHAIRLIFT_STATION_END_CAP_SE | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_CHAIRLIFT_STATION_END_CAP_SE);
         PaintAddImageAsChild(session, imageId, { 0, 0, height }, { 4, 4, 26 }, { 14, 14, height + 4 });
 
         drawLeftColumn = false;
     }
     else if ((direction == 3 && isStart) || (direction == 1 && isEnd))
     {
-        imageId = SPR_FENCE_METAL_SE | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_FENCE_METAL_SE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 28, 1, 27 }, { 2, 30, height + 4 });
 
-        imageId = chairlift_bullwheel_frames[ride.chairlift_bullwheel_rotation / 16384] | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+            chairlift_bullwheel_frames[ride.chairlift_bullwheel_rotation / 16384]);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 4, 4, 26 }, { 14, 14, height + 4 });
 
-        imageId = SPR_CHAIRLIFT_STATION_END_CAP_NW | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_CHAIRLIFT_STATION_END_CAP_NW);
         PaintAddImageAsChild(session, imageId, { 0, 0, height }, { 4, 4, 26 }, { 14, 14, height + 4 });
 
         drawRightColumn = false;
@@ -339,13 +343,13 @@ static void chairlift_paint_station_se_nw(
 
     if (drawLeftColumn)
     {
-        imageId = SPR_CHAIRLIFT_STATION_COLUMN_SE_NW | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_CHAIRLIFT_STATION_COLUMN_SE_NW);
         PaintAddImageAsParent(session, imageId, { 16, 0, height + 2 }, { 1, 1, 7 }, { 16, 1, height + 2 });
     }
 
     if (drawRightColumn)
     {
-        imageId = SPR_CHAIRLIFT_STATION_COLUMN_SE_NW | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_CHAIRLIFT_STATION_COLUMN_SE_NW);
         PaintAddImageAsParent(
             session, imageId, { 16, 30, height + 2 }, { 1, 1, 7 }, { 16, 1, height + 2 }); // bound offset x is wrong?
 
@@ -375,16 +379,16 @@ static void chairlift_paint_flat(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId;
+    ImageId imageId;
     if (direction & 1)
     {
-        imageId = SPR_CHAIRLIFT_CABLE_FLAT_SE_NW | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_CHAIRLIFT_CABLE_FLAT_SE_NW);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 6, 32, 2 }, { 13, 0, height + 28 });
         paint_util_push_tunnel_right(session, height, TUNNEL_SQUARE_FLAT);
     }
     else
     {
-        imageId = SPR_CHAIRLIFT_CABLE_FLAT_SW_NE | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_CHAIRLIFT_CABLE_FLAT_SW_NE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 6, 2 }, { 0, 13, height + 28 });
         paint_util_push_tunnel_left(session, height, TUNNEL_SQUARE_FLAT);
     }
@@ -398,30 +402,30 @@ static void chairlift_paint_25_deg_up(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId;
+    ImageId imageId;
 
     switch (direction)
     {
         case 0:
-            imageId = SPR_CHAIRLIFT_CABLE_UP_SW_NE | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_CHAIRLIFT_CABLE_UP_SW_NE);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 6, 2 }, { 0, 13, height + 28 });
             paint_util_push_tunnel_left(session, height - 8, TUNNEL_SQUARE_7);
             break;
 
         case 1:
-            imageId = SPR_CHAIRLIFT_CABLE_UP_NW_SE | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_CHAIRLIFT_CABLE_UP_NW_SE);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 6, 32, 2 }, { 13, 0, height + 28 });
             paint_util_push_tunnel_right(session, height + 8, TUNNEL_SQUARE_8);
             break;
 
         case 2:
-            imageId = SPR_CHAIRLIFT_CABLE_UP_NE_SW | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_CHAIRLIFT_CABLE_UP_NE_SW);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 6, 2 }, { 0, 13, height + 28 });
             paint_util_push_tunnel_left(session, height + 8, TUNNEL_SQUARE_8);
             break;
 
         case 3:
-            imageId = SPR_CHAIRLIFT_CABLE_UP_SE_NW | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_CHAIRLIFT_CABLE_UP_SE_NW);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 6, 32, 2 }, { 13, 0, height + 28 });
             paint_util_push_tunnel_right(session, height - 8, TUNNEL_SQUARE_7);
             break;
@@ -436,45 +440,45 @@ static void chairlift_paint_flat_to_25_deg_up(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId;
+    ImageId imageId;
 
     switch (direction)
     {
         case 0:
-            imageId = SPR_20508 | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_20508);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 6, 2 }, { 0, 13, height + 28 });
 
-            imageId = SPR_20520 | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_20520);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 4, 4, 25 }, { 14, 14, height + 1 });
 
             paint_util_push_tunnel_left(session, height, TUNNEL_SQUARE_FLAT);
             break;
 
         case 1:
-            imageId = SPR_20509 | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_20509);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 6, 32, 2 }, { 13, 0, height + 28 });
 
-            imageId = SPR_20521 | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_20521);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 4, 4, 25 }, { 14, 14, height + 1 });
 
             paint_util_push_tunnel_right(session, height, TUNNEL_SQUARE_8);
             break;
 
         case 2:
-            imageId = SPR_20510 | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_20510);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 6, 2 }, { 0, 13, height + 28 });
 
-            imageId = SPR_20522 | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_20522);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 4, 4, 25 }, { 14, 14, height + 1 });
 
             paint_util_push_tunnel_left(session, height, TUNNEL_SQUARE_8);
             break;
 
         case 3:
-            imageId = SPR_20511 | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_20511);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 6, 32, 2 }, { 13, 0, height + 28 });
 
-            imageId = SPR_20523 | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_20523);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 4, 4, 25 }, { 14, 14, height + 1 });
 
             paint_util_push_tunnel_right(session, height, TUNNEL_SQUARE_FLAT);
@@ -491,45 +495,45 @@ static void chairlift_paint_25_deg_up_to_flat(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId;
+    ImageId imageId;
 
     switch (direction)
     {
         case 0:
-            imageId = SPR_20512 | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_20512);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 6, 2 }, { 0, 13, height + 28 });
 
-            imageId = SPR_20524 | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_20524);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 4, 4, 25 }, { 14, 14, height + 1 });
 
             paint_util_push_tunnel_left(session, height - 8, TUNNEL_SQUARE_FLAT);
             break;
 
         case 1:
-            imageId = SPR_20513 | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_20513);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 6, 32, 2 }, { 13, 0, height + 28 });
 
-            imageId = SPR_20525 | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_20525);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 4, 4, 25 }, { 14, 14, height + 1 });
 
             paint_util_push_tunnel_right(session, height + 8, TUNNEL_14);
             break;
 
         case 2:
-            imageId = SPR_20514 | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_20514);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 6, 2 }, { 0, 13, height + 28 });
 
-            imageId = SPR_20526 | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_20526);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 4, 4, 25 }, { 14, 14, height + 1 });
 
             paint_util_push_tunnel_left(session, height + 8, TUNNEL_14);
             break;
 
         case 3:
-            imageId = SPR_20515 | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_20515);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 6, 32, 2 }, { 13, 0, height + 28 });
 
-            imageId = SPR_20527 | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_20527);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 4, 4, 25 }, { 14, 14, height + 1 });
 
             paint_util_push_tunnel_right(session, height - 8, TUNNEL_SQUARE_FLAT);
@@ -570,55 +574,55 @@ static void chairlift_paint_left_quarter_turn_1_tile(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId;
+    ImageId imageId;
 
     switch (direction)
     {
         case 0:
-            imageId = SPR_CHAIRLIFT_CORNER_NW_SW | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_CHAIRLIFT_CORNER_NW_SW);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 16, 16, 2 }, { 16, 0, height + 28 });
 
-            imageId = SPR_20532 | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_20532);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 2, 2, 27 }, { 16, 4, height });
 
-            imageId = SPR_20536 | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_20536);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 2, 2, 27 }, { 28, 4, height });
 
             paint_util_push_tunnel_left(session, height, TUNNEL_SQUARE_FLAT);
             break;
 
         case 1:
-            imageId = SPR_CHAIRLIFT_CORNER_NW_NE | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_CHAIRLIFT_CORNER_NW_NE);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 16, 16, 2 }, { 0, 0, height + 28 });
 
-            imageId = SPR_20533 | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_20533);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 2, 2, 27 }, { 16, 4, height });
 
-            imageId = SPR_20537 | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_20537);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 2, 2, 27 }, { 4, 16, height });
             break;
 
         case 2:
-            imageId = SPR_CHAIRLIFT_CORNER_SE_NE | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_CHAIRLIFT_CORNER_SE_NE);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 16, 16, 2 }, { 0, 16, height + 28 });
 
-            imageId = SPR_20534 | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_20534);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 2, 2, 27 }, { 4, 16, height });
 
-            imageId = SPR_20538 | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_20538);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 2, 2, 27 }, { 16, 28, height });
 
             paint_util_push_tunnel_right(session, height, TUNNEL_SQUARE_FLAT);
             break;
 
         case 3:
-            imageId = SPR_CHAIRLIFT_CORNER_SW_SE | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_CHAIRLIFT_CORNER_SW_SE);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 16, 16, 2 }, { 16, 16, height + 28 });
 
-            imageId = SPR_20535 | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_20535);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 2, 2, 27 }, { 28, 16, height });
 
-            imageId = SPR_20539 | session.TrackColours[SCHEME_SUPPORTS];
+            imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_20539);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 2, 2, 27 }, { 16, 28, height });
 
             paint_util_push_tunnel_left(session, height, TUNNEL_SQUARE_FLAT);

--- a/src/openrct2/ride/transport/Lift.cpp
+++ b/src/openrct2/ride/transport/Lift.cpp
@@ -34,14 +34,14 @@ static constexpr const uint32_t lift_cage_sprites[][2] = {
     { SPR_LIFT_CAGE_NW_BACK, SPR_LIFT_CAGE_NW_FRONT },
 };
 
-static void paint_lift_cage(paint_session& session, int8_t index, uint32_t colourFlags, int32_t height, uint8_t rotation)
+static void paint_lift_cage(paint_session& session, int8_t index, ImageId colourFlags, int32_t height, uint8_t rotation)
 {
-    uint32_t imageId;
+    ImageId imageId;
 
-    imageId = lift_cage_sprites[1 + index][0] | colourFlags;
+    imageId = colourFlags.WithIndex(lift_cage_sprites[1 + index][0]);
     PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 2, 2, 30 }, { 2, 2, height });
 
-    imageId = lift_cage_sprites[1 + index][1] | colourFlags;
+    imageId = colourFlags.WithIndex(lift_cage_sprites[1 + index][1]);
     PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 2, 2, 30 }, { 28, 28, height });
 }
 
@@ -70,7 +70,7 @@ static void paint_lift_base(
 
     int32_t edges = edges_3x3[trackSequence];
 
-    uint32_t imageId = SPR_FLOOR_METAL_B | session.TrackColours[SCHEME_SUPPORTS];
+    auto imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_FLOOR_METAL_B);
     PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 32, 1 }, { 0, 0, height });
 
     track_paint_util_paint_fences(

--- a/src/openrct2/ride/transport/MiniatureRailway.cpp
+++ b/src/openrct2/ride/transport/MiniatureRailway.cpp
@@ -565,22 +565,21 @@ static constexpr const uint32_t miniature_railway_track_pieces_diag_25_deg_up[4]
     SPR_MINIATURE_RAILWAY_DIAG_25_DEG_UP_S_N,
 };
 
-static uint32_t miniature_railway_track_to_gravel(uint32_t imageId)
+static ImageId miniature_railway_track_to_gravel(ImageId imageId)
 {
-    return imageId - SPR_MINIATURE_RAILWAY_FLAT_SW_NE + SPR_G2_MINIATURE_RAILWAY_GRAVEL_SW_NE;
+    return ImageId(imageId.GetIndex() - SPR_MINIATURE_RAILWAY_FLAT_SW_NE + SPR_G2_MINIATURE_RAILWAY_GRAVEL_SW_NE);
 }
 
-static uint32_t miniature_railway_track_to_grooved(uint32_t imageId)
+static ImageId miniature_railway_track_to_grooved(ImageId imageId)
 {
-    return imageId - SPR_MINIATURE_RAILWAY_FLAT_SW_NE + SPR_G2_MINIATURE_RAILWAY_GROOVED_SW_NE;
+    return ImageId(imageId.GetIndex() - SPR_MINIATURE_RAILWAY_FLAT_SW_NE + SPR_G2_MINIATURE_RAILWAY_GROOVED_SW_NE);
 }
 
-static uint32_t miniature_railway_track_to_grooved_indent(
-    uint32_t imageId, const TileElement* path, uint8_t direction, uint8_t rotation)
+static ImageId miniature_railway_track_to_grooved_indent(const TileElement* path, uint8_t direction, uint8_t rotation)
 {
     if (path == nullptr)
     {
-        return 0;
+        return ImageId(0);
     }
 
     uint32_t imageIdAlt = SPR_G2_MINIATURE_RAILWAY_GROOVED_SW_NE;
@@ -619,7 +618,7 @@ static uint32_t miniature_railway_track_to_grooved_indent(
         imageIdAlt = imageIds[(correctedEdges & 0x1) ? 0 : 1][(correctedEdges & 0x4) ? 0 : 1];
     }
 
-    return imageIdAlt;
+    return ImageId(imageIdAlt);
 }
 
 /** rct2: 0x008AD0C0 */
@@ -637,16 +636,16 @@ static void paint_miniature_railway_track_flat(
     }
 
     bool isSupported = wooden_a_supports_paint_setup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-    uint32_t imageId, imageIdAlt;
+    ImageId imageId, imageIdAlt;
 
     // In the following 3 calls to PaintAddImageAsParentRotated/PaintAddImageAsChildRotated, we add 1 to the
     //  bound_box_offset_z argument to make straight tracks draw above footpaths
     if (isSupported)
     {
-        imageId = miniature_railway_track_floor[direction] | session.TrackColours[SCHEME_SUPPORTS];
+        imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(miniature_railway_track_floor[direction]);
         PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
 
-        imageId = miniature_railway_track_pieces_flat[direction] | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(miniature_railway_track_pieces_flat[direction]);
         if (!paintAsGravel)
         {
             PaintAddImageAsChildRotated(session, direction, imageId, { 0, 6, height }, { 32, 20, 2 }, { 0, 6, height });
@@ -661,17 +660,15 @@ static void paint_miniature_railway_track_flat(
             imageIdAlt = miniature_railway_track_to_grooved(imageId);
             PaintAddImageAsChildRotated(session, direction, imageIdAlt, { 0, 6, height }, { 32, 20, 2 }, { 0, 6, height + 2 });
             imageIdAlt = miniature_railway_track_to_grooved_indent(
-                imageId, session.PathElementOnSameHeight, direction, session.CurrentRotation);
+                session.PathElementOnSameHeight, direction, session.CurrentRotation);
             PaintAddImageAsChildRotated(
-                session, direction,
-                (imageIdAlt & 0x7FFFF) | IMAGE_TYPE_REMAP | IMAGE_TYPE_TRANSPARENT
-                    | (EnumValue(FilterPaletteID::PaletteDarken2) << 19),
-                { 0, 6, height }, { 32, 20, 2 }, { 0, 6, height + 2 });
+                session, direction, imageIdAlt.WithTransparancy(FilterPaletteID::PaletteDarken2), { 0, 6, height },
+                { 32, 20, 2 }, { 0, 6, height + 2 });
         }
     }
     else
     {
-        imageId = miniature_railway_track_pieces_flat[direction] | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(miniature_railway_track_pieces_flat[direction]);
         if (!paintAsGravel)
         {
             PaintAddImageAsParentRotated(session, direction, imageId, { 0, 6, height }, { 32, 20, 2 }, { 0, 6, height });
@@ -686,12 +683,10 @@ static void paint_miniature_railway_track_flat(
             imageIdAlt = miniature_railway_track_to_grooved(imageId);
             PaintAddImageAsParentRotated(session, direction, imageIdAlt, { 0, 6, height }, { 32, 20, 2 }, { 0, 6, height + 2 });
             imageIdAlt = miniature_railway_track_to_grooved_indent(
-                imageId, session.PathElementOnSameHeight, direction, session.CurrentRotation);
+                session.PathElementOnSameHeight, direction, session.CurrentRotation);
             PaintAddImageAsParentRotated(
-                session, direction,
-                (imageIdAlt & 0x7FFFF) | IMAGE_TYPE_REMAP | IMAGE_TYPE_TRANSPARENT
-                    | (EnumValue(FilterPaletteID::PaletteDarken2) << 19),
-                { 0, 6, height }, { 32, 20, 2 }, { 0, 6, height + 2 });
+                session, direction, imageIdAlt.WithTransparancy(FilterPaletteID::PaletteDarken2), { 0, 6, height },
+                { 32, 20, 2 }, { 0, 6, height + 2 });
         }
     }
 
@@ -706,14 +701,14 @@ static void paint_miniature_railway_station(
     paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId;
+    ImageId imageId;
 
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
 
-    imageId = miniature_railway_station_floor[direction] | session.TrackColours[SCHEME_MISC];
+    imageId = session.TrackColours[SCHEME_MISC].WithIndex(miniature_railway_station_floor[direction]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height - 2 }, { 32, 28, 2 }, { 0, 2, height });
 
-    imageId = miniature_railway_track_pieces_flat_station[direction] | session.TrackColours[SCHEME_TRACK];
+    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(miniature_railway_track_pieces_flat_station[direction]);
     PaintAddImageAsChildRotated(session, direction, imageId, { 0, 6, height }, { 32, 20, 2 }, { 0, 0, height });
 
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -730,7 +725,7 @@ static void paint_miniature_railway_track_25_deg_up(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId = miniature_railway_track_pieces_25_deg_up[direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(miniature_railway_track_pieces_25_deg_up[direction]);
 
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 2, height }, { 32, 25, 2 }, { 0, 3, height });
 
@@ -761,7 +756,7 @@ static void paint_miniature_railway_track_flat_to_25_deg_up(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId = miniature_railway_track_pieces_flat_to_25_deg_up[direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(miniature_railway_track_pieces_flat_to_25_deg_up[direction]);
 
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 2, height }, { 32, 25, 2 }, { 0, 3, height });
 
@@ -792,7 +787,7 @@ static void paint_miniature_railway_track_25_deg_up_to_flat(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId = miniature_railway_track_pieces_25_deg_up_to_flat[direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(miniature_railway_track_pieces_25_deg_up_to_flat[direction]);
 
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 2, height }, { 32, 25, 2 }, { 0, 3, height });
 
@@ -1004,8 +999,8 @@ static void paint_miniature_railway_track_right_quarter_turn_5_tiles(
                 miniature_railway_right_quarter_turn_5_tiles_bound_offsets);
 
             int32_t index = miniature_railway_right_quarter_turn_5_tiles_sprite_map[trackSequence];
-            uint32_t imageId = miniature_railway_track_pieces_flat_quarter_turn_5_tiles[direction][index]
-                | session.TrackColours[SCHEME_TRACK];
+            auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+                miniature_railway_track_pieces_flat_quarter_turn_5_tiles[direction][index]);
             CoordsXY offset = miniature_railway_right_quarter_turn_5_tiles_offsets[direction][index];
             CoordsXY boundsLength = miniature_railway_right_quarter_turn_5_tiles_bound_lengths[direction][index];
             CoordsXYZ boundsOffset = CoordsXYZ(offset, 0);
@@ -1125,8 +1120,8 @@ static void paint_miniature_railway_track_s_bend_left(
         { 32, 27 },
     };
 
-    uint32_t imageId = miniature_railway_track_pieces_s_bend_left[direction & 1][trackSequence]
-        | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+        miniature_railway_track_pieces_s_bend_left[direction & 1][trackSequence]);
     CoordsXY offset = offsetList[trackSequence];
     CoordsXY bounds = boundsList[trackSequence];
 
@@ -1138,12 +1133,13 @@ static void paint_miniature_railway_track_s_bend_left(
     }
     else
     {
-        imageId = miniature_railway_s_bend_left_tiles_track_floor[direction & 1][trackSequence]
-            | session.TrackColours[SCHEME_SUPPORTS];
+        imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(
+            miniature_railway_s_bend_left_tiles_track_floor[direction & 1][trackSequence]);
         PaintAddImageAsParentRotated(
             session, direction, imageId, { 0, 0, height }, { bounds.x, bounds.y, 2 }, { offset.x, offset.y, height });
 
-        imageId = miniature_railway_track_pieces_s_bend_left[direction & 1][trackSequence] | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+            miniature_railway_track_pieces_s_bend_left[direction & 1][trackSequence]);
         PaintAddImageAsChildRotated(
             session, direction, imageId, { offset.x, offset.y, height }, { bounds.x, bounds.y, 2 },
             { offset.x, offset.y, height });
@@ -1233,8 +1229,8 @@ static void paint_miniature_railway_track_s_bend_right(
         { 32, 27 },
     };
 
-    uint32_t imageId = miniature_railway_track_pieces_s_bend_right[direction & 1][trackSequence]
-        | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+        miniature_railway_track_pieces_s_bend_right[direction & 1][trackSequence]);
     CoordsXY offset = offsetList[trackSequence];
     CoordsXY bounds = boundsList[trackSequence];
     if (!isSupported)
@@ -1245,13 +1241,13 @@ static void paint_miniature_railway_track_s_bend_right(
     }
     else
     {
-        imageId = miniature_railway_s_bend_right_tiles_track_floor[direction & 1][trackSequence]
-            | session.TrackColours[SCHEME_SUPPORTS];
+        imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(
+            miniature_railway_s_bend_right_tiles_track_floor[direction & 1][trackSequence]);
         PaintAddImageAsParentRotated(
             session, direction, imageId, { 0, 0, height }, { bounds.x, bounds.y, 2 }, { offset.x, offset.y, height });
 
-        imageId = miniature_railway_track_pieces_s_bend_right[direction & 1][trackSequence]
-            | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+            miniature_railway_track_pieces_s_bend_right[direction & 1][trackSequence]);
         PaintAddImageAsChildRotated(
             session, direction, imageId, { offset.x, offset.y, height }, { bounds.x, bounds.y, 2 },
             { offset.x, offset.y, height });
@@ -1361,7 +1357,8 @@ static void paint_miniature_railway_track_right_quarter_turn_3_tiles(
         // The following piece was missing in vanilla RCT2
         if (trackSequence == 1 && direction == 0)
         {
-            uint32_t imageId = SPR_G2_MINIATURE_RAILWAY_QUARTER_TURN_3_TILES_SW_SE_PART_3 | session.TrackColours[SCHEME_TRACK];
+            auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+                SPR_G2_MINIATURE_RAILWAY_QUARTER_TURN_3_TILES_SW_SE_PART_3);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 8, 8, 2 }, { 0, 0, height });
         }
     }
@@ -1376,8 +1373,8 @@ static void paint_miniature_railway_track_right_quarter_turn_3_tiles(
 
         int32_t index = _right_quarter_turn_3_tiles_sprite_map[trackSequence];
 
-        uint32_t imageId = miniature_railway_track_pieces_flat_quarter_turn_3_tiles[direction][index]
-            | session.TrackColours[SCHEME_TRACK];
+        auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+            miniature_railway_track_pieces_flat_quarter_turn_3_tiles[direction][index]);
         CoordsXY offset = defaultRightQuarterTurn3TilesOffsets[direction][index];
         CoordsXY boundsLength = defaultRightQuarterTurn3TilesBoundLengths[direction][index];
         CoordsXYZ boundsOffset(offset, 0);
@@ -1533,13 +1530,14 @@ static void paint_miniature_railway_track_left_eighth_to_diag(
         isSupported = wooden_a_supports_paint_setup(
             session, supportType[direction][trackSequence], 0, height, session.TrackColours[SCHEME_SUPPORTS]);
     }
-    uint32_t imageId;
+    ImageId imageId;
     if (!isSupported)
     {
         int8_t index = paint_miniature_railway_eighth_to_diag_index[trackSequence];
         if (index >= 0)
         {
-            imageId = miniature_railway_track_pieces_left_eight_to_diag[direction][index] | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+                miniature_railway_track_pieces_left_eight_to_diag[direction][index]);
             CoordsXY offset = miniature_railway_track_pieces_left_eight_to_diag_offset[direction][index];
             CoordsXYZ bounds = miniature_railway_track_pieces_left_eight_to_diag_bounds[direction][index];
             if (isRightEighthToOrthog)
@@ -1552,8 +1550,8 @@ static void paint_miniature_railway_track_left_eighth_to_diag(
     }
     else
     {
-        imageId = miniature_railway_floor_track_pieces_left_eight_to_diag[direction][trackSequence]
-            | session.TrackColours[SCHEME_SUPPORTS];
+        imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(
+            miniature_railway_floor_track_pieces_left_eight_to_diag[direction][trackSequence]);
         CoordsXY offset = miniature_railway_track_floor_pieces_left_eight_to_diag_offset[direction][trackSequence];
         CoordsXYZ bounds = miniature_railway_track_floor_pieces_left_eight_to_diag_bounds[direction][trackSequence];
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, bounds, { offset, height });
@@ -1561,7 +1559,8 @@ static void paint_miniature_railway_track_left_eighth_to_diag(
         int8_t index = paint_miniature_railway_eighth_to_diag_index[trackSequence];
         if (index >= 0)
         {
-            imageId = miniature_railway_track_pieces_left_eight_to_diag[direction][index] | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+                miniature_railway_track_pieces_left_eight_to_diag[direction][index]);
             offset = miniature_railway_track_pieces_left_eight_to_diag_offset[direction][index];
             bounds = miniature_railway_track_pieces_left_eight_to_diag_bounds[direction][index];
             PaintAddImageAsChild(session, imageId, { 0, 0, height }, bounds, { offset, height });
@@ -1696,13 +1695,14 @@ static void paint_miniature_railway_track_right_eighth_to_diag(
             session, supportType[direction][trackSequence], 0, height, session.TrackColours[SCHEME_SUPPORTS]);
     }
 
-    uint32_t imageId;
+    ImageId imageId;
     if (!isSupported)
     {
         int8_t index = paint_miniature_railway_eighth_to_diag_index[trackSequence];
         if (index >= 0)
         {
-            imageId = miniature_railway_track_pieces_right_eight_to_diag[direction][index] | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+                miniature_railway_track_pieces_right_eight_to_diag[direction][index]);
             CoordsXY offset = miniature_railway_track_pieces_right_eight_to_diag_offset[direction][index];
             CoordsXYZ bounds = miniature_railway_track_pieces_right_eight_to_diag_bounds[direction][index];
             if (isLeftEighthToOrthog)
@@ -1715,8 +1715,8 @@ static void paint_miniature_railway_track_right_eighth_to_diag(
     }
     else
     {
-        imageId = miniature_railway_floor_track_pieces_right_eight_to_diag[direction][trackSequence]
-            | session.TrackColours[SCHEME_SUPPORTS];
+        imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(
+            miniature_railway_floor_track_pieces_right_eight_to_diag[direction][trackSequence]);
         CoordsXY offset = miniature_railway_track_floor_pieces_right_eight_to_diag_offset[direction][trackSequence];
         CoordsXYZ bounds = miniature_railway_track_floor_pieces_right_eight_to_diag_bounds[direction][trackSequence];
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, bounds, { offset, height });
@@ -1724,7 +1724,8 @@ static void paint_miniature_railway_track_right_eighth_to_diag(
         int8_t index = paint_miniature_railway_eighth_to_diag_index[trackSequence];
         if (index >= 0)
         {
-            imageId = miniature_railway_track_pieces_right_eight_to_diag[direction][index] | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+                miniature_railway_track_pieces_right_eight_to_diag[direction][index]);
             offset = miniature_railway_track_pieces_right_eight_to_diag_offset[direction][index];
             bounds = miniature_railway_track_pieces_right_eight_to_diag_bounds[direction][index];
             PaintAddImageAsChild(session, imageId, { 0, 0, height }, bounds, { offset, height });
@@ -1833,19 +1834,20 @@ static void miniature_railway_track_diag_flat(
     if (isSupported)
     {
         PaintAddImageAsParent(
-            session, floorImage | session.TrackColours[SCHEME_SUPPORTS], { 0, 0, height },
+            session, session.TrackColours[SCHEME_SUPPORTS].WithIndex(floorImage), { 0, 0, height },
             { floorBoundSize, (drawRail ? 2 : 0) }, { floorBoundOffset, height });
         if (drawRail)
         {
             PaintAddImageAsChild(
-                session, imageId | session.TrackColours[SCHEME_TRACK], { -16, -16, height }, { 32, 32, 2 },
+                session, session.TrackColours[SCHEME_TRACK].WithIndex(imageId), { -16, -16, height }, { 32, 32, 2 },
                 { -16, -16, height });
         }
     }
     else if (drawRail)
     {
         PaintAddImageAsParent(
-            session, imageId | session.TrackColours[SCHEME_TRACK], { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+            session, session.TrackColours[SCHEME_TRACK].WithIndex(imageId), { -16, -16, height }, { 32, 32, 2 },
+            { -16, -16, height });
     }
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -1859,7 +1861,7 @@ enum
 };
 
 static bool wooden_supports_paint_setup(
-    paint_session& session, int32_t woodType, int32_t supportType, int32_t special, int32_t height, uint32_t imageColourFlags)
+    paint_session& session, int32_t woodType, int32_t supportType, int32_t special, int32_t height, ImageId imageColourFlags)
 {
     switch (woodType)
     {
@@ -1932,20 +1934,20 @@ static void miniature_railway_track_diag_25_deg_up(
     if (hasSupports)
     {
         PaintAddImageAsParent(
-            session, floorImage | session.TrackColours[SCHEME_SUPPORTS],
+            session, session.TrackColours[SCHEME_SUPPORTS].WithIndex(floorImage),
             { 0, 0, height + offsetsB[direction][trackSequence][0] }, { floorBoundSize, (drawRail ? 2 : 0) },
             { floorBoundOffset, height + offsetsB[direction][trackSequence][1] });
         if (drawRail)
         {
             PaintAddImageAsChild(
-                session, imageId | session.TrackColours[SCHEME_TRACK], { -16, -16, height }, { 32, 32, 2 },
+                session, session.TrackColours[SCHEME_TRACK].WithIndex(imageId), { -16, -16, height }, { 32, 32, 2 },
                 { -16, -16, height + offsetB[direction] });
         }
     }
     else if (drawRail)
     {
         PaintAddImageAsParent(
-            session, imageId | session.TrackColours[SCHEME_TRACK], { -16, -16, height }, { 32, 32, 2 },
+            session, session.TrackColours[SCHEME_TRACK].WithIndex(imageId), { -16, -16, height }, { 32, 32, 2 },
             { -16, -16, height + offsetB[direction] });
     }
 
@@ -1984,19 +1986,20 @@ static void miniature_railway_track_diag_flat_to_25_deg_up(
     if (hasSupports)
     {
         PaintAddImageAsParent(
-            session, floorImage | session.TrackColours[SCHEME_SUPPORTS], { 0, 0, height },
+            session, session.TrackColours[SCHEME_SUPPORTS].WithIndex(floorImage), { 0, 0, height },
             { floorBoundSize, (drawRail ? 2 : 0) }, { floorBoundOffset, height });
         if (drawRail)
         {
             PaintAddImageAsChild(
-                session, imageId | session.TrackColours[SCHEME_TRACK], { -16, -16, height }, { 32, 32, 2 },
+                session, session.TrackColours[SCHEME_TRACK].WithIndex(imageId), { -16, -16, height }, { 32, 32, 2 },
                 { -16, -16, height });
         }
     }
     else if (drawRail)
     {
         PaintAddImageAsParent(
-            session, imageId | session.TrackColours[SCHEME_TRACK], { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+            session, session.TrackColours[SCHEME_TRACK].WithIndex(imageId), { -16, -16, height }, { 32, 32, 2 },
+            { -16, -16, height });
     }
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -2058,20 +2061,20 @@ static void miniature_railway_track_diag_25_deg_up_to_flat(
     if (hasSupports)
     {
         PaintAddImageAsParent(
-            session, floorImage | session.TrackColours[SCHEME_SUPPORTS],
+            session, session.TrackColours[SCHEME_SUPPORTS].WithIndex(floorImage),
             { 0, 0, height + offsetsB[direction][trackSequence][0] }, { floorBoundSize, (drawRail ? 2 : 0) },
             { floorBoundOffset, height + offsetsB[direction][trackSequence][1] });
         if (drawRail)
         {
             PaintAddImageAsChild(
-                session, imageId | session.TrackColours[SCHEME_TRACK], { -16, -16, height }, { 32, 32, 2 },
+                session, session.TrackColours[SCHEME_TRACK].WithIndex(imageId), { -16, -16, height }, { 32, 32, 2 },
                 { -16, -16, height + railOffsets[direction] });
         }
     }
     else if (drawRail)
     {
         PaintAddImageAsParent(
-            session, imageId | session.TrackColours[SCHEME_TRACK], { -16, -16, height }, { 32, 32, 2 },
+            session, session.TrackColours[SCHEME_TRACK].WithIndex(imageId), { -16, -16, height }, { 32, 32, 2 },
             { -16, -16, height + railOffsets[direction] });
     }
 
@@ -2133,20 +2136,20 @@ static void miniature_railway_track_diag_25_deg_down(
     if (hasSupports)
     {
         PaintAddImageAsParent(
-            session, floorImage | session.TrackColours[SCHEME_SUPPORTS],
+            session, session.TrackColours[SCHEME_SUPPORTS].WithIndex(floorImage),
             { 0, 0, height + offsetsB[direction][trackSequence][0] }, { floorBoundSize, (drawRail ? 2 : 0) },
             { floorBoundOffset, height + offsetsB[direction][trackSequence][1] });
         if (drawRail)
         {
             PaintAddImageAsChild(
-                session, imageId | session.TrackColours[SCHEME_TRACK], { -16, -16, height }, { 32, 32, 2 },
+                session, session.TrackColours[SCHEME_TRACK].WithIndex(imageId), { -16, -16, height }, { 32, 32, 2 },
                 { -16, -16, height + railOffsets[direction] });
         }
     }
     else if (drawRail)
     {
         PaintAddImageAsParent(
-            session, imageId | session.TrackColours[SCHEME_TRACK], { -16, -16, height }, { 32, 32, 2 },
+            session, session.TrackColours[SCHEME_TRACK].WithIndex(imageId), { -16, -16, height }, { 32, 32, 2 },
             { -16, -16, height + railOffsets[direction] });
     }
 
@@ -2207,20 +2210,20 @@ static void miniature_railway_track_diag_flat_to_25_deg_down(
     if (hasSupports)
     {
         PaintAddImageAsParent(
-            session, floorImage | session.TrackColours[SCHEME_SUPPORTS],
+            session, session.TrackColours[SCHEME_SUPPORTS].WithIndex(floorImage),
             { 0, 0, height + offsetsB[direction][trackSequence][0] }, { floorBoundSize, (drawRail ? 2 : 0) },
             { floorBoundOffset, height + offsetsB[direction][trackSequence][1] });
         if (drawRail)
         {
             PaintAddImageAsChild(
-                session, imageId | session.TrackColours[SCHEME_TRACK], { -16, -16, height }, { 32, 32, 2 },
+                session, session.TrackColours[SCHEME_TRACK].WithIndex(imageId), { -16, -16, height }, { 32, 32, 2 },
                 { -16, -16, height + railOffsets[direction] });
         }
     }
     else if (drawRail)
     {
         PaintAddImageAsParent(
-            session, imageId | session.TrackColours[SCHEME_TRACK], { -16, -16, height }, { 32, 32, 2 },
+            session, session.TrackColours[SCHEME_TRACK].WithIndex(imageId), { -16, -16, height }, { 32, 32, 2 },
             { -16, -16, height + railOffsets[direction] });
     }
 
@@ -2257,19 +2260,20 @@ static void miniature_railway_track_diag_25_deg_down_to_flat(
     if (hasSupports)
     {
         PaintAddImageAsParent(
-            session, floorImage | session.TrackColours[SCHEME_SUPPORTS], { 0, 0, height },
+            session, session.TrackColours[SCHEME_SUPPORTS].WithIndex(floorImage), { 0, 0, height },
             { floorBoundSize, (drawRail ? 2 : 0) }, { floorBoundOffset, height });
         if (drawRail)
         {
             PaintAddImageAsChild(
-                session, imageId | session.TrackColours[SCHEME_TRACK], { -16, -16, height }, { 32, 32, 2 },
+                session, session.TrackColours[SCHEME_TRACK].WithIndex(imageId), { -16, -16, height }, { 32, 32, 2 },
                 { -16, -16, height });
         }
     }
     else if (drawRail)
     {
         PaintAddImageAsParent(
-            session, imageId | session.TrackColours[SCHEME_TRACK], { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+            session, session.TrackColours[SCHEME_TRACK].WithIndex(imageId), { -16, -16, height }, { 32, 32, 2 },
+            { -16, -16, height });
     }
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);

--- a/src/openrct2/ride/transport/Monorail.cpp
+++ b/src/openrct2/ride/transport/Monorail.cpp
@@ -388,7 +388,7 @@ static void paint_monorail_track_flat(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId = monorail_track_pieces_flat[direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(monorail_track_pieces_flat[direction]);
 
     if (direction == 0 || direction == 2)
     {
@@ -423,7 +423,7 @@ static void paint_monorail_station(
     paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId;
+    ImageId imageId;
     const StationObject* stationObject = nullptr;
 
     stationObject = ride.GetStationObject();
@@ -432,17 +432,17 @@ static void paint_monorail_station(
     {
         if (direction == 0 || direction == 2)
         {
-            imageId = SPR_STATION_BASE_B_SW_NE | session.TrackColours[SCHEME_MISC];
+            imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_STATION_BASE_B_SW_NE);
             PaintAddImageAsParent(session, imageId, { 0, 0, height - 2 }, { 32, 28, 2 }, { 0, 2, height });
         }
         else if (direction == 1 || direction == 3)
         {
-            imageId = SPR_STATION_BASE_B_NW_SE | session.TrackColours[SCHEME_MISC];
+            imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_STATION_BASE_B_NW_SE);
             PaintAddImageAsParent(session, imageId, { 0, 0, height - 2 }, { 28, 32, 2 }, { 2, 0, height });
         }
     }
 
-    imageId = monorail_track_pieces_flat[direction] | session.TrackColours[SCHEME_TRACK];
+    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(monorail_track_pieces_flat[direction]);
     if (direction == 0 || direction == 2)
     {
         PaintAddImageAsChild(session, imageId, { 0, 6, height }, { 32, 20, 2 }, { 0, 0, height });
@@ -483,7 +483,7 @@ static void paint_monorail_track_25_deg_up(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId = monorail_track_pieces_25_deg_up[direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(monorail_track_pieces_25_deg_up[direction]);
 
     if (direction == 0 || direction == 2)
     {
@@ -525,7 +525,7 @@ static void paint_monorail_track_flat_to_25_deg_up(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId = monorail_track_pieces_flat_to_25_deg_up[direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(monorail_track_pieces_flat_to_25_deg_up[direction]);
 
     if (direction == 0 || direction == 2)
     {
@@ -567,7 +567,7 @@ static void paint_monorail_track_25_deg_up_to_flat(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId = monorail_track_pieces_25_deg_up_to_flat[direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(monorail_track_pieces_25_deg_up_to_flat[direction]);
 
     if (direction == 0 || direction == 2)
     {
@@ -717,7 +717,8 @@ static void paint_monorail_track_s_bend_left(
         { { 0, 6 }, { 32, 20 } },
     };
 
-    uint32_t imageId = monorail_track_pieces_s_bend_left[direction & 1][trackSequence] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+        monorail_track_pieces_s_bend_left[direction & 1][trackSequence]);
     const CoordsXY& offset = boxList[trackSequence].offset;
     const CoordsXY& bounds = boxList[trackSequence].length;
     if (direction == 0 || direction == 2)
@@ -811,7 +812,8 @@ static void paint_monorail_track_s_bend_right(
         { { 0, 6 }, { 32, 20 } }, { { 0, 6 }, { 32, 26 } }, { { 0, 0 }, { 32, 26 } }, { { 0, 6 }, { 32, 20 } }
     };
 
-    uint32_t imageId = monorail_track_pieces_s_bend_right[direction & 1][trackSequence] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+        monorail_track_pieces_s_bend_right[direction & 1][trackSequence]);
     const CoordsXY& offset = boxList[trackSequence].offset;
     const CoordsXY& bounds = boxList[trackSequence].length;
     if (direction == 0 || direction == 2)
@@ -949,7 +951,8 @@ static void paint_monorail_track_left_eighth_to_diag(
     int8_t index = paint_monorail_eighth_to_diag_index[trackSequence];
     if (index >= 0)
     {
-        uint32_t imageId = ghost_train_track_pieces_left_eight_to_diag[direction][index] | session.TrackColours[SCHEME_TRACK];
+        auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+            ghost_train_track_pieces_left_eight_to_diag[direction][index]);
         const CoordsXY& offset = GhostTrainTrackPiecesLeftEightToDiagBoxes[direction][index].offset;
         const CoordsXY& bounds = GhostTrainTrackPiecesLeftEightToDiagBoxes[direction][index].length;
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { bounds.x, bounds.y, 2 }, { offset.x, offset.y, height });
@@ -1017,7 +1020,8 @@ static void paint_monorail_track_right_eighth_to_diag(
     int8_t index = paint_monorail_eighth_to_diag_index[trackSequence];
     if (index >= 0)
     {
-        uint32_t imageId = ghost_train_track_pieces_right_eight_to_diag[direction][index] | session.TrackColours[SCHEME_TRACK];
+        auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+            ghost_train_track_pieces_right_eight_to_diag[direction][index]);
         const CoordsXY offset = GhostTrainTrackPiecesRightEightToDiagBoxes[direction][index].offset;
         const CoordsXY bounds = GhostTrainTrackPiecesRightEightToDiagBoxes[direction][index].length;
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { bounds.x, bounds.y, 2 }, { offset.x, offset.y, height });
@@ -1125,7 +1129,7 @@ static void paint_monorail_track_diag_flat(
 {
     if (monorail_diag_image_segment[direction][trackSequence])
     {
-        uint32_t imageId = monorail_track_pieces_diag_flat[direction] | session.TrackColours[SCHEME_TRACK];
+        auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(monorail_track_pieces_diag_flat[direction]);
         PaintAddImageAsParent(session, imageId, { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
     }
 
@@ -1148,7 +1152,7 @@ static void paint_monorail_track_diag_25_deg_up(
 {
     if (monorail_diag_image_segment[direction][trackSequence])
     {
-        uint32_t imageId = monorail_track_pieces_diag_25_deg_up[direction] | session.TrackColours[SCHEME_TRACK];
+        auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(monorail_track_pieces_diag_25_deg_up[direction]);
         PaintAddImageAsParent(session, imageId, { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
     }
 
@@ -1171,7 +1175,7 @@ static void paint_monorail_track_diag_flat_to_25_deg_up(
 {
     if (monorail_diag_image_segment[direction][trackSequence])
     {
-        uint32_t imageId = monorail_track_pieces_diag_flat_to_25_deg_up[direction] | session.TrackColours[SCHEME_TRACK];
+        auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(monorail_track_pieces_diag_flat_to_25_deg_up[direction]);
         PaintAddImageAsParent(session, imageId, { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
     }
 
@@ -1194,7 +1198,7 @@ static void paint_monorail_track_diag_25_deg_up_to_flat(
 {
     if (monorail_diag_image_segment[direction][trackSequence])
     {
-        uint32_t imageId = monorail_track_pieces_diag_25_deg_up_to_flat[direction] | session.TrackColours[SCHEME_TRACK];
+        auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(monorail_track_pieces_diag_25_deg_up_to_flat[direction]);
         PaintAddImageAsParent(session, imageId, { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
     }
 
@@ -1217,7 +1221,7 @@ static void paint_monorail_track_diag_25_deg_down(
 {
     if (monorail_diag_image_segment[direction][trackSequence])
     {
-        uint32_t imageId = monorail_track_pieces_diag_25_deg_up[(direction + 2) % 4] | session.TrackColours[SCHEME_TRACK];
+        auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(monorail_track_pieces_diag_25_deg_up[(direction + 2) % 4]);
         PaintAddImageAsParent(session, imageId, { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
     }
 
@@ -1240,8 +1244,8 @@ static void paint_monorail_track_diag_flat_to_25_deg_down(
 {
     if (monorail_diag_image_segment[direction][trackSequence])
     {
-        uint32_t imageId = monorail_track_pieces_diag_25_deg_up_to_flat[(direction + 2) % 4]
-            | session.TrackColours[SCHEME_TRACK];
+        auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+            monorail_track_pieces_diag_25_deg_up_to_flat[(direction + 2) % 4]);
         PaintAddImageAsParent(session, imageId, { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
     }
 
@@ -1264,8 +1268,8 @@ static void paint_monorail_track_diag_25_deg_down_to_flat(
 {
     if (monorail_diag_image_segment[direction][trackSequence])
     {
-        uint32_t imageId = monorail_track_pieces_diag_flat_to_25_deg_up[(direction + 2) % 4]
-            | session.TrackColours[SCHEME_TRACK];
+        auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+            monorail_track_pieces_diag_flat_to_25_deg_up[(direction + 2) % 4]);
         PaintAddImageAsParent(session, imageId, { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
     }
 

--- a/src/openrct2/ride/transport/SuspendedMonorail.cpp
+++ b/src/openrct2/ride/transport/SuspendedMonorail.cpp
@@ -29,13 +29,13 @@ static void suspended_monorail_track_flat(
         case 0:
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25853, { 0, 0, height + 32 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25853), { 0, 0, height + 32 }, { 32, 20, 3 },
                 { 0, 6, height + 32 });
             break;
         case 1:
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25854, { 0, 0, height + 32 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25854), { 0, 0, height + 32 }, { 32, 20, 3 },
                 { 0, 6, height + 32 });
             break;
     }
@@ -64,13 +64,13 @@ static void suspended_monorail_track_station(
     };
 
     PaintAddImageAsParentRotated(
-        session, direction, imageIds[direction][0] | session.TrackColours[SCHEME_MISC], { 0, 0, height }, { 32, 28, 1 },
-        { 0, 2, height });
+        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][0]), { 0, 0, height },
+        { 32, 28, 1 }, { 0, 2, height });
     PaintAddImageAsParentRotated(
-        session, direction, imageIds[direction][1] | session.TrackColours[SCHEME_TRACK], { 0, 0, height + 32 }, { 32, 20, 3 },
-        { 0, 6, height + 32 });
+        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][1]), { 0, 0, height + 32 },
+        { 32, 20, 3 }, { 0, 6, height + 32 });
     PaintAddImageAsChildRotated(
-        session, direction, imageIds[direction][2] | session.TrackColours[SCHEME_SUPPORTS], { 0, 6, height + 32 },
+        session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(imageIds[direction][2]), { 0, 6, height + 32 },
         { 32, 20, 3 }, { 0, 6, height + 32 });
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], 3);
     track_paint_util_draw_station_inverted(session, ride, direction, height, trackElement, STATION_VARIANT_TALL);
@@ -88,22 +88,22 @@ static void suspended_monorail_track_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25945, { 0, 0, height + 32 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25945), { 0, 0, height + 32 }, { 32, 20, 3 },
                 { 0, 6, height + 48 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25946, { 0, 0, height + 32 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25946), { 0, 0, height + 32 }, { 32, 20, 3 },
                 { 0, 6, height + 48 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25947, { 0, 0, height + 32 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25947), { 0, 0, height + 32 }, { 32, 20, 3 },
                 { 0, 6, height + 48 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25948, { 0, 0, height + 32 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25948), { 0, 0, height + 32 }, { 32, 20, 3 },
                 { 0, 6, height + 48 });
             break;
     }
@@ -153,22 +153,22 @@ static void suspended_monorail_track_flat_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25937, { 0, 0, height + 32 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25937), { 0, 0, height + 32 }, { 32, 20, 3 },
                 { 0, 6, height + 40 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25938, { 0, 0, height + 32 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25938), { 0, 0, height + 32 }, { 32, 20, 3 },
                 { 0, 6, height + 40 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25939, { 0, 0, height + 32 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25939), { 0, 0, height + 32 }, { 32, 20, 3 },
                 { 0, 6, height + 40 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25940, { 0, 0, height + 32 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25940), { 0, 0, height + 32 }, { 32, 20, 3 },
                 { 0, 6, height + 40 });
             break;
     }
@@ -218,22 +218,22 @@ static void suspended_monorail_track_25_deg_up_to_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25941, { 0, 0, height + 32 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25941), { 0, 0, height + 32 }, { 32, 20, 3 },
                 { 0, 6, height + 40 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25942, { 0, 0, height + 32 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25942), { 0, 0, height + 32 }, { 32, 20, 3 },
                 { 0, 6, height + 40 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25943, { 0, 0, height + 32 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25943), { 0, 0, height + 32 }, { 32, 20, 3 },
                 { 0, 6, height + 40 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours[SCHEME_TRACK] | 25944, { 0, 0, height + 32 }, { 32, 20, 3 },
+                session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25944), { 0, 0, height + 32 }, { 32, 20, 3 },
                 { 0, 6, height + 40 });
             break;
     }
@@ -310,23 +310,23 @@ static void suspended_monorail_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25876, { 0, 0, height + 32 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25876), { 0, 0, height + 32 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25881, { 0, 0, height + 32 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25881), { 0, 0, height + 32 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25886, { 0, 0, height + 32 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25886), { 0, 0, height + 32 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25871, { 0, 0, height + 32 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25871), { 0, 0, height + 32 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
             }
 
@@ -350,21 +350,23 @@ static void suspended_monorail_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25875, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25875), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25880, { 0, 0, height + 32 }, { 32, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25880), { 0, 0, height + 32 },
+                        { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25885, { 0, 0, height + 32 }, { 32, 16, 3 },
-                        { 0, 16, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25885), { 0, 0, height + 32 },
+                        { 32, 16, 3 }, { 0, 16, height + 32 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25870, { 0, 0, height + 32 }, { 32, 16, 3 },
-                        { 0, 16, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25870), { 0, 0, height + 32 },
+                        { 32, 16, 3 }, { 0, 16, height + 32 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -379,22 +381,23 @@ static void suspended_monorail_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25874, { 0, 0, height + 32 }, { 16, 16, 3 },
-                        { 0, 16, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25874), { 0, 0, height + 32 },
+                        { 16, 16, 3 }, { 0, 16, height + 32 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25879, { 0, 0, height + 32 }, { 16, 16, 3 },
-                        { 16, 16, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25879), { 0, 0, height + 32 },
+                        { 16, 16, 3 }, { 16, 16, height + 32 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25884, { 0, 0, height + 32 }, { 16, 16, 3 },
-                        { 16, 0, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25884), { 0, 0, height + 32 },
+                        { 16, 16, 3 }, { 16, 0, height + 32 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25869, { 0, 0, height + 32 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25869), { 0, 0, height + 32 },
+                        { 16, 16, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -409,21 +412,23 @@ static void suspended_monorail_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25873, { 0, 0, height + 32 }, { 16, 32, 3 },
-                        { 16, 0, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25873), { 0, 0, height + 32 },
+                        { 16, 32, 3 }, { 16, 0, height + 32 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25878, { 0, 0, height + 32 }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25878), { 0, 0, height + 32 },
+                        { 16, 32, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25883, { 0, 0, height + 32 }, { 16, 32, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25883), { 0, 0, height + 32 },
+                        { 16, 32, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25868, { 0, 0, height + 32 }, { 16, 32, 3 },
-                        { 16, 0, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25868), { 0, 0, height + 32 },
+                        { 16, 32, 3 }, { 16, 0, height + 32 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -438,23 +443,23 @@ static void suspended_monorail_track_left_quarter_turn_5(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25872, { 0, 0, height + 32 }, { 20, 32, 3 },
-                        { 6, 0, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25872), { 0, 0, height + 32 },
+                        { 20, 32, 3 }, { 6, 0, height + 32 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25877, { 0, 0, height + 32 }, { 20, 32, 3 },
-                        { 6, 0, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25877), { 0, 0, height + 32 },
+                        { 20, 32, 3 }, { 6, 0, height + 32 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25882, { 0, 0, height + 32 }, { 20, 32, 3 },
-                        { 6, 0, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25882), { 0, 0, height + 32 },
+                        { 20, 32, 3 }, { 6, 0, height + 32 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25867, { 0, 0, height + 32 }, { 20, 32, 3 },
-                        { 6, 0, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25867), { 0, 0, height + 32 },
+                        { 20, 32, 3 }, { 6, 0, height + 32 });
                     break;
             }
 
@@ -499,23 +504,23 @@ static void suspended_monorail_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25919, { 0, 0, height + 32 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25919), { 0, 0, height + 32 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25923, { 0, 0, height + 32 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25923), { 0, 0, height + 32 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25922, { 0, 0, height + 32 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25922), { 0, 0, height + 32 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25926, { 0, 0, height + 32 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25926), { 0, 0, height + 32 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
             }
 
@@ -535,21 +540,23 @@ static void suspended_monorail_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25920, { 0, 0, height + 32 }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25920), { 0, 0, height + 32 },
+                        { 32, 26, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25924, { 0, 0, height + 32 }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25924), { 0, 0, height + 32 },
+                        { 32, 26, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25921, { 0, 0, height + 32 }, { 32, 26, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25921), { 0, 0, height + 32 },
+                        { 32, 26, 3 }, { 0, 6, height + 32 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25925, { 0, 0, height + 32 }, { 32, 26, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25925), { 0, 0, height + 32 },
+                        { 32, 26, 3 }, { 0, 6, height + 32 });
                     break;
             }
 
@@ -577,21 +584,23 @@ static void suspended_monorail_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25921, { 0, 0, height + 32 }, { 32, 26, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25921), { 0, 0, height + 32 },
+                        { 32, 26, 3 }, { 0, 6, height + 32 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25925, { 0, 0, height + 32 }, { 32, 26, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25925), { 0, 0, height + 32 },
+                        { 32, 26, 3 }, { 0, 6, height + 32 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25920, { 0, 0, height + 32 }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25920), { 0, 0, height + 32 },
+                        { 32, 26, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25924, { 0, 0, height + 32 }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25924), { 0, 0, height + 32 },
+                        { 32, 26, 3 });
                     break;
             }
 
@@ -619,23 +628,23 @@ static void suspended_monorail_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25922, { 0, 0, height + 32 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25922), { 0, 0, height + 32 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25926, { 0, 0, height + 32 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25926), { 0, 0, height + 32 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25919, { 0, 0, height + 32 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25919), { 0, 0, height + 32 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25923, { 0, 0, height + 32 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25923), { 0, 0, height + 32 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
             }
 
@@ -670,23 +679,23 @@ static void suspended_monorail_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25927, { 0, 0, height + 32 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25927), { 0, 0, height + 32 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25931, { 0, 0, height + 32 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25931), { 0, 0, height + 32 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25930, { 0, 0, height + 32 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25930), { 0, 0, height + 32 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25934, { 0, 0, height + 32 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25934), { 0, 0, height + 32 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
             }
 
@@ -706,21 +715,23 @@ static void suspended_monorail_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25928, { 0, 0, height + 32 }, { 32, 26, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25928), { 0, 0, height + 32 },
+                        { 32, 26, 3 }, { 0, 6, height + 32 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25932, { 0, 0, height + 32 }, { 32, 26, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25932), { 0, 0, height + 32 },
+                        { 32, 26, 3 }, { 0, 6, height + 32 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25929, { 0, 0, height + 32 }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25929), { 0, 0, height + 32 },
+                        { 32, 26, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25933, { 0, 0, height + 32 }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25933), { 0, 0, height + 32 },
+                        { 32, 26, 3 });
                     break;
             }
 
@@ -748,21 +759,23 @@ static void suspended_monorail_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25929, { 0, 0, height + 32 }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25929), { 0, 0, height + 32 },
+                        { 32, 26, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25933, { 0, 0, height + 32 }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25933), { 0, 0, height + 32 },
+                        { 32, 26, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25928, { 0, 0, height + 32 }, { 32, 26, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25928), { 0, 0, height + 32 },
+                        { 32, 26, 3 }, { 0, 6, height + 32 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25932, { 0, 0, height + 32 }, { 32, 26, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25932), { 0, 0, height + 32 },
+                        { 32, 26, 3 }, { 0, 6, height + 32 });
                     break;
             }
 
@@ -790,23 +803,23 @@ static void suspended_monorail_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25930, { 0, 0, height + 32 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25930), { 0, 0, height + 32 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25934, { 0, 0, height + 32 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25934), { 0, 0, height + 32 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25927, { 0, 0, height + 32 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25927), { 0, 0, height + 32 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25931, { 0, 0, height + 32 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25931), { 0, 0, height + 32 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
             }
 
@@ -841,23 +854,23 @@ static void suspended_monorail_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25860, { 0, 0, height + 32 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25860), { 0, 0, height + 32 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25863, { 0, 0, height + 32 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25863), { 0, 0, height + 32 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25866, { 0, 0, height + 32 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25866), { 0, 0, height + 32 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25857, { 0, 0, height + 32 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25857), { 0, 0, height + 32 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
             }
 
@@ -881,22 +894,23 @@ static void suspended_monorail_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25859, { 0, 0, height + 32 }, { 16, 16, 3 },
-                        { 16, 0, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25859), { 0, 0, height + 32 },
+                        { 16, 16, 3 }, { 16, 0, height + 32 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25862, { 0, 0, height + 32 }, { 16, 16, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25862), { 0, 0, height + 32 },
+                        { 16, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25865, { 0, 0, height + 32 }, { 16, 16, 3 },
-                        { 0, 16, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25865), { 0, 0, height + 32 },
+                        { 16, 16, 3 }, { 0, 16, height + 32 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25856, { 0, 0, height + 32 }, { 16, 16, 3 },
-                        { 16, 16, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25856), { 0, 0, height + 32 },
+                        { 16, 16, 3 }, { 16, 16, height + 32 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -908,23 +922,23 @@ static void suspended_monorail_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25858, { 0, 0, height + 32 }, { 20, 32, 3 },
-                        { 6, 0, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25858), { 0, 0, height + 32 },
+                        { 20, 32, 3 }, { 6, 0, height + 32 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25861, { 0, 0, height + 32 }, { 20, 32, 3 },
-                        { 6, 0, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25861), { 0, 0, height + 32 },
+                        { 20, 32, 3 }, { 6, 0, height + 32 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25864, { 0, 0, height + 32 }, { 20, 32, 3 },
-                        { 6, 0, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25864), { 0, 0, height + 32 },
+                        { 20, 32, 3 }, { 6, 0, height + 32 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25855, { 0, 0, height + 32 }, { 20, 32, 3 },
-                        { 6, 0, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25855), { 0, 0, height + 32 },
+                        { 20, 32, 3 }, { 6, 0, height + 32 });
                     break;
             }
 
@@ -969,23 +983,23 @@ static void suspended_monorail_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25903, { 0, 0, height + 32 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25903), { 0, 0, height + 32 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25907, { 0, 0, height + 32 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25907), { 0, 0, height + 32 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25911, { 0, 0, height + 32 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25911), { 0, 0, height + 32 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25915, { 0, 0, height + 32 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25915), { 0, 0, height + 32 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
             }
 
@@ -1005,23 +1019,23 @@ static void suspended_monorail_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25904, { 0, 0, height + 32 }, { 32, 16, 3 },
-                        { 0, 0, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25904), { 0, 0, height + 32 },
+                        { 32, 16, 3 }, { 0, 0, height + 32 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25908, { 0, 0, height + 32 }, { 34, 16, 3 },
-                        { 0, 0, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25908), { 0, 0, height + 32 },
+                        { 34, 16, 3 }, { 0, 0, height + 32 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25912, { 0, 0, height + 32 }, { 32, 16, 3 },
-                        { 0, 16, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25912), { 0, 0, height + 32 },
+                        { 32, 16, 3 }, { 0, 16, height + 32 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25916, { 0, 0, height + 32 }, { 32, 16, 3 },
-                        { 0, 16, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25916), { 0, 0, height + 32 },
+                        { 32, 16, 3 }, { 0, 16, height + 32 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1036,23 +1050,23 @@ static void suspended_monorail_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25905, { 0, 0, height + 32 }, { 16, 16, 3 },
-                        { 0, 16, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25905), { 0, 0, height + 32 },
+                        { 16, 16, 3 }, { 0, 16, height + 32 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25909, { 0, 0, height + 32 }, { 16, 16, 3 },
-                        { 16, 16, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25909), { 0, 0, height + 32 },
+                        { 16, 16, 3 }, { 16, 16, height + 32 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25913, { 0, 0, height + 32 }, { 16, 16, 3 },
-                        { 16, 0, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25913), { 0, 0, height + 32 },
+                        { 16, 16, 3 }, { 16, 0, height + 32 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25917, { 0, 0, height + 32 }, { 16, 16, 3 },
-                        { 0, 0, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25917), { 0, 0, height + 32 },
+                        { 16, 16, 3 }, { 0, 0, height + 32 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1070,23 +1084,23 @@ static void suspended_monorail_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25906, { 0, 0, height + 32 }, { 16, 16, 3 },
-                        { 16, 16, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25906), { 0, 0, height + 32 },
+                        { 16, 16, 3 }, { 16, 16, height + 32 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25910, { 0, 0, height + 32 }, { 16, 18, 3 },
-                        { 0, 16, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25910), { 0, 0, height + 32 },
+                        { 16, 18, 3 }, { 0, 16, height + 32 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25914, { 0, 0, height + 32 }, { 16, 16, 3 },
-                        { 0, 0, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25914), { 0, 0, height + 32 },
+                        { 16, 16, 3 }, { 0, 0, height + 32 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25918, { 0, 0, height + 32 }, { 16, 16, 3 },
-                        { 16, 0, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25918), { 0, 0, height + 32 },
+                        { 16, 16, 3 }, { 16, 0, height + 32 });
                     break;
             }
 
@@ -1132,23 +1146,23 @@ static void suspended_monorail_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25887, { 0, 0, height + 32 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25887), { 0, 0, height + 32 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25891, { 0, 0, height + 32 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25891), { 0, 0, height + 32 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25895, { 0, 0, height + 32 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25895), { 0, 0, height + 32 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25899, { 0, 0, height + 32 }, { 32, 20, 3 },
-                        { 0, 6, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25899), { 0, 0, height + 32 },
+                        { 32, 20, 3 }, { 0, 6, height + 32 });
                     break;
             }
 
@@ -1168,23 +1182,23 @@ static void suspended_monorail_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25888, { 0, 0, height + 32 }, { 32, 16, 3 },
-                        { 0, 16, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25888), { 0, 0, height + 32 },
+                        { 32, 16, 3 }, { 0, 16, height + 32 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25892, { 0, 0, height + 32 }, { 32, 16, 3 },
-                        { 0, 16, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25892), { 0, 0, height + 32 },
+                        { 32, 16, 3 }, { 0, 16, height + 32 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25896, { 0, 0, height + 32 }, { 34, 16, 3 },
-                        { 0, 0, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25896), { 0, 0, height + 32 },
+                        { 34, 16, 3 }, { 0, 0, height + 32 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25900, { 0, 0, height + 32 }, { 32, 16, 3 },
-                        { 0, 0, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25900), { 0, 0, height + 32 },
+                        { 32, 16, 3 }, { 0, 0, height + 32 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1199,23 +1213,23 @@ static void suspended_monorail_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25889, { 0, 0, height + 32 }, { 16, 16, 3 },
-                        { 0, 0, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25889), { 0, 0, height + 32 },
+                        { 16, 16, 3 }, { 0, 0, height + 32 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25893, { 0, 0, height + 32 }, { 16, 16, 3 },
-                        { 16, 0, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25893), { 0, 0, height + 32 },
+                        { 16, 16, 3 }, { 16, 0, height + 32 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25897, { 0, 0, height + 32 }, { 28, 28, 3 },
-                        { 4, 4, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25897), { 0, 0, height + 32 },
+                        { 28, 28, 3 }, { 4, 4, height + 32 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25901, { 0, 0, height + 32 }, { 16, 16, 3 },
-                        { 0, 16, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25901), { 0, 0, height + 32 },
+                        { 16, 16, 3 }, { 0, 16, height + 32 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1233,23 +1247,23 @@ static void suspended_monorail_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25890, { 0, 0, height + 32 }, { 16, 16, 3 },
-                        { 16, 0, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25890), { 0, 0, height + 32 },
+                        { 16, 16, 3 }, { 16, 0, height + 32 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25894, { 0, 0, height + 32 }, { 16, 16, 3 },
-                        { 0, 0, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25894), { 0, 0, height + 32 },
+                        { 16, 16, 3 }, { 0, 0, height + 32 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25898, { 0, 0, height + 32 }, { 16, 18, 3 },
-                        { 0, 16, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25898), { 0, 0, height + 32 },
+                        { 16, 18, 3 }, { 0, 16, height + 32 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25902, { 0, 0, height + 32 }, { 16, 16, 3 },
-                        { 16, 16, height + 32 });
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25902), { 0, 0, height + 32 },
+                        { 16, 16, 3 }, { 16, 16, height + 32 });
                     break;
             }
 
@@ -1313,7 +1327,7 @@ static void suspended_monorail_track_diag_flat(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25936, { -16, -16, height + 32 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25936), { -16, -16, height + 32 },
                         { 32, 32, 3 }, { -16, -16, height + 32 });
                     break;
             }
@@ -1326,7 +1340,7 @@ static void suspended_monorail_track_diag_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25935, { -16, -16, height + 32 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25935), { -16, -16, height + 32 },
                         { 32, 32, 3 }, { -16, -16, height + 32 });
                     break;
             }
@@ -1339,7 +1353,7 @@ static void suspended_monorail_track_diag_flat(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25935, { -16, -16, height + 32 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25935), { -16, -16, height + 32 },
                         { 32, 32, 3 }, { -16, -16, height + 32 });
                     break;
             }
@@ -1352,7 +1366,7 @@ static void suspended_monorail_track_diag_flat(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25936, { -16, -16, height + 32 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25936), { -16, -16, height + 32 },
                         { 32, 32, 3 }, { -16, -16, height + 32 });
                     break;
             }
@@ -1396,7 +1410,7 @@ static void suspended_monorail_track_diag_25_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25960, { -16, -16, height + 32 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25960), { -16, -16, height + 32 },
                         { 32, 32, 3 }, { -16, -16, height + 48 });
                     break;
             }
@@ -1409,7 +1423,7 @@ static void suspended_monorail_track_diag_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25957, { -16, -16, height + 32 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25957), { -16, -16, height + 32 },
                         { 32, 32, 3 }, { -16, -16, height + 48 });
                     break;
             }
@@ -1422,7 +1436,7 @@ static void suspended_monorail_track_diag_25_deg_up(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25959, { -16, -16, height + 32 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25959), { -16, -16, height + 32 },
                         { 32, 32, 3 }, { -16, -16, height + 48 });
                     break;
             }
@@ -1435,7 +1449,7 @@ static void suspended_monorail_track_diag_25_deg_up(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25958, { -16, -16, height + 32 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25958), { -16, -16, height + 32 },
                         { 32, 32, 3 }, { -16, -16, height + 48 });
                     break;
             }
@@ -1479,7 +1493,7 @@ static void suspended_monorail_track_diag_flat_to_25_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25952, { -16, -16, height + 32 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25952), { -16, -16, height + 32 },
                         { 32, 32, 3 }, { -16, -16, height + 40 });
                     break;
             }
@@ -1492,7 +1506,7 @@ static void suspended_monorail_track_diag_flat_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25949, { -16, -16, height + 32 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25949), { -16, -16, height + 32 },
                         { 32, 32, 3 }, { -16, -16, height + 40 });
                     break;
             }
@@ -1505,7 +1519,7 @@ static void suspended_monorail_track_diag_flat_to_25_deg_up(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25951, { -16, -16, height + 32 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25951), { -16, -16, height + 32 },
                         { 32, 32, 3 }, { -16, -16, height + 40 });
                     break;
             }
@@ -1518,7 +1532,7 @@ static void suspended_monorail_track_diag_flat_to_25_deg_up(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25950, { -16, -16, height + 32 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25950), { -16, -16, height + 32 },
                         { 32, 32, 3 }, { -16, -16, height + 40 });
                     break;
             }
@@ -1562,7 +1576,7 @@ static void suspended_monorail_track_diag_25_deg_up_to_flat(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25956, { -16, -16, height + 32 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25956), { -16, -16, height + 32 },
                         { 32, 32, 3 }, { -16, -16, height + 40 });
                     break;
             }
@@ -1575,7 +1589,7 @@ static void suspended_monorail_track_diag_25_deg_up_to_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25953, { -16, -16, height + 32 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25953), { -16, -16, height + 32 },
                         { 32, 32, 3 }, { -16, -16, height + 40 });
                     break;
             }
@@ -1588,7 +1602,7 @@ static void suspended_monorail_track_diag_25_deg_up_to_flat(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25955, { -16, -16, height + 32 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25955), { -16, -16, height + 32 },
                         { 32, 32, 3 }, { -16, -16, height + 40 });
                     break;
             }
@@ -1601,7 +1615,7 @@ static void suspended_monorail_track_diag_25_deg_up_to_flat(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25954, { -16, -16, height + 32 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25954), { -16, -16, height + 32 },
                         { 32, 32, 3 }, { -16, -16, height + 40 });
                     break;
             }
@@ -1645,7 +1659,7 @@ static void suspended_monorail_track_diag_25_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25958, { -16, -16, height + 32 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25958), { -16, -16, height + 32 },
                         { 32, 32, 3 }, { -16, -16, height + 48 });
                     break;
             }
@@ -1658,7 +1672,7 @@ static void suspended_monorail_track_diag_25_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25959, { -16, -16, height + 32 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25959), { -16, -16, height + 32 },
                         { 32, 32, 3 }, { -16, -16, height + 48 });
                     break;
             }
@@ -1671,7 +1685,7 @@ static void suspended_monorail_track_diag_25_deg_down(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25957, { -16, -16, height + 32 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25957), { -16, -16, height + 32 },
                         { 32, 32, 3 }, { -16, -16, height + 48 });
                     break;
             }
@@ -1684,7 +1698,7 @@ static void suspended_monorail_track_diag_25_deg_down(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25960, { -16, -16, height + 32 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25960), { -16, -16, height + 32 },
                         { 32, 32, 3 }, { -16, -16, height + 48 });
                     break;
             }
@@ -1728,7 +1742,7 @@ static void suspended_monorail_track_diag_flat_to_25_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25954, { -16, -16, height + 32 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25954), { -16, -16, height + 32 },
                         { 32, 32, 3 }, { -16, -16, height + 40 });
                     break;
             }
@@ -1740,7 +1754,7 @@ static void suspended_monorail_track_diag_flat_to_25_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25955, { -16, -16, height + 32 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25955), { -16, -16, height + 32 },
                         { 32, 32, 3 }, { -16, -16, height + 40 });
                     break;
             }
@@ -1752,7 +1766,7 @@ static void suspended_monorail_track_diag_flat_to_25_deg_down(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25953, { -16, -16, height + 32 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25953), { -16, -16, height + 32 },
                         { 32, 32, 3 }, { -16, -16, height + 40 });
                     break;
             }
@@ -1764,7 +1778,7 @@ static void suspended_monorail_track_diag_flat_to_25_deg_down(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25956, { -16, -16, height + 32 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25956), { -16, -16, height + 32 },
                         { 32, 32, 3 }, { -16, -16, height + 40 });
                     break;
             }
@@ -1808,7 +1822,7 @@ static void suspended_monorail_track_diag_25_deg_down_to_flat(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25950, { -16, -16, height + 32 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25950), { -16, -16, height + 32 },
                         { 32, 32, 3 }, { -16, -16, height + 40 });
                     break;
             }
@@ -1821,7 +1835,7 @@ static void suspended_monorail_track_diag_25_deg_down_to_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25951, { -16, -16, height + 32 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25951), { -16, -16, height + 32 },
                         { 32, 32, 3 }, { -16, -16, height + 40 });
                     break;
             }
@@ -1834,7 +1848,7 @@ static void suspended_monorail_track_diag_25_deg_down_to_flat(
             {
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25949, { -16, -16, height + 32 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25949), { -16, -16, height + 32 },
                         { 32, 32, 3 }, { -16, -16, height + 40 });
                     break;
             }
@@ -1847,7 +1861,7 @@ static void suspended_monorail_track_diag_25_deg_down_to_flat(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 25952, { -16, -16, height + 32 },
+                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(25952), { -16, -16, height + 32 },
                         { 32, 32, 3 }, { -16, -16, height + 40 });
                     break;
             }

--- a/src/openrct2/ride/water/BoatHire.cpp
+++ b/src/openrct2/ride/water/BoatHire.cpp
@@ -35,23 +35,23 @@ static void paint_boat_hire_track_flat(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId;
+    ImageId imageId;
 
     const auto offset = CoordsXYZ{ 0, 0, height };
     if (direction & 1)
     {
-        imageId = SPR_BOAT_HIRE_FLAT_BACK_NW_SE | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_BOAT_HIRE_FLAT_BACK_NW_SE);
         PaintAddImageAsParent(session, imageId, offset, { 1, 32, 3 }, { 4, 0, height });
 
-        imageId = SPR_BOAT_HIRE_FLAT_FRONT_NW_SE | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_BOAT_HIRE_FLAT_FRONT_NW_SE);
         PaintAddImageAsParent(session, imageId, offset, { 1, 32, 3 }, { 28, 0, height });
     }
     else
     {
-        imageId = SPR_BOAT_HIRE_FLAT_BACK_SW_NE | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_BOAT_HIRE_FLAT_BACK_SW_NE);
         PaintAddImageAsParent(session, imageId, offset, { 32, 1, 3 }, { 0, 4, height });
 
-        imageId = SPR_BOAT_HIRE_FLAT_FRONT_SW_NE | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_BOAT_HIRE_FLAT_FRONT_SW_NE);
         PaintAddImageAsParent(session, imageId, offset, { 32, 1, 3 }, { 0, 28, height });
     }
 
@@ -89,36 +89,36 @@ static void paint_boat_hire_track_left_quarter_turn_1_tile(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId;
+    ImageId imageId;
     const auto offset = CoordsXYZ{ 0, 0, height };
     switch (direction)
     {
         case 0:
-            imageId = SPR_BOAT_HIRE_FLAT_QUARTER_TURN_1_TILE_BACK_SW_NW | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_BOAT_HIRE_FLAT_QUARTER_TURN_1_TILE_BACK_SW_NW);
             PaintAddImageAsParent(session, imageId, offset, { 32, 32, 0 }, { 0, 0, height });
 
-            imageId = SPR_BOAT_HIRE_FLAT_QUARTER_TURN_1_TILE_FRONT_SW_NW | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_BOAT_HIRE_FLAT_QUARTER_TURN_1_TILE_FRONT_SW_NW);
             PaintAddImageAsParent(session, imageId, offset, { 3, 3, 3 }, { 28, 28, height + 2 });
             break;
         case 1:
-            imageId = SPR_BOAT_HIRE_FLAT_QUARTER_TURN_1_TILE_BACK_NW_NE | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_BOAT_HIRE_FLAT_QUARTER_TURN_1_TILE_BACK_NW_NE);
             PaintAddImageAsParent(session, imageId, offset, { 32, 32, 0 }, { 0, 0, height });
 
-            imageId = SPR_BOAT_HIRE_FLAT_QUARTER_TURN_1_TILE_FRONT_NW_NE | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_BOAT_HIRE_FLAT_QUARTER_TURN_1_TILE_FRONT_NW_NE);
             PaintAddImageAsParent(session, imageId, offset, { 3, 3, 3 }, { 28, 28, height + 2 });
             break;
         case 2:
-            imageId = SPR_BOAT_HIRE_FLAT_QUARTER_TURN_1_TILE_BACK_NE_SE | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_BOAT_HIRE_FLAT_QUARTER_TURN_1_TILE_BACK_NE_SE);
             PaintAddImageAsParent(session, imageId, offset, { 32, 32, 0 }, { 0, 0, height });
 
-            imageId = SPR_BOAT_HIRE_FLAT_QUARTER_TURN_1_TILE_FRONT_NE_SE | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_BOAT_HIRE_FLAT_QUARTER_TURN_1_TILE_FRONT_NE_SE);
             PaintAddImageAsParent(session, imageId, offset, { 3, 3, 3 }, { 28, 28, height + 2 });
             break;
         case 3:
-            imageId = SPR_BOAT_HIRE_FLAT_QUARTER_TURN_1_TILE_FRONT_SE_SW | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_BOAT_HIRE_FLAT_QUARTER_TURN_1_TILE_FRONT_SE_SW);
             PaintAddImageAsParent(session, imageId, offset, { 3, 3, 3 }, { 28, 28, height + 2 });
 
-            imageId = SPR_BOAT_HIRE_FLAT_QUARTER_TURN_1_TILE_BACK_SE_SW | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_BOAT_HIRE_FLAT_QUARTER_TURN_1_TILE_BACK_SE_SW);
             PaintAddImageAsParent(session, imageId, offset, { 32, 32, 0 }, { 0, 0, height });
             break;
     }

--- a/src/openrct2/ride/water/DingySlide.cpp
+++ b/src/openrct2/ride/water/DingySlide.cpp
@@ -368,10 +368,10 @@ static void dinghy_slide_track_flat(
     };
 
     uint8_t isChained = trackElement.HasChain() ? 1 : 0;
-    uint32_t imageId = imageIds[isChained][direction][0] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[isChained][direction][0]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
 
-    imageId = imageIds[isChained][direction][1] | session.TrackColours[SCHEME_TRACK];
+    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[isChained][direction][1]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
 
     if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -398,10 +398,11 @@ static void dinghy_slide_track_station(
     };
 
     PaintAddImageAsParentRotated(
-        session, direction, imageIds[direction][0] | session.TrackColours[SCHEME_TRACK], { 0, 0, height }, { 32, 20, 1 },
-        { 0, 6, height + 3 });
+        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]), { 0, 0, height },
+        { 32, 20, 1 }, { 0, 6, height + 3 });
     PaintAddImageAsParentRotated(
-        session, direction, imageIds[direction][1] | session.TrackColours[SCHEME_MISC], { 0, 0, height }, { 32, 32, 1 });
+        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][1]), { 0, 0, height },
+        { 32, 32, 1 });
 
     metal_a_supports_paint_setup(
         session, METAL_SUPPORTS_TUBES, 5 + (direction & 1), 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -436,10 +437,10 @@ static void dinghy_slide_track_25_deg_up(
     };
 
     uint8_t isChained = trackElement.HasChain() ? 1 : 0;
-    uint32_t imageId = imageIds[isChained][direction][0] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[isChained][direction][0]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
 
-    imageId = imageIds[isChained][direction][1] | session.TrackColours[SCHEME_TRACK];
+    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[isChained][direction][1]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 1, 50 }, { 0, 27, height });
 
     if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -472,10 +473,10 @@ static void dinghy_slide_track_60_deg_up(
         { SPR_DINGHY_SLIDE_60_DEG_SE_NW, SPR_DINGHY_SLIDE_60_DEG_FRONT_SE_NW },
     };
 
-    uint32_t imageId = imageIds[direction][0] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
 
-    imageId = imageIds[direction][1] | session.TrackColours[SCHEME_TRACK];
+    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][1]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 1, 98 }, { 0, 27, height });
 
     if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -517,10 +518,10 @@ static void dinghy_slide_track_flat_to_25_deg_up(
     };
 
     uint8_t isChained = trackElement.HasChain() ? 1 : 0;
-    uint32_t imageId = imageIds[isChained][direction][0] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[isChained][direction][0]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
 
-    imageId = imageIds[isChained][direction][1] | session.TrackColours[SCHEME_TRACK];
+    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[isChained][direction][1]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 1, 42 }, { 0, 27, height });
 
     if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -553,10 +554,10 @@ static void dinghy_slide_track_25_deg_up_to_60_deg_up(
         { SPR_DINGHY_SLIDE_25_DEG_TO_60_DEG_SE_NW, SPR_DINGHY_SLIDE_25_DEG_TO_60_DEG_FRONT_SE_NW },
     };
 
-    uint32_t imageId = imageIds[direction][0] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
 
-    imageId = imageIds[direction][1] | session.TrackColours[SCHEME_TRACK];
+    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][1]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 1, 66 }, { 0, 27, height });
 
     if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -589,10 +590,10 @@ static void dinghy_slide_track_60_deg_up_to_25_deg_up(
         { SPR_DINGHY_SLIDE_60_DEG_TO_25_DEG_SE_NW, SPR_DINGHY_SLIDE_60_DEG_TO_25_DEG_FRONT_SE_NW },
     };
 
-    uint32_t imageId = imageIds[direction][0] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
 
-    imageId = imageIds[direction][1] | session.TrackColours[SCHEME_TRACK];
+    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][1]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 1, 66 }, { 0, 27, height });
 
     if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -634,10 +635,10 @@ static void dinghy_slide_track_25_deg_up_to_flat(
     };
 
     uint8_t isChained = trackElement.HasChain() ? 1 : 0;
-    uint32_t imageId = imageIds[isChained][direction][0] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[isChained][direction][0]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
 
-    imageId = imageIds[isChained][direction][1] | session.TrackColours[SCHEME_TRACK];
+    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[isChained][direction][1]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
 
     if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -868,8 +869,8 @@ static void dinghy_slide_track_s_bend_left(
         },
     };
 
-    uint32_t imageId = imageIds[direction][trackSequence][0] | session.TrackColours[SCHEME_TRACK];
-    uint32_t frontImageId = imageIds[direction][trackSequence][1] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][trackSequence][0]);
+    auto frontImageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][trackSequence][1]);
     int16_t bboy;
 
     switch (trackSequence)
@@ -975,8 +976,8 @@ static void dinghy_slide_track_s_bend_right(
         },
     };
 
-    uint32_t imageId = imageIds[direction][trackSequence][0] | session.TrackColours[SCHEME_TRACK];
-    uint32_t frontImageId = imageIds[direction][trackSequence][1] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][trackSequence][0]);
+    auto frontImageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][trackSequence][1]);
     int16_t bboy;
 
     switch (trackSequence)
@@ -1149,10 +1150,10 @@ static void dinghy_slide_track_flat_covered(
         { SPR_DINGHY_SLIDE_FLAT_COVERED_NW_SE, SPR_DINGHY_SLIDE_FLAT_COVERED_FRONT_NW_SE },
     };
 
-    uint32_t imageId = imageIds[direction][0] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
 
-    imageId = imageIds[direction][1] | session.TrackColours[SCHEME_TRACK];
+    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][1]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
 
     if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -1178,10 +1179,10 @@ static void dinghy_slide_track_25_deg_up_covered(
         { SPR_DINGHY_SLIDE_25_DEG_COVERED_SE_NW, SPR_DINGHY_SLIDE_25_DEG_COVERED_FRONT_SE_NW },
     };
 
-    uint32_t imageId = imageIds[direction][0] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
 
-    imageId = imageIds[direction][1] | session.TrackColours[SCHEME_TRACK];
+    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][1]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 1, 50 }, { 0, 27, height });
 
     if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -1214,10 +1215,10 @@ static void dinghy_slide_track_60_deg_up_covered(
         { SPR_DINGHY_SLIDE_60_DEG_COVERED_SE_NW, SPR_DINGHY_SLIDE_60_DEG_COVERED_FRONT_SE_NW },
     };
 
-    uint32_t imageId = imageIds[direction][0] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
 
-    imageId = imageIds[direction][1] | session.TrackColours[SCHEME_TRACK];
+    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][1]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 1, 98 }, { 0, 27, height });
 
     if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -1250,10 +1251,10 @@ static void dinghy_slide_track_flat_to_25_deg_up_covered(
         { SPR_DINGHY_SLIDE_FLAT_TO_25_DEG_COVERED_SE_NW, SPR_DINGHY_SLIDE_FLAT_TO_25_DEG_COVERED_FRONT_SE_NW },
     };
 
-    uint32_t imageId = imageIds[direction][0] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
 
-    imageId = imageIds[direction][1] | session.TrackColours[SCHEME_TRACK];
+    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][1]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 1, 42 }, { 0, 27, height });
 
     if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -1286,10 +1287,10 @@ static void dinghy_slide_track_25_deg_up_to_60_deg_up_covered(
         { SPR_DINGHY_SLIDE_25_DEG_TO_60_DEG_COVERED_SE_NW, SPR_DINGHY_SLIDE_25_DEG_TO_60_DEG_COVERED_FRONT_SE_NW },
     };
 
-    uint32_t imageId = imageIds[direction][0] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
 
-    imageId = imageIds[direction][1] | session.TrackColours[SCHEME_TRACK];
+    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][1]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 1, 66 }, { 0, 27, height });
 
     if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -1322,10 +1323,10 @@ static void dinghy_slide_track_60_deg_up_to_25_deg_up_covered(
         { SPR_DINGHY_SLIDE_60_DEG_TO_25_DEG_COVERED_SE_NW, SPR_DINGHY_SLIDE_60_DEG_TO_25_DEG_COVERED_FRONT_SE_NW },
     };
 
-    uint32_t imageId = imageIds[direction][0] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
 
-    imageId = imageIds[direction][1] | session.TrackColours[SCHEME_TRACK];
+    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][1]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 1, 66 }, { 0, 27, height });
 
     if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -1358,10 +1359,10 @@ static void dinghy_slide_track_25_deg_up_to_flat_covered(
         { SPR_DINGHY_SLIDE_25_DEG_TO_FLAT_COVERED_SE_NW, SPR_DINGHY_SLIDE_25_DEG_TO_FLAT_COVERED_FRONT_SE_NW },
     };
 
-    uint32_t imageId = imageIds[direction][0] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
 
-    imageId = imageIds[direction][1] | session.TrackColours[SCHEME_TRACK];
+    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][1]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
 
     if (track_paint_util_should_paint_supports(session.MapPosition))
@@ -1585,8 +1586,8 @@ static void dinghy_slide_track_s_bend_left_covered(
         },
     };
 
-    uint32_t imageId = imageIds[direction][trackSequence][0] | session.TrackColours[SCHEME_TRACK];
-    uint32_t frontImageId = imageIds[direction][trackSequence][1] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][trackSequence][0]);
+    auto frontImageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][trackSequence][1]);
     int16_t bboy;
 
     switch (trackSequence)
@@ -1692,8 +1693,8 @@ static void dinghy_slide_track_s_bend_right_covered(
         },
     };
 
-    uint32_t imageId = imageIds[direction][trackSequence][0] | session.TrackColours[SCHEME_TRACK];
-    uint32_t frontImageId = imageIds[direction][trackSequence][1] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][trackSequence][0]);
+    auto frontImageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][trackSequence][1]);
     int16_t bboy;
 
     switch (trackSequence)

--- a/src/openrct2/ride/water/LogFlume.cpp
+++ b/src/openrct2/ride/water/LogFlume.cpp
@@ -164,8 +164,8 @@ static void paint_log_flume_track_flat(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId = LogFlumeTrackFlatImageIds[direction][0] | session.TrackColours[SCHEME_TRACK];
-    uint32_t frontImageId = LogFlumeTrackFlatImageIds[direction][1] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(LogFlumeTrackFlatImageIds[direction][0]);
+    auto frontImageId = session.TrackColours[SCHEME_TRACK].WithIndex(LogFlumeTrackFlatImageIds[direction][1]);
 
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
     PaintAddImageAsParentRotated(session, direction, frontImageId, { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
@@ -185,16 +185,16 @@ static void paint_log_flume_track_station(
     paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId = LogFlumeTrackFlatImageIds[direction][0] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(LogFlumeTrackFlatImageIds[direction][0]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 1 }, { 0, 6, height + 3 });
 
     if (direction & 1)
     {
-        imageId = SPR_STATION_BASE_B_NW_SE | session.TrackColours[SCHEME_MISC];
+        imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_STATION_BASE_B_NW_SE);
     }
     else
     {
-        imageId = SPR_STATION_BASE_B_SW_NE | session.TrackColours[SCHEME_MISC];
+        imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_STATION_BASE_B_SW_NE);
     }
     PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 32, 1 });
 
@@ -229,8 +229,8 @@ static void paint_log_flume_track_25_deg_up(
         { SPR_LOG_FLUME_25_DEG_UP_SE_NW, SPR_LOG_FLUME_25_DEG_UP_FRONT_SE_NW },
     };
 
-    uint32_t imageId = imageIds[direction][0] | session.TrackColours[SCHEME_TRACK];
-    uint32_t frontImageId = imageIds[direction][1] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]);
+    auto frontImageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][1]);
 
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
     PaintAddImageAsParentRotated(session, direction, frontImageId, { 0, 0, height }, { 32, 1, 50 }, { 0, 27, height });
@@ -264,8 +264,8 @@ static void paint_log_flume_track_flat_to_25_deg_up(
         { SPR_LOG_FLUME_FLAT_TO_25_DEG_UP_SE_NW, SPR_LOG_FLUME_FLAT_TO_25_DEG_UP_FRONT_SE_NW },
     };
 
-    uint32_t imageId = imageIds[direction][0] | session.TrackColours[SCHEME_TRACK];
-    uint32_t frontImageId = imageIds[direction][1] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]);
+    auto frontImageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][1]);
 
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
     PaintAddImageAsParentRotated(session, direction, frontImageId, { 0, 0, height }, { 32, 1, 42 }, { 0, 27, height });
@@ -299,8 +299,8 @@ static void paint_log_flume_track_25_deg_up_to_flat(
         { SPR_LOG_FLUME_25_DEG_UP_TO_FLAT_SE_NW, SPR_LOG_FLUME_25_DEG_UP_TO_FLAT_FRONT_SE_NW },
     };
 
-    uint32_t imageId = imageIds[direction][0] | session.TrackColours[SCHEME_TRACK];
-    uint32_t frontImageId = imageIds[direction][1] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]);
+    auto frontImageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][1]);
 
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
     PaintAddImageAsParentRotated(session, direction, frontImageId, { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
@@ -334,8 +334,8 @@ static void paint_log_flume_track_25_deg_down(
         { SPR_LOG_FLUME_25_DEG_DOWN_SE_NW, SPR_LOG_FLUME_25_DEG_UP_FRONT_NW_SE },
     };
 
-    uint32_t imageId = imageIds[direction][0] | session.TrackColours[SCHEME_TRACK];
-    uint32_t frontImageId = imageIds[direction][1] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]);
+    auto frontImageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][1]);
 
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
     PaintAddImageAsParentRotated(session, direction, frontImageId, { 0, 0, height }, { 32, 1, 50 }, { 0, 27, height });
@@ -369,8 +369,8 @@ static void paint_log_flume_track_flat_to_25_deg_down(
         { SPR_LOG_FLUME_FLAT_TO_25_DEG_DOWN_SE_NW, SPR_LOG_FLUME_25_DEG_UP_TO_FLAT_FRONT_NW_SE },
     };
 
-    uint32_t imageId = imageIds[direction][0] | session.TrackColours[SCHEME_TRACK];
-    uint32_t frontImageId = imageIds[direction][1] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]);
+    auto frontImageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][1]);
 
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
     PaintAddImageAsParentRotated(session, direction, frontImageId, { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
@@ -404,8 +404,8 @@ static void paint_log_flume_track_25_deg_down_to_flat(
         { SPR_LOG_FLUME_25_DEG_DOWN_TO_FLAT_SE_NW, SPR_LOG_FLUME_FLAT_TO_25_DEG_UP_FRONT_NW_SE },
     };
 
-    uint32_t imageId = imageIds[direction][0] | session.TrackColours[SCHEME_TRACK];
-    uint32_t frontImageId = imageIds[direction][1] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]);
+    auto frontImageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][1]);
 
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
     PaintAddImageAsParentRotated(session, direction, frontImageId, { 0, 0, height }, { 32, 1, 42 }, { 0, 27, height });
@@ -459,8 +459,8 @@ static void paint_log_flume_track_s_bend_left(
         },
     };
 
-    uint32_t imageId = imageIds[direction][trackSequence][0] | session.TrackColours[SCHEME_TRACK];
-    uint32_t frontImageId = imageIds[direction][trackSequence][1] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][trackSequence][0]);
+    auto frontImageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][trackSequence][1]);
     int16_t bboy;
 
     switch (trackSequence)
@@ -566,8 +566,8 @@ static void paint_log_flume_track_s_bend_right(
         },
     };
 
-    uint32_t imageId = imageIds[direction][trackSequence][0] | session.TrackColours[SCHEME_TRACK];
-    uint32_t frontImageId = imageIds[direction][trackSequence][1] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][trackSequence][0]);
+    auto frontImageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][trackSequence][1]);
     int16_t bboy;
 
     switch (trackSequence)
@@ -802,8 +802,7 @@ static void paint_log_flume_track_on_ride_photo(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId = SPR_STATION_BASE_D | IMAGE_TYPE_REMAP;
-    PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 32, 1 });
+    PaintAddImageAsParent(session, SPR_STATION_BASE_D | IMAGE_TYPE_REMAP, { 0, 0, height }, { 32, 32, 1 });
 
     if (direction & 1)
     {
@@ -816,10 +815,10 @@ static void paint_log_flume_track_on_ride_photo(
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_FORK, 8, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
     }
 
-    imageId = LogFlumeTrackFlatImageIds[direction][0] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(LogFlumeTrackFlatImageIds[direction][0]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 3 });
 
-    imageId = LogFlumeTrackFlatImageIds[direction][1] | session.TrackColours[SCHEME_TRACK];
+    imageId = session.TrackColours[SCHEME_TRACK].WithIndex(LogFlumeTrackFlatImageIds[direction][1]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 1, 21 }, { 0, 27, height + 5 });
 
     track_paint_util_onride_photo_paint(session, direction, height + 3, trackElement);
@@ -840,8 +839,8 @@ static void paint_log_flume_track_reverser(
         { SPR_LOG_FLUME_REVERSER_SE_NW, SPR_LOG_FLUME_REVERSER_FRONT_SE_NW },
     };
 
-    uint32_t imageId = imageIds[direction][0] | session.TrackColours[SCHEME_TRACK];
-    uint32_t frontImageId = imageIds[direction][1] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]);
+    auto frontImageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][1]);
 
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
     PaintAddImageAsParentRotated(session, direction, frontImageId, { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });

--- a/src/openrct2/ride/water/RiverRapids.cpp
+++ b/src/openrct2/ride/water/RiverRapids.cpp
@@ -282,26 +282,26 @@ static void paint_river_rapids_track_flat(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId;
+    ImageId imageId;
 
     if (direction & 1)
     {
-        imageId = (direction == 1 ? SPR_RIVER_RAPIDS_FLAT_NW_SE : SPR_RIVER_RAPIDS_FLAT_SE_NW)
-            | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+            (direction == 1 ? SPR_RIVER_RAPIDS_FLAT_NW_SE : SPR_RIVER_RAPIDS_FLAT_SE_NW));
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 24, 32, 11 }, { 4, 0, height });
 
-        imageId = (direction == 1 ? SPR_RIVER_RAPIDS_FLAT_FRONT_NW_SE : SPR_RIVER_RAPIDS_FLAT_FRONT_SE_NW)
-            | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+            (direction == 1 ? SPR_RIVER_RAPIDS_FLAT_FRONT_NW_SE : SPR_RIVER_RAPIDS_FLAT_FRONT_SE_NW));
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 32, 3 }, { 27, 0, height + 17 });
     }
     else
     {
-        imageId = (direction == 0 ? SPR_RIVER_RAPIDS_FLAT_SW_NE : SPR_RIVER_RAPIDS_FLAT_NE_SW)
-            | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+            (direction == 0 ? SPR_RIVER_RAPIDS_FLAT_SW_NE : SPR_RIVER_RAPIDS_FLAT_NE_SW));
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 24, 11 }, { 0, 4, height });
 
-        imageId = (direction == 0 ? SPR_RIVER_RAPIDS_FLAT_FRONT_SW_NE : SPR_RIVER_RAPIDS_FLAT_FRONT_NE_SW)
-            | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+            (direction == 0 ? SPR_RIVER_RAPIDS_FLAT_FRONT_SW_NE : SPR_RIVER_RAPIDS_FLAT_FRONT_NE_SW));
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 1, 3 }, { 0, 27, height + 17 });
     }
 
@@ -333,16 +333,16 @@ static void paint_river_rapids_station(
 static void paint_river_rapids_track_25_deg(
     paint_session& session, uint8_t direction, int32_t height, const uint32_t sprites[4][2])
 {
-    uint32_t imageId;
+    ImageId imageId;
     paint_struct* ps;
 
     switch (direction)
     {
         case 0:
-            imageId = sprites[direction][0] | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(sprites[direction][0]);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 24, 4 }, { 0, 4, height });
 
-            imageId = sprites[direction][1] | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(sprites[direction][1]);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height + 16 });
 
             wooden_a_supports_paint_setup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -350,11 +350,11 @@ static void paint_river_rapids_track_25_deg(
             break;
 
         case 1:
-            imageId = sprites[direction][0] | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(sprites[direction][0]);
             ps = PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 24, 32, 4 }, { 4, 0, height });
             session.WoodenSupportsPrependTo = ps;
 
-            imageId = sprites[direction][1] | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(sprites[direction][1]);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 32, 34 }, { 27, 0, height + 16 });
 
             wooden_a_supports_paint_setup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -362,11 +362,11 @@ static void paint_river_rapids_track_25_deg(
             break;
 
         case 2:
-            imageId = sprites[direction][0] | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(sprites[direction][0]);
             ps = PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 24, 4 }, { 0, 4, height });
             session.WoodenSupportsPrependTo = ps;
 
-            imageId = sprites[direction][1] | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(sprites[direction][1]);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height + 16 });
 
             wooden_a_supports_paint_setup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -374,10 +374,10 @@ static void paint_river_rapids_track_25_deg(
             break;
 
         case 3:
-            imageId = sprites[direction][0] | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(sprites[direction][0]);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 24, 32, 4 }, { 4, 0, height });
 
-            imageId = sprites[direction][1] | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(sprites[direction][1]);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 32, 34 }, { 27, 0, height + 16 });
 
             wooden_a_supports_paint_setup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -392,16 +392,16 @@ static void paint_river_rapids_track_25_deg(
 static void paint_river_rapids_track_25_deg_to_flat_a(
     paint_session& session, uint8_t direction, int32_t height, const uint32_t sprites[4][2])
 {
-    uint32_t imageId;
+    ImageId imageId;
     paint_struct* ps;
 
     switch (direction)
     {
         case 0:
-            imageId = sprites[direction][0] | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(sprites[direction][0]);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 24, 4 }, { 0, 4, height });
 
-            imageId = sprites[direction][1] | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(sprites[direction][1]);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 1, 18 }, { 0, 27, height + 16 });
 
             wooden_a_supports_paint_setup(session, 0, 5, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -409,11 +409,11 @@ static void paint_river_rapids_track_25_deg_to_flat_a(
             break;
 
         case 1:
-            imageId = sprites[direction][0] | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(sprites[direction][0]);
             ps = PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 24, 32, 4 }, { 4, 0, height });
             session.WoodenSupportsPrependTo = ps;
 
-            imageId = sprites[direction][1] | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(sprites[direction][1]);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 32, 18 }, { 27, 0, height + 16 });
 
             wooden_a_supports_paint_setup(session, 1, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -421,11 +421,11 @@ static void paint_river_rapids_track_25_deg_to_flat_a(
             break;
 
         case 2:
-            imageId = sprites[direction][0] | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(sprites[direction][0]);
             ps = PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 24, 4 }, { 0, 4, height });
             session.WoodenSupportsPrependTo = ps;
 
-            imageId = sprites[direction][1] | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(sprites[direction][1]);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 1, 18 }, { 0, 27, height + 16 });
 
             wooden_a_supports_paint_setup(session, 0, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -433,10 +433,10 @@ static void paint_river_rapids_track_25_deg_to_flat_a(
             break;
 
         case 3:
-            imageId = sprites[direction][0] | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(sprites[direction][0]);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 24, 32, 4 }, { 4, 0, height });
 
-            imageId = sprites[direction][1] | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(sprites[direction][1]);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 32, 18 }, { 27, 0, height + 16 });
 
             wooden_a_supports_paint_setup(session, 1, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -451,16 +451,16 @@ static void paint_river_rapids_track_25_deg_to_flat_a(
 static void paint_river_rapids_track_25_deg_to_flat_b(
     paint_session& session, uint8_t direction, int32_t height, const uint32_t sprites[4][2])
 {
-    uint32_t imageId;
+    ImageId imageId;
     paint_struct* ps;
 
     switch (direction)
     {
         case 0:
-            imageId = sprites[direction][0] | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(sprites[direction][0]);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 24, 11 }, { 0, 4, height });
 
-            imageId = sprites[direction][1] | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(sprites[direction][1]);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height + 16 });
 
             wooden_a_supports_paint_setup(session, 0, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -468,11 +468,11 @@ static void paint_river_rapids_track_25_deg_to_flat_b(
             break;
 
         case 1:
-            imageId = sprites[direction][0] | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(sprites[direction][0]);
             ps = PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 24, 32, 11 }, { 4, 0, height });
             session.WoodenSupportsPrependTo = ps;
 
-            imageId = sprites[direction][1] | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(sprites[direction][1]);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height + 16 });
 
             wooden_a_supports_paint_setup(session, 1, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -480,11 +480,11 @@ static void paint_river_rapids_track_25_deg_to_flat_b(
             break;
 
         case 2:
-            imageId = sprites[direction][0] | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(sprites[direction][0]);
             ps = PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 24, 11 }, { 0, 4, height });
             session.WoodenSupportsPrependTo = ps;
 
-            imageId = sprites[direction][1] | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(sprites[direction][1]);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height + 16 });
 
             wooden_a_supports_paint_setup(session, 0, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -492,10 +492,10 @@ static void paint_river_rapids_track_25_deg_to_flat_b(
             break;
 
         case 3:
-            imageId = sprites[direction][0] | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(sprites[direction][0]);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 24, 32, 11 }, { 4, 0, height });
 
-            imageId = sprites[direction][1] | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(sprites[direction][1]);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height + 16 });
 
             wooden_a_supports_paint_setup(session, 1, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -562,45 +562,45 @@ static void paint_river_rapids_track_left_quarter_turn_1_tile(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId;
+    ImageId imageId;
     switch (direction)
     {
         case 0:
-            imageId = SPR_RIVER_RAPIDS_LEFT_QUARTER_TURN_1_TILE_SW_NW | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_RIVER_RAPIDS_LEFT_QUARTER_TURN_1_TILE_SW_NW);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 28, 26, 11 }, { 4, 2, height });
 
-            imageId = SPR_RIVER_RAPIDS_LEFT_QUARTER_TURN_1_TILE_FRONT_SW_NW | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_RIVER_RAPIDS_LEFT_QUARTER_TURN_1_TILE_FRONT_SW_NW);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 2, 1, 7 }, { 28, 27, height + 13 });
 
             paint_util_push_tunnel_left(session, height, TUNNEL_SQUARE_FLAT);
             break;
 
         case 1:
-            imageId = SPR_RIVER_RAPIDS_LEFT_QUARTER_TURN_1_TILE_NW_NE | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_RIVER_RAPIDS_LEFT_QUARTER_TURN_1_TILE_NW_NE);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 28, 28, 11 }, { 0, 0, height });
 
-            imageId = SPR_RIVER_RAPIDS_QUARTER_TURN_1_TILE_FRONT_LEFT_NW_NE | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_RIVER_RAPIDS_QUARTER_TURN_1_TILE_FRONT_LEFT_NW_NE);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 30, 7 }, { 27, 1, height + 13 });
 
-            imageId = SPR_RIVER_RAPIDS_QUARTER_TURN_1_TILE_FRONT_RIGHT_NW_NE | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_RIVER_RAPIDS_QUARTER_TURN_1_TILE_FRONT_RIGHT_NW_NE);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 30, 1, 7 }, { 1, 27, height + 13 });
             break;
 
         case 2:
-            imageId = SPR_RIVER_RAPIDS_LEFT_QUARTER_TURN_1_TILE_NE_SE | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_RIVER_RAPIDS_LEFT_QUARTER_TURN_1_TILE_NE_SE);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 26, 28, 11 }, { 2, 4, height });
 
-            imageId = SPR_RIVER_RAPIDS_LEFT_QUARTER_TURN_1_TILE_FRONT_NE_SE | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_RIVER_RAPIDS_LEFT_QUARTER_TURN_1_TILE_FRONT_NE_SE);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 2, 7 }, { 27, 28, height + 13 });
 
             paint_util_push_tunnel_right(session, height, TUNNEL_SQUARE_FLAT);
             break;
 
         case 3:
-            imageId = SPR_RIVER_RAPIDS_LEFT_QUARTER_TURN_1_TILE_SE_SW | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_RIVER_RAPIDS_LEFT_QUARTER_TURN_1_TILE_SE_SW);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 28, 28, 11 }, { 4, 4, height });
 
-            imageId = SPR_RIVER_RAPIDS_LEFT_QUARTER_TURN_1_TILE_FRONT_SE_SW | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_RIVER_RAPIDS_LEFT_QUARTER_TURN_1_TILE_FRONT_SE_SW);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 1, 7 }, { 28, 28, height + 13 });
 
             paint_util_push_tunnel_left(session, height, TUNNEL_SQUARE_FLAT);
@@ -618,15 +618,15 @@ static void paint_river_rapids_track_right_quarter_turn_1_tile(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId;
+    ImageId imageId;
 
     switch (direction)
     {
         case 0:
-            imageId = SPR_RIVER_RAPIDS_RIGHT_QUARTER_TURN_1_TILE_SW_SE | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_RIVER_RAPIDS_RIGHT_QUARTER_TURN_1_TILE_SW_SE);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 28, 28, 11 }, { 4, 4, height });
 
-            imageId = SPR_RIVER_RAPIDS_RIGHT_QUARTER_TURN_1_TILE_FRONT_SW_SE | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_RIVER_RAPIDS_RIGHT_QUARTER_TURN_1_TILE_FRONT_SW_SE);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 1, 7 }, { 28, 28, height + 13 });
 
             paint_util_push_tunnel_left(session, height, TUNNEL_SQUARE_FLAT);
@@ -634,31 +634,31 @@ static void paint_river_rapids_track_right_quarter_turn_1_tile(
             break;
 
         case 1:
-            imageId = SPR_RIVER_RAPIDS_RIGHT_QUARTER_TURN_1_TILE_SE_NE | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_RIVER_RAPIDS_RIGHT_QUARTER_TURN_1_TILE_SE_NE);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 28, 26, 11 }, { 4, 2, height });
 
-            imageId = SPR_RIVER_RAPIDS_RIGHT_QUARTER_TURN_1_TILE_FRONT_SE_NE | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_RIVER_RAPIDS_RIGHT_QUARTER_TURN_1_TILE_FRONT_SE_NE);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 2, 1, 7 }, { 28, 27, height + 13 });
 
             paint_util_push_tunnel_left(session, height, TUNNEL_SQUARE_FLAT);
             break;
 
         case 2:
-            imageId = SPR_RIVER_RAPIDS_RIGHT_QUARTER_TURN_1_TILE_NE_NW | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_RIVER_RAPIDS_RIGHT_QUARTER_TURN_1_TILE_NE_NW);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 28, 28, 11 }, { 0, 0, height });
 
-            imageId = SPR_RIVER_RAPIDS_QUARTER_TURN_1_TILE_FRONT_LEFT_NW_NE | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_RIVER_RAPIDS_QUARTER_TURN_1_TILE_FRONT_LEFT_NW_NE);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 30, 7 }, { 27, 1, height + 13 });
 
-            imageId = SPR_RIVER_RAPIDS_QUARTER_TURN_1_TILE_FRONT_RIGHT_NW_NE | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_RIVER_RAPIDS_QUARTER_TURN_1_TILE_FRONT_RIGHT_NW_NE);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 30, 1, 7 }, { 1, 27, height + 13 });
             break;
 
         case 3:
-            imageId = SPR_RIVER_RAPIDS_RIGHT_QUARTER_TURN_1_TILE_NW_SW | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_RIVER_RAPIDS_RIGHT_QUARTER_TURN_1_TILE_NW_SW);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 26, 28, 11 }, { 2, 4, height });
 
-            imageId = SPR_RIVER_RAPIDS_RIGHT_QUARTER_TURN_1_TILE_FRONT_NW_SW | session.TrackColours[SCHEME_TRACK];
+            imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_RIVER_RAPIDS_RIGHT_QUARTER_TURN_1_TILE_FRONT_NW_SW);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 28, 7 }, { 27, 2, height + 13 });
 
             paint_util_push_tunnel_right(session, height, TUNNEL_SQUARE_FLAT);
@@ -675,46 +675,46 @@ static void paint_river_rapids_track_waterfall(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId;
+    ImageId imageId;
 
     uint16_t frameNum = (gCurrentTicks / 2) & 7;
 
     if (direction & 1)
     {
-        imageId = (direction == 1 ? SPR_RIVER_RAPIDS_WATERFALL_NW_SE : SPR_RIVER_RAPIDS_WATERFALL_SE_NW)
-            | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+            (direction == 1 ? SPR_RIVER_RAPIDS_WATERFALL_NW_SE : SPR_RIVER_RAPIDS_WATERFALL_SE_NW));
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 24, 32, 11 }, { 4, 0, height });
 
-        imageId = (SPR_RIVER_RAPIDS_WATERFALL_BASE_NE_FRAME_0 + frameNum) | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex((SPR_RIVER_RAPIDS_WATERFALL_BASE_NE_FRAME_0 + frameNum));
         PaintAddImageAsChild(session, imageId, { 0, 0, height }, { 24, 32, 11 }, { 4, 0, height });
 
-        imageId = (SPR_RIVER_RAPIDS_WATERFALL_TOP_NE_FRAME_0 + frameNum) | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex((SPR_RIVER_RAPIDS_WATERFALL_TOP_NE_FRAME_0 + frameNum));
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 32, 27 }, { 4, 0, height + 17 });
 
-        imageId = (direction == 1 ? SPR_RIVER_RAPIDS_WATERFALL_FRONT_NW_SE : SPR_RIVER_RAPIDS_WATERFALL_FRONT_SE_NW)
-            | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+            (direction == 1 ? SPR_RIVER_RAPIDS_WATERFALL_FRONT_NW_SE : SPR_RIVER_RAPIDS_WATERFALL_FRONT_SE_NW));
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 32, 27 }, { 27, 0, height + 17 });
 
-        imageId = (SPR_RIVER_RAPIDS_WATERFALL_SIDE_SW_FRAME_0 + frameNum) | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex((SPR_RIVER_RAPIDS_WATERFALL_SIDE_SW_FRAME_0 + frameNum));
         PaintAddImageAsChild(session, imageId, { 0, 0, height }, { 1, 32, 27 }, { 27, 0, height + 17 });
     }
     else
     {
-        imageId = (direction == 0 ? SPR_RIVER_RAPIDS_WATERFALL_SW_NE : SPR_RIVER_RAPIDS_WATERFALL_NE_SW)
-            | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+            (direction == 0 ? SPR_RIVER_RAPIDS_WATERFALL_SW_NE : SPR_RIVER_RAPIDS_WATERFALL_NE_SW));
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 24, 11 }, { 0, 4, height });
 
-        imageId = (SPR_RIVER_RAPIDS_WATERFALL_BASE_NW_FRAME_0 + frameNum) | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex((SPR_RIVER_RAPIDS_WATERFALL_BASE_NW_FRAME_0 + frameNum));
         PaintAddImageAsChild(session, imageId, { 0, 0, height }, { 32, 24, 11 }, { 0, 4, height });
 
-        imageId = (SPR_RIVER_RAPIDS_WATERFALL_TOP_NW_FRAME_0 + frameNum) | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex((SPR_RIVER_RAPIDS_WATERFALL_TOP_NW_FRAME_0 + frameNum));
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 1, 27 }, { 0, 4, height + 17 });
 
-        imageId = (direction == 0 ? SPR_RIVER_RAPIDS_WATERFALL_FRONT_SW_NE : SPR_RIVER_RAPIDS_WATERFALL_FRONT_NE_SW)
-            | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+            (direction == 0 ? SPR_RIVER_RAPIDS_WATERFALL_FRONT_SW_NE : SPR_RIVER_RAPIDS_WATERFALL_FRONT_NE_SW));
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 1, 27 }, { 0, 27, height + 17 });
 
-        imageId = (SPR_RIVER_RAPIDS_WATERFALL_SIDE_SE_FRAME_0 + frameNum) | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex((SPR_RIVER_RAPIDS_WATERFALL_SIDE_SE_FRAME_0 + frameNum));
         PaintAddImageAsChild(session, imageId, { 0, 0, height }, { 32, 1, 27 }, { 0, 27, height + 17 });
     }
 
@@ -738,24 +738,24 @@ static void paint_river_rapids_track_rapids(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId;
+    ImageId imageId;
 
     uint16_t frameNum = (gCurrentTicks / 2) & 7;
 
     if (direction & 1)
     {
-        imageId = (SPR_RIVER_RAPIDS_RAPIDS_NW_SE_FRAME_0 + frameNum) | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex((SPR_RIVER_RAPIDS_RAPIDS_NW_SE_FRAME_0 + frameNum));
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 24, 32, 11 }, { 4, 0, height });
 
-        imageId = SPR_RIVER_RAPIDS_RAPIDS_FRONT_NW_SE | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_RIVER_RAPIDS_RAPIDS_FRONT_NW_SE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 32, 11 }, { 27, 0, height + 17 });
     }
     else
     {
-        imageId = (SPR_RIVER_RAPIDS_RAPIDS_SW_NE_FRAME_0 + frameNum) | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex((SPR_RIVER_RAPIDS_RAPIDS_SW_NE_FRAME_0 + frameNum));
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 24, 11 }, { 0, 4, height });
 
-        imageId = SPR_RIVER_RAPIDS_RAPIDS_FRONT_SW_NE | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_RIVER_RAPIDS_RAPIDS_FRONT_SW_NE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 1, 11 }, { 0, 27, height + 17 });
     }
 
@@ -789,34 +789,34 @@ static void paint_river_rapids_track_whirlpool(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId;
+    ImageId imageId;
 
     uint8_t frameNum = (gCurrentTicks / 4) % 16;
 
     if (direction & 1)
     {
-        imageId = (direction == 1 ? SPR_RIVER_RAPIDS_FLAT_NW_SE : SPR_RIVER_RAPIDS_FLAT_SE_NW)
-            | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+            (direction == 1 ? SPR_RIVER_RAPIDS_FLAT_NW_SE : SPR_RIVER_RAPIDS_FLAT_SE_NW));
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 24, 32, 11 }, { 4, 0, height });
 
-        imageId = (SPR_RIVER_RAPIDS_RAPIDS_WHIRLPOOL_FRAME_0 + frameNum) | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex((SPR_RIVER_RAPIDS_RAPIDS_WHIRLPOOL_FRAME_0 + frameNum));
         PaintAddImageAsChild(session, imageId, { 0, 0, height }, { 24, 32, 11 }, { 4, 0, height });
 
-        imageId = (direction == 1 ? SPR_RIVER_RAPIDS_FLAT_FRONT_NW_SE : SPR_RIVER_RAPIDS_FLAT_FRONT_SE_NW)
-            | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+            (direction == 1 ? SPR_RIVER_RAPIDS_FLAT_FRONT_NW_SE : SPR_RIVER_RAPIDS_FLAT_FRONT_SE_NW));
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 32, 3 }, { 27, 0, height + 17 });
     }
     else
     {
-        imageId = (direction == 0 ? SPR_RIVER_RAPIDS_FLAT_SW_NE : SPR_RIVER_RAPIDS_FLAT_NE_SW)
-            | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+            (direction == 0 ? SPR_RIVER_RAPIDS_FLAT_SW_NE : SPR_RIVER_RAPIDS_FLAT_NE_SW));
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 24, 11 }, { 0, 4, height });
 
-        imageId = (SPR_RIVER_RAPIDS_RAPIDS_WHIRLPOOL_FRAME_0 + frameNum) | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex((SPR_RIVER_RAPIDS_RAPIDS_WHIRLPOOL_FRAME_0 + frameNum));
         PaintAddImageAsChild(session, imageId, { 0, 0, height }, { 32, 24, 11 }, { 0, 4, height });
 
-        imageId = (direction == 0 ? SPR_RIVER_RAPIDS_FLAT_FRONT_SW_NE : SPR_RIVER_RAPIDS_FLAT_FRONT_NE_SW)
-            | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+            (direction == 0 ? SPR_RIVER_RAPIDS_FLAT_FRONT_SW_NE : SPR_RIVER_RAPIDS_FLAT_FRONT_NE_SW));
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 1, 3 }, { 0, 27, height + 17 });
     }
 

--- a/src/openrct2/ride/water/SplashBoats.cpp
+++ b/src/openrct2/ride/water/SplashBoats.cpp
@@ -478,8 +478,8 @@ static void paint_splash_boats_track_25_deg_up(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId = SplashBoats25DegUpImageId[direction] | session.TrackColours[SCHEME_TRACK];
-    uint32_t frontImageId = SplashBoats25DegUpFrontImageId[direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SplashBoats25DegUpImageId[direction]);
+    auto frontImageId = session.TrackColours[SCHEME_TRACK].WithIndex(SplashBoats25DegUpFrontImageId[direction]);
 
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
     PaintAddImageAsParentRotated(session, direction, frontImageId, { 0, 0, height }, { 32, 1, 50 }, { 0, 27, height });
@@ -502,8 +502,8 @@ static void paint_splash_boats_track_60_deg_up(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId = SplashBoats60DegUpImageId[direction] | session.TrackColours[SCHEME_TRACK];
-    uint32_t frontImageId = SplashBoats60DegUpFrontImageId[direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SplashBoats60DegUpImageId[direction]);
+    auto frontImageId = session.TrackColours[SCHEME_TRACK].WithIndex(SplashBoats60DegUpFrontImageId[direction]);
 
     session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
         session, direction, imageId, { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
@@ -527,8 +527,8 @@ static void paint_splash_boats_track_flat_to_25_deg_up(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId = SplashBoatsFlatTo25DegUpImageId[direction] | session.TrackColours[SCHEME_TRACK];
-    uint32_t frontImageId = SplashBoatsFlatTo25DegUpFrontImageId[direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SplashBoatsFlatTo25DegUpImageId[direction]);
+    auto frontImageId = session.TrackColours[SCHEME_TRACK].WithIndex(SplashBoatsFlatTo25DegUpFrontImageId[direction]);
 
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
     PaintAddImageAsParentRotated(session, direction, frontImageId, { 0, 0, height }, { 32, 1, 42 }, { 0, 27, height });
@@ -551,8 +551,8 @@ static void paint_splash_boats_track_25_deg_up_to_flat(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId = SplashBoats25DegUpToFlatImageId[direction] | session.TrackColours[SCHEME_TRACK];
-    uint32_t frontImageId = SplashBoats25DegUpToFlatFrontImageId[direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SplashBoats25DegUpToFlatImageId[direction]);
+    auto frontImageId = session.TrackColours[SCHEME_TRACK].WithIndex(SplashBoats25DegUpToFlatFrontImageId[direction]);
 
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
     PaintAddImageAsParentRotated(session, direction, frontImageId, { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
@@ -575,8 +575,8 @@ static void paint_splash_boats_track_25_deg_up_to_60_deg_up(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId = SplashBoats25DegUpTo60DegUpImageId[direction] | session.TrackColours[SCHEME_TRACK];
-    uint32_t frontImageId = SplashBoats25DegUpTo60DegUpFrontImageId[direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SplashBoats25DegUpTo60DegUpImageId[direction]);
+    auto frontImageId = session.TrackColours[SCHEME_TRACK].WithIndex(SplashBoats25DegUpTo60DegUpFrontImageId[direction]);
 
     session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
         session, direction, imageId, { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
@@ -600,8 +600,8 @@ static void paint_splash_boats_track_60_deg_up_to_25_deg_up(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId = SplashBoats60DegUpTo25DegUpImageId[direction] | session.TrackColours[SCHEME_TRACK];
-    uint32_t frontImageId = SplashBoats60DegUpTo25DegUpFrontImageId[direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SplashBoats60DegUpTo25DegUpImageId[direction]);
+    auto frontImageId = session.TrackColours[SCHEME_TRACK].WithIndex(SplashBoats60DegUpTo25DegUpFrontImageId[direction]);
 
     session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
         session, direction, imageId, { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
@@ -625,8 +625,8 @@ static void paint_splash_boats_track_25_deg_down(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId = SplashBoats25DegDownImageId[direction] | session.TrackColours[SCHEME_TRACK];
-    uint32_t frontImageId = SplashBoats25DegDownFrontImageId[direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SplashBoats25DegDownImageId[direction]);
+    auto frontImageId = session.TrackColours[SCHEME_TRACK].WithIndex(SplashBoats25DegDownFrontImageId[direction]);
 
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
     PaintAddImageAsParentRotated(session, direction, frontImageId, { 0, 0, height }, { 32, 1, 50 }, { 0, 27, height });
@@ -658,8 +658,8 @@ static void paint_splash_boats_track_flat_to_25_deg_down(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId = SplashBoatsFlatTo25DegDownImageId[direction] | session.TrackColours[SCHEME_TRACK];
-    uint32_t frontImageId = SplashBoatsFlatTo25DegDownFrontImageId[direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SplashBoatsFlatTo25DegDownImageId[direction]);
+    auto frontImageId = session.TrackColours[SCHEME_TRACK].WithIndex(SplashBoatsFlatTo25DegDownFrontImageId[direction]);
 
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
     PaintAddImageAsParentRotated(session, direction, frontImageId, { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height });
@@ -698,8 +698,8 @@ static void paint_splash_boats_track_25_deg_down_to_flat(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId = SplashBoats25DegDownToFlatImageId[direction] | session.TrackColours[SCHEME_TRACK];
-    uint32_t frontImageId = SplashBoats25DegDownToFlatFrontImageId[direction] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SplashBoats25DegDownToFlatImageId[direction]);
+    auto frontImageId = session.TrackColours[SCHEME_TRACK].WithIndex(SplashBoats25DegDownToFlatFrontImageId[direction]);
 
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
     PaintAddImageAsParentRotated(session, direction, frontImageId, { 0, 0, height }, { 32, 1, 42 }, { 0, 27, height });
@@ -726,26 +726,26 @@ static void paint_splash_boats_track_flat(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint32_t imageId;
+    ImageId imageId;
 
     if (direction & 1)
     {
-        imageId = (direction == 1 ? SPR_SPLASH_BOATS_FLAT_TOP_NW_SE : SPR_SPLASH_BOATS_FLAT_TOP_SE_NW)
-            | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+            (direction == 1 ? SPR_SPLASH_BOATS_FLAT_TOP_NW_SE : SPR_SPLASH_BOATS_FLAT_TOP_SE_NW));
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
 
-        imageId = (direction == 1 ? SPR_SPLASH_BOATS_FLAT_SIDE_NW_SE : SPR_SPLASH_BOATS_FLAT_SIDE_SE_NW)
-            | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+            (direction == 1 ? SPR_SPLASH_BOATS_FLAT_SIDE_NW_SE : SPR_SPLASH_BOATS_FLAT_SIDE_SE_NW));
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height });
     }
     else
     {
-        imageId = (direction == 0 ? SPR_SPLASH_BOATS_FLAT_TOP_SW_NE : SPR_SPLASH_BOATS_FLAT_TOP_NE_SW)
-            | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+            (direction == 0 ? SPR_SPLASH_BOATS_FLAT_TOP_SW_NE : SPR_SPLASH_BOATS_FLAT_TOP_NE_SW));
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
 
-        imageId = (direction == 0 ? SPR_SPLASH_BOATS_FLAT_SIDE_SW_NE : SPR_SPLASH_BOATS_FLAT_SIDE_NE_SW)
-            | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+            (direction == 0 ? SPR_SPLASH_BOATS_FLAT_SIDE_SW_NE : SPR_SPLASH_BOATS_FLAT_SIDE_NE_SW));
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
     }
 
@@ -771,20 +771,20 @@ static void paint_splash_boats_station(
 {
     if (direction & 1)
     {
-        uint32_t imageId = (direction == 1 ? SPR_SPLASH_BOATS_FLAT_TOP_NW_SE : SPR_SPLASH_BOATS_FLAT_TOP_SE_NW)
-            | session.TrackColours[SCHEME_TRACK];
+        auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+            (direction == 1 ? SPR_SPLASH_BOATS_FLAT_TOP_NW_SE : SPR_SPLASH_BOATS_FLAT_TOP_SE_NW));
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 20, 32, 1 }, { 6, 0, height + 3 });
 
-        imageId = SPR_STATION_BASE_B_NW_SE | session.TrackColours[SCHEME_MISC];
+        imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_STATION_BASE_B_NW_SE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 32, 1 });
     }
     else
     {
-        uint32_t imageId = (direction == 0 ? SPR_SPLASH_BOATS_FLAT_TOP_SW_NE : SPR_SPLASH_BOATS_FLAT_TOP_NE_SW)
-            | session.TrackColours[SCHEME_TRACK];
+        auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
+            (direction == 0 ? SPR_SPLASH_BOATS_FLAT_TOP_SW_NE : SPR_SPLASH_BOATS_FLAT_TOP_NE_SW));
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 20, 1 }, { 0, 6, height + 3 });
 
-        imageId = SPR_STATION_BASE_B_SW_NE | session.TrackColours[SCHEME_MISC];
+        imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_STATION_BASE_B_SW_NE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 32, 1 });
     }
 
@@ -992,8 +992,8 @@ static void paint_splash_boats_track_s_bend_left(
         },
     };
 
-    uint32_t imageId = imageIds[direction][trackSequence][0] | session.TrackColours[SCHEME_TRACK];
-    uint32_t frontImageId = imageIds[direction][trackSequence][1] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][trackSequence][0]);
+    auto frontImageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][trackSequence][1]);
     int16_t bboy;
     static constexpr const int32_t supportTypes1[] = { 5, 2, 3, 4 };
     static constexpr const int32_t supportTypes2[] = { 3, 4, 5, 2 };
@@ -1094,8 +1094,8 @@ static void paint_splash_boats_track_s_bend_right(
         },
     };
 
-    uint32_t imageId = imageIds[direction][trackSequence][0] | session.TrackColours[SCHEME_TRACK];
-    uint32_t frontImageId = imageIds[direction][trackSequence][1] | session.TrackColours[SCHEME_TRACK];
+    auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][trackSequence][0]);
+    auto frontImageId = session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][trackSequence][1]);
     int16_t bboy;
     static constexpr const int32_t supportTypes1[] = { 4, 5, 2, 3 };
     static constexpr const int32_t supportTypes2[] = { 2, 3, 4, 5 };
@@ -1172,19 +1172,19 @@ static void paint_splash_boats_track_on_ride_photo(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 0, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 0, 1 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 0, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 0, 1 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 0, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 0, 1 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, { 0, 0, height }, { 32, 0, 1 });
+                session, direction, ImageId(IMAGE_TYPE_REMAP | SPR_STATION_BASE_D), { 0, 0, height }, { 32, 0, 1 });
             break;
     }
 

--- a/src/openrct2/ride/water/SubmarineRide.cpp
+++ b/src/openrct2/ride/water/SubmarineRide.cpp
@@ -69,11 +69,11 @@ static void submarine_ride_paint_track_station(
 {
     const auto* stationObj = ride.GetStationObject();
     int32_t heightLower = height - 16;
-    uint32_t imageId;
+    ImageId imageId;
 
     if (direction & 1)
     {
-        imageId = SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_FLAT_SE_NW | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_FLAT_SE_NW);
         PaintAddImageAsParent(session, imageId, { 0, 0, heightLower }, { 20, 32, 3 }, { 6, 0, heightLower });
 
         paint_util_push_tunnel_right(session, height, TUNNEL_SQUARE_FLAT);
@@ -82,7 +82,7 @@ static void submarine_ride_paint_track_station(
     }
     else
     {
-        imageId = SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_FLAT_NE_SW | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_FLAT_NE_SW);
         PaintAddImageAsParent(session, imageId, { 0, 0, heightLower }, { 32, 20, 3 }, { 0, 6, heightLower });
 
         paint_util_push_tunnel_left(session, height, TUNNEL_SQUARE_FLAT);
@@ -99,17 +99,17 @@ static void submarine_ride_paint_track_flat(
     const TrackElement& trackElement)
 {
     int32_t heightLower = height - 16;
-    uint32_t imageId;
+    ImageId imageId;
 
     if (direction & 1)
     {
-        imageId = SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_FLAT_SE_NW | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_FLAT_SE_NW);
         PaintAddImageAsParent(session, imageId, { 0, 0, heightLower }, { 20, 32, 3 }, { 6, 0, heightLower });
         paint_util_push_tunnel_right(session, heightLower, TUNNEL_0);
     }
     else
     {
-        imageId = SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_FLAT_NE_SW | session.TrackColours[SCHEME_TRACK];
+        imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_FLAT_NE_SW);
         PaintAddImageAsParent(session, imageId, { 0, 0, heightLower }, { 32, 20, 3 }, { 0, 6, heightLower });
         paint_util_push_tunnel_left(session, heightLower, TUNNEL_0);
     }


### PR DESCRIPTION
This is quite a big refactor, but it should modify the bulk of the ride drawing code to pass ImageId to the paint functions. A second pass is needed to do the rest, but this PR is already enormous.

The reason I requested a review of both Ted and Rik is because I’d the former’s approval for the code and the latter’s for the testing.

Part of #18124.